### PR TITLE
refactor: clean up root TypeScript debug scripts

### DIFF
--- a/DB_VERIFICATION_REPORT.md
+++ b/DB_VERIFICATION_REPORT.md
@@ -117,7 +117,7 @@ sentiment_cache, metadata
 
 ### 5. E2E RAG Tools Test Results ❌
 
-**Test Suite:** test-rag-final-run.ts  
+**Test Suite:** scripts/debug/root/test-rag-final-run.ts  
 **Authentication:** ✅ SUCCESS (a@vibeos.com)  
 **Edge Function:** ❌ 502 Bad Gateway on ALL requests
 
@@ -213,7 +213,7 @@ https://supabase.com/dashboard/project/vltmrnjsubfzrgrtdqey/functions/chat-strea
 
 5. **Test edge function after migrations**
    - Verify `chat-stream-v2` responds correctly
-   - Rerun E2E tests: `npx tsx test-rag-final-run.ts`
+   - Rerun E2E tests: `npx tsx scripts/debug/root/test-rag-final-run.ts`
 
 6. **Update PENDING_DATABASE_MIGRATION.md**
    - Document current status
@@ -232,10 +232,10 @@ https://supabase.com/dashboard/project/vltmrnjsubfzrgrtdqey/functions/chat-strea
 ## Test Artifacts
 
 ### Scripts Created:
-- `/Users/admin/repos/brain/verify-db-functions.ts` - Function verification
-- `/Users/admin/repos/brain/test-db-complete.ts` - Comprehensive DB tests
-- `/Users/admin/repos/brain/check-schema-simple.ts` - Schema checker
-- `/Users/admin/repos/brain/test-rag-final-run.ts` - E2E RAG tools test
+- `scripts/debug/root/verify-db-functions.ts` - Function verification
+- `scripts/debug/root/test-db-complete.ts` - Comprehensive DB tests
+- `scripts/debug/root/check-schema-simple.ts` - Schema checker
+- `scripts/debug/root/test-rag-final-run.ts` - E2E RAG tools test
 
 ### Test Output Files:
 - This report: `DB_VERIFICATION_REPORT.md`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,6 +45,13 @@ See [RAG_TESTING_GUIDE.md](./RAG_TESTING_GUIDE.md) for:
 
 ## Other Scripts
 
+### Root Script Archive
+
+Legacy root-level debug scripts now live in `scripts/debug/root/`.
+
+- Run with: `npx tsx scripts/debug/root/<script-name>.ts`
+- See `scripts/debug/root/README.md` for required env vars
+
 ### Supabase Import Scripts
 
 | Script | Purpose |

--- a/scripts/debug/root/README.md
+++ b/scripts/debug/root/README.md
@@ -1,0 +1,25 @@
+# Root Script Archive
+
+These scripts were previously stored at the repository root.
+
+They are ad-hoc diagnostics/debug utilities (not app runtime files), and were moved to keep the root clean and safer.
+
+## Run
+
+```bash
+npx tsx scripts/debug/root/<script-name>.ts
+```
+
+## Required Environment Variables
+
+- `SUPABASE_URL` (or `VITE_SUPABASE_URL`)
+- `SUPABASE_SERVICE_ROLE_KEY` (for admin/debug scripts)
+- `SUPABASE_ANON_KEY` (or `VITE_SUPABASE_PUBLISHABLE_KEY`)
+- `CALLVAULTAI_LOGIN` / `CALLVAULTAI_LOGIN_PASSWORD` (for auth-based RAG tests)
+- `DEBUG_TEST_USER_ID` (scripts that need explicit user scope)
+- `DEBUG_TEST_USER_EMAIL` (optional override for user-email tests)
+
+## Notes
+
+- No credentials are hardcoded in these scripts anymore.
+- Keep this directory out of production workflows; it is for manual debugging only.

--- a/scripts/debug/root/check-data-detailed.ts
+++ b/scripts/debug/root/check-data-detailed.ts
@@ -1,7 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 

--- a/scripts/debug/root/check-db-data.ts
+++ b/scripts/debug/root/check-db-data.ts
@@ -1,7 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 

