### PR TITLE
Align chat page with new design guidelines (two-card system)

### DIFF
--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -185,13 +185,17 @@ export function ChatSidebar({
 
   return (
     <>
-      <div className="flex h-full flex-col bg-card border-r border-cb-border overflow-hidden">
+      {/* Sidebar wrapper - w-[280px] per guidelines */}
+      <div
+        className="bg-card h-full flex flex-col rounded-lg border border-border overflow-hidden"
+        data-component="SIDEBAR"
+      >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-cb-border px-4 py-3">
-          <h2 className="font-montserrat text-sm font-extrabold uppercase text-cb-ink">
-            Conversations
-          </h2>
-          <Button variant="hollow" size="icon" onClick={onNewChat} aria-label="New chat">
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h3 className="font-display text-xs font-extrabold uppercase text-cb-ink">
+            Chat History
+          </h3>
+          <Button variant="ghost" size="icon" onClick={onNewChat} aria-label="New chat">
             <RiAddLine className="h-4 w-4" />
           </Button>
         </div>

--- a/src/components/chat/chat-main-card.tsx
+++ b/src/components/chat/chat-main-card.tsx
@@ -2,38 +2,104 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 /**
- * ChatMainCard - Premium Card Container (Kortex-inspired)
+ * Chat Card System - Two-Card Layout (per new-chat-design-guidelines.md)
  *
- * This is the main content card for the chat interface following the
- * Conversion Brain brand guidelines while incorporating Kortex design patterns.
+ * This implements the "Two-Card System" from the design guidelines:
+ * - BG-CARD-MAIN (ChatOuterCard): The "browser window" - outermost container
+ * - BG-CARD-INNER (ChatInnerCard): The "website content" - chat interface
  *
- * Structure:
- * - Card wrapper with rounded corners, subtle shadow, and border
- * - Flexible content area for chat messages or welcome state
- * - Bottom-fixed input area
+ * Both cards use IDENTICAL styling (bg-card, rounded-2xl, shadow-lg, border).
+ * The only difference is their navigation pattern:
+ * - BG-CARD-MAIN has NO navigation (just contains sidebar + inner card)
+ * - BG-CARD-INNER has header with title + action buttons
  */
 
 // ============================================================================
-// ChatMainCard - The outer card wrapper
+// ChatOuterCard (BG-CARD-MAIN) - The "browser window" container
+// ============================================================================
+
+interface ChatOuterCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+/**
+ * BG-CARD-MAIN: The outermost application container.
+ * Contains a flex layout with sidebar + inner card (NO header, NO wrapper).
+ *
+ * Styling: bg-card rounded-2xl shadow-lg border border-border px-10 overflow-hidden h-full
+ */
+export function ChatOuterCard({ children, className, ...props }: ChatOuterCardProps) {
+  return (
+    <div
+      className={cn(
+        // BG-CARD-MAIN styling (from guidelines)
+        'bg-card rounded-2xl shadow-lg',
+        'border border-border',
+        'px-10 overflow-hidden h-full',
+        className
+      )}
+      data-component="BG-CARD-MAIN"
+      {...props}
+    >
+      {/* Direct child is flex container with sidebar + inner card */}
+      <div className="flex gap-4 h-full py-4">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// ChatInnerCard (BG-CARD-INNER) - The chat interface container
+// ============================================================================
+
+interface ChatInnerCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+/**
+ * BG-CARD-INNER: The nested card containing the actual chat interface.
+ * Contains: Header → Messages → Input (vertical flex layout)
+ *
+ * Styling: flex-1 bg-card rounded-2xl shadow-lg border border-border overflow-hidden flex flex-col
+ */
+export function ChatInnerCard({ children, className, ...props }: ChatInnerCardProps) {
+  return (
+    <div
+      className={cn(
+        // BG-CARD-INNER styling (IDENTICAL to BG-CARD-MAIN except flex-1 and flex-col)
+        'flex-1 bg-card rounded-2xl shadow-lg',
+        'border border-border',
+        'overflow-hidden flex flex-col',
+        className
+      )}
+      data-component="BG-CARD-INNER"
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ============================================================================
+// LEGACY: ChatMainCard - kept for backwards compatibility (use ChatInnerCard)
 // ============================================================================
 
 interface ChatMainCardProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
+/**
+ * @deprecated Use ChatOuterCard + ChatInnerCard instead for proper two-card system
+ */
 export function ChatMainCard({ children, className, ...props }: ChatMainCardProps) {
   return (
     <div
       className={cn(
-        // Kortex-style card with rounded corners and shadow
         'relative flex flex-col h-full w-full',
         'bg-card rounded-2xl',
-        'border border-cb-border dark:border-cb-border-dark',
+        'border border-border',
         'shadow-lg',
-        // Smooth transitions on hover (subtle effect)
-        'transition-shadow duration-200',
-        'hover:shadow-xl',
-        // Overflow handling
         'overflow-hidden',
         className
       )}
@@ -45,20 +111,22 @@ export function ChatMainCard({ children, className, ...props }: ChatMainCardProp
 }
 
 // ============================================================================
-// ChatMainCardContent - Scrollable content area
+// ChatInnerCardContent - Scrollable content area (inside BG-CARD-INNER)
 // ============================================================================
 
-interface ChatMainCardContentProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ChatInnerCardContentProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
-export function ChatMainCardContent({ children, className, ...props }: ChatMainCardContentProps) {
+/**
+ * Content area inside BG-CARD-INNER.
+ * Padding: px-6 py-4 (per guidelines)
+ */
+export function ChatInnerCardContent({ children, className, ...props }: ChatInnerCardContentProps) {
   return (
     <div
       className={cn(
-        'flex-1 overflow-y-auto',
-        // Padding for content breathing room
-        'px-4 md:px-8 py-6',
+        'flex-1 overflow-hidden',
         className
       )}
       {...props}
@@ -68,51 +136,64 @@ export function ChatMainCardContent({ children, className, ...props }: ChatMainC
   );
 }
 
+// Legacy alias
+export const ChatMainCardContent = ChatInnerCardContent;
+
 // ============================================================================
-// ChatMainCardInputArea - Bottom-fixed input section
+// ChatInnerCardInputArea - Bottom-fixed input section (inside BG-CARD-INNER)
 // ============================================================================
 
-interface ChatMainCardInputAreaProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ChatInnerCardInputAreaProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
-export function ChatMainCardInputArea({ children, className, ...props }: ChatMainCardInputAreaProps) {
+/**
+ * Input area inside BG-CARD-INNER, fixed at bottom.
+ * Padding: px-6 py-4 (per guidelines)
+ * NO max-width constraint - fills the card width
+ */
+export function ChatInnerCardInputArea({ children, className, ...props }: ChatInnerCardInputAreaProps) {
   return (
     <div
       className={cn(
         // Fixed at bottom with border separator
         'flex-shrink-0',
-        'border-t border-cb-border dark:border-cb-border-dark',
+        'border-t border-border',
         'bg-card',
-        // Padding and max-width for centered input
-        'px-4 py-4',
+        // Padding per guidelines: px-6 py-4 (24px horizontal, 16px vertical)
+        'px-6 py-4',
         className
       )}
       {...props}
     >
-      {/* Centered container for input - Kortex style max-width */}
-      <div className="w-full max-w-[800px] mx-auto">
-        {children}
-      </div>
+      {children}
     </div>
   );
 }
 
+// Legacy alias
+export const ChatMainCardInputArea = ChatInnerCardInputArea;
+
 // ============================================================================
-// ChatMainCardHeader - Optional header section for title/filters
+// ChatInnerCardHeader - Header section inside BG-CARD-INNER
 // ============================================================================
 
-interface ChatMainCardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ChatInnerCardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
-export function ChatMainCardHeader({ children, className, ...props }: ChatMainCardHeaderProps) {
+/**
+ * Header inside BG-CARD-INNER with title + action buttons.
+ * Padding: px-6 py-4 (per guidelines)
+ */
+export function ChatInnerCardHeader({ children, className, ...props }: ChatInnerCardHeaderProps) {
   return (
     <div
       className={cn(
         'flex-shrink-0',
-        'px-4 md:px-6 py-3',
-        'border-b border-cb-border dark:border-cb-border-dark',
+        // Padding per guidelines: px-6 py-4 (24px horizontal, 16px vertical)
+        'px-6 py-4',
+        'border-b border-border',
         'bg-card',
         className
       )}
@@ -122,3 +203,6 @@ export function ChatMainCardHeader({ children, className, ...props }: ChatMainCa
     </div>
   );
 }
+
+// Legacy alias
+export const ChatMainCardHeader = ChatInnerCardHeader;

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -17,10 +17,11 @@ import {
   ChatContainerScrollAnchor,
 } from '@/components/chat/chat-container';
 import {
-  ChatMainCard,
-  ChatMainCardContent,
-  ChatMainCardInputArea,
-  ChatMainCardHeader,
+  ChatOuterCard,
+  ChatInnerCard,
+  ChatInnerCardContent,
+  ChatInnerCardInputArea,
+  ChatInnerCardHeader,
 } from '@/components/chat/chat-main-card';
 import { ChatWelcome } from '@/components/chat/chat-welcome';
 import {
@@ -459,39 +460,42 @@ export default function Chat() {
   });
 
   return (
-    <div className="flex h-[calc(100vh-52px)] bg-viewport">
-      {/* Mobile sidebar overlay */}
+    <div className="h-[calc(100vh-52px)] bg-viewport">
+      {/* Mobile sidebar overlay backdrop */}
       {showSidebar && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 md:hidden"
           onClick={() => setShowSidebar(false)}
         />
       )}
 
-      {/* Sidebar - hidden on mobile, shown as overlay when toggled */}
-      <div className={`
-        fixed md:relative inset-y-0 left-0 z-50 md:z-auto
-        w-80 flex-shrink-0
-        transform transition-transform duration-200 ease-in-out
-        ${showSidebar ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
-        md:block
-      `}>
-        <ChatSidebar
-          sessions={sessions}
-          activeSessionId={currentSessionId}
-          onSessionSelect={handleSessionSelect}
-          onNewChat={handleNewChat}
-          onDeleteSession={handleDeleteSession}
-          onTogglePin={handleTogglePin}
-          onToggleArchive={handleToggleArchive}
-        />
-      </div>
+      {/* Main container with gutters */}
+      <div className="h-full p-2 md:p-4">
+        {/* BG-CARD-MAIN: Browser window container */}
+        <ChatOuterCard>
+          {/* SIDEBAR (Chat Session Navigation) - inside BG-CARD-MAIN */}
+          <div
+            className={`
+              ${showSidebar ? 'fixed inset-y-0 left-0 z-50 shadow-2xl' : 'hidden'}
+              md:block md:relative md:z-auto md:shadow-none
+              w-[280px] flex-shrink-0 transition-all duration-200
+            `}
+          >
+            <ChatSidebar
+              sessions={sessions}
+              activeSessionId={currentSessionId}
+              onSessionSelect={handleSessionSelect}
+              onNewChat={handleNewChat}
+              onDeleteSession={handleDeleteSession}
+              onTogglePin={handleTogglePin}
+              onToggleArchive={handleToggleArchive}
+            />
+          </div>
 
-      {/* Main chat area - Kortex-style premium card layout */}
-      <div className="flex flex-1 flex-col w-full p-2 md:p-4 bg-viewport">
-        <ChatMainCard>
-          {/* Header with title and filters */}
-          <ChatMainCardHeader>
+          {/* BG-CARD-INNER: Chat interface */}
+          <ChatInnerCard>
+            {/* Header - INSIDE BG-CARD-INNER */}
+            <ChatInnerCardHeader>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 md:gap-3">
                 {/* Mobile menu toggle */}
@@ -700,12 +704,12 @@ export default function Chat() {
                 </Popover>
               </div>
             </div>
-          </ChatMainCardHeader>
+            </ChatInnerCardHeader>
 
-          {/* Chat content area */}
-          <ChatMainCardContent>
+            {/* Chat content area */}
+            <ChatInnerCardContent>
             <ChatContainerRoot className="h-full">
-              <ChatContainerContent className="px-2 md:px-4 py-4">
+              <ChatContainerContent className="px-6 py-4">
                 {/* Kortex-style Welcome/Empty State */}
                 {messages.length === 0 && (
                   <ChatWelcome
@@ -838,10 +842,10 @@ export default function Chat() {
               <ChatContainerScrollAnchor />
               <ScrollButton className="shadow-lg" />
             </ChatContainerRoot>
-          </ChatMainCardContent>
+            </ChatInnerCardContent>
 
-          {/* Input area - Kortex-style centered container */}
-          <ChatMainCardInputArea>
+            {/* Input area */}
+            <ChatInnerCardInputArea>
             <div className="relative w-full">
               {/* Mentions popover */}
               {showMentions && filteredCalls.length > 0 && (
@@ -921,14 +925,15 @@ export default function Chat() {
                 </PromptInputFooter>
               </PromptInput>
 
-              {/* Kortex-style Keyboard Hint Bar */}
+              {/* Keyboard Hint Bar */}
               <PromptInputHintBar>
                 <KeyboardHint label="Send with" shortcut="Enter" />
                 <KeyboardHint label="New line" shortcut="Shift+Enter" />
               </PromptInputHintBar>
             </div>
-          </ChatMainCardInputArea>
-        </ChatMainCard>
+            </ChatInnerCardInputArea>
+          </ChatInnerCard>
+        </ChatOuterCard>
       </div>
 
       {/* Call Detail Dialog for viewing source citations */}


### PR DESCRIPTION
### **User description**
Implements the structural changes from new-chat-design-guidelines.md:

- Add ChatOuterCard (BG-CARD-MAIN) and ChatInnerCard (BG-CARD-INNER)
  components implementing the two-card system
- Move sidebar INSIDE the outer card as per guidelines
- Update sidebar width to 280px with rounded-lg border styling
- Fix padding values: px-6 py-4 for header, content, and input areas
- Remove max-width constraint from input area
- Update component naming to match guideline terminology


___

### **PR Type**
Enhancement


___

### **Description**
- Implement two-card system (BG-CARD-MAIN and BG-CARD-INNER) per design guidelines

- Move sidebar inside outer card with 280px width and rounded styling

- Standardize padding to px-6 py-4 across header, content, and input areas

- Remove max-width constraint from input area for full-width layout

- Update component naming and add legacy aliases for backwards compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChatOuterCard<br/>BG-CARD-MAIN"] --> B["Sidebar<br/>280px"]
  A --> C["ChatInnerCard<br/>BG-CARD-INNER"]
  C --> D["Header<br/>px-6 py-4"]
  C --> E["Content<br/>px-6 py-4"]
  C --> F["Input Area<br/>px-6 py-4"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-main-card.tsx</strong><dd><code>Introduce two-card system with new component structure</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/chat/chat-main-card.tsx

<ul><li>Add ChatOuterCard (BG-CARD-MAIN) component for outermost container <br>with sidebar + inner card<br> <li> Add ChatInnerCard (BG-CARD-INNER) component for chat interface with <br>header, content, and input<br> <li> Rename ChatMainCardContent to ChatInnerCardContent with updated <br>padding (px-6 py-4)<br> <li> Rename ChatMainCardInputArea to ChatInnerCardInputArea, remove <br>max-width constraint<br> <li> Rename ChatMainCardHeader to ChatInnerCardHeader with standardized <br>padding<br> <li> Add legacy aliases for backwards compatibility<br> <li> Update border color references from cb-border to border<br> <li> Add comprehensive documentation for two-card system architecture</ul>


</details>


  </td>
  <td><a href="https://github.com/Vibe-Marketer/brain/pull/3/files#diff-2bc34bb6e9368efff5ca5ea0b941fe87b097aeaf12a4b13b62de4da239621543">+119/-35</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatSidebar.tsx</strong><dd><code>Update sidebar styling and header text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/chat/ChatSidebar.tsx

<ul><li>Update wrapper div with rounded-lg border styling and 280px width per <br>guidelines<br> <li> Change border color from cb-border to border<br> <li> Rename header from "Conversations" to "Chat History"<br> <li> Update button variant from hollow to ghost<br> <li> Change heading element from h2 to h3 and font from montserrat to <br>display<br> <li> Add data-component attribute for component identification</ul>


</details>


  </td>
  <td><a href="https://github.com/Vibe-Marketer/brain/pull/3/files#diff-1c6f5f9bed58a3d5a11cb71ed8aee39dc0883ef1ae4b2e0e56bce23fd10802ff">+10/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Chat.tsx</strong><dd><code>Refactor Chat page layout for two-card system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/Chat.tsx

<ul><li>Restructure layout to use ChatOuterCard wrapping sidebar and <br>ChatInnerCard<br> <li> Move sidebar inside ChatOuterCard as per new design guidelines<br> <li> Update sidebar width to 280px with fixed/relative positioning logic<br> <li> Replace all ChatMainCard* component imports with ChatOuterCard and <br>ChatInnerCard*<br> <li> Update ChatContainerContent padding from px-2 md:px-4 to px-6<br> <li> Add backdrop-blur-sm to mobile sidebar overlay<br> <li> Simplify main container structure with new two-card system</ul>


</details>


  </td>
  <td><a href="https://github.com/Vibe-Marketer/brain/pull/3/files#diff-07a68b3863c00c1c7466151060e4cf6b90ceeeab1e6452044ec2493a854a18d8">+46/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