--- a/scripts/debug/root/check-db-functions.ts
+++ b/scripts/debug/root/check-db-functions.ts
@@ -1,7 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+const testUserId = requireEnv('DEBUG_TEST_USER_ID');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
@@ -18,7 +27,7 @@ async function checkFunctions() {
       full_text_weight: 1.0,
       semantic_weight: 1.0,
       rrf_k: 60,
-      filter_user_id: 'ad6cdef0-8dc0-4ad5-bfe7-f0e1bce01be4', // a@vibeos.com
+      filter_user_id: testUserId,
       filter_date_start: null,
       filter_date_end: null,
       filter_speakers: null,
@@ -41,7 +50,7 @@ async function checkFunctions() {
   console.log('\nTesting: get_available_metadata');
   try {
     const { data, error } = await supabase.rpc('get_available_metadata', {
-      p_user_id: 'ad6cdef0-8dc0-4ad5-bfe7-f0e1bce01be4',
+      p_user_id: testUserId,
       p_metadata_type: 'speakers',
     });
     
@@ -63,7 +72,7 @@ async function checkFunctions() {
     const { data, error } = await supabase
       .from('fathom_transcripts')
       .select('id, text')
-      .eq('user_id', 'ad6cdef0-8dc0-4ad5-bfe7-f0e1bce01be4')
+      .eq('user_id', testUserId)
       .limit(1)
       .single();
     

--- a/scripts/debug/root/check-schema-simple.ts
+++ b/scripts/debug/root/check-schema-simple.ts
@@ -1,6 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
 
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
 dotenv.config();
 
 const supabase = createClient(

--- a/scripts/debug/root/check-schema.ts
+++ b/scripts/debug/root/check-schema.ts
@@ -1,7 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 

--- a/scripts/debug/root/find-user-with-data.ts
+++ b/scripts/debug/root/find-user-with-data.ts
@@ -1,7 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 

--- a/scripts/debug/root/get-test-user.ts
+++ b/scripts/debug/root/get-test-user.ts
@@ -1,7 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey, {
   auth: {

--- a/scripts/debug/root/test-db-complete.ts
+++ b/scripts/debug/root/test-db-complete.ts
@@ -1,6 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
 
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
 dotenv.config();
 
 const supabase = createClient(

--- a/scripts/debug/root/test-rag-final-run.ts
+++ b/scripts/debug/root/test-rag-final-run.ts
@@ -1,10 +1,18 @@
 import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
 
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
 dotenv.config();
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL!;
-const anonKey = process.env.VITE_SUPABASE_PUBLISHABLE_KEY!;
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const anonKey = requireEnv('SUPABASE_ANON_KEY', 'VITE_SUPABASE_PUBLISHABLE_KEY');
 
 const supabase = createClient(supabaseUrl, anonKey);
 

--- a/scripts/debug/root/test-rag-tools-v2.ts
+++ b/scripts/debug/root/test-rag-tools-v2.ts
@@ -1,16 +1,24 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM4NzUwMDcsImV4cCI6MjA3OTQ1MTAwN30.jkT4qFvOuRnyMexcOfgt1AZSbrRFyDsJfPVsGdA0BUo';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const anonKey = requireEnv('SUPABASE_ANON_KEY', 'VITE_SUPABASE_PUBLISHABLE_KEY');
+const testUserEmail = requireEnv('CALLVAULTAI_LOGIN');
+const testUserPassword = requireEnv('CALLVAULTAI_LOGIN_PASSWORD');
 
 const supabase = createClient(supabaseUrl, anonKey);
 
-//Test user from .env comments: sepihe5967@gavrom.com / Password1!
-
 async function getAuthToken(): Promise<string> {
   const { data, error } = await supabase.auth.signInWithPassword({
-    email: 'sepihe5967@gavrom.com',
-    password: 'Password1!',
+    email: testUserEmail,
+    password: testUserPassword,
   });
   
   if (error || !data.session) {
@@ -28,7 +36,7 @@ async function testQuery(token: string, messages: any[], testName: string) {
   console.log(`${'='.repeat(70)}`);
   
   try {
-    const response = await fetch('https://vltmrnjsubfzrgrtdqey.supabase.co/functions/v1/chat-stream-v2', {
+    const response = await fetch(`${supabaseUrl}/functions/v1/chat-stream-v2`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/scripts/debug/root/test-rag-tools.ts
+++ b/scripts/debug/root/test-rag-tools.ts
@@ -1,8 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://vltmrnjsubfzrgrtdqey.supabase.co';
-const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2Mzg3NTAwNywiZXhwIjoyMDc5NDUxMDA3fQ.a8Lp_JzIk4f4ROiRPBTNGZgnTMQ6Ok5rRuQzkx3stv8';
-const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsdG1ybmpzdWJmenJncnRkcWV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM4NzUwMDcsImV4cCI6MjA3OTQ1MTAwN30.jkT4qFvOuRnyMexcOfgt1AZSbrRFyDsJfPVsGdA0BUo';
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
+const supabaseUrl = requireEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+const anonKey = requireEnv('SUPABASE_ANON_KEY', 'VITE_SUPABASE_PUBLISHABLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
@@ -35,7 +43,7 @@ async function testQuery(token: string, messages: any[], testName: string) {
   console.log(`${'='.repeat(60)}`);
   
   try {
-    const response = await fetch('https://vltmrnjsubfzrgrtdqey.supabase.co/functions/v1/chat-stream-v2', {
+    const response = await fetch(`${supabaseUrl}/functions/v1/chat-stream-v2`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/scripts/debug/root/verify-db-functions.ts
+++ b/scripts/debug/root/verify-db-functions.ts
@@ -1,6 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
 
+const requireEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name] ?? (fallback ? process.env[fallback] : undefined);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}${fallback ? ` (or ${fallback})` : ''}`);
+  }
+  return value;
+};
+
 dotenv.config();
 
 const supabase = createClient(


### PR DESCRIPTION
## Summary
- Move ad-hoc root `.ts` debug/verification scripts into `scripts/debug/root/`
- Keep only actual root config TS files at repo root (`vite`, `vitest`, `playwright`, `tailwind`)
- Remove hardcoded Supabase keys/user credentials from moved scripts and require env vars instead
- Update docs references to new script paths

## Why
- Root directory had operational/debug scripts mixed with app/config files, which made the repo look unhealthy
- Several scripts contained hardcoded credentials and test identifiers
- This makes script intent explicit and lowers accidental credential exposure risk

## Follow-up
- If any old command docs still reference root paths, update to `scripts/debug/root/<script>.ts`