### PR TITLE
fix: tighten recordings SELECT RLS — scope to workspace membership

### DIFF
--- a/supabase/migrations/20260308000001_tighten_recordings_select_rls.sql
+++ b/supabase/migrations/20260308000001_tighten_recordings_select_rls.sql
@@ -1,0 +1,51 @@
+-- Migration: Tighten recordings SELECT RLS — scope to workspace membership
+-- Purpose: Regular org members should only see recordings they own or that exist
+--          in workspaces they belong to. Org admins/owners retain full visibility.
+--          Closes #53.
+-- Date: 2026-03-08
+
+-- ============================================================================
+-- 1. Drop existing SELECT policies from prior tightening attempt
+-- ============================================================================
+DROP POLICY IF EXISTS "Users can view own recordings" ON recordings;
+DROP POLICY IF EXISTS "Users can view shared recordings in their workspaces" ON recordings;
+-- Also drop the original broad policy in case it was re-applied
+DROP POLICY IF EXISTS "Users can view recordings in their organizations" ON recordings;
+
+-- ============================================================================
+-- 2. Org admins/owners can see ALL recordings in their organization
+-- ============================================================================
+CREATE POLICY "Org admins can view all recordings"
+  ON recordings FOR SELECT
+  USING (is_organization_admin_or_owner(organization_id, auth.uid()));
+
+-- ============================================================================
+-- 3. Users can always see their own recordings
+-- ============================================================================
+CREATE POLICY "Users can view own recordings"
+  ON recordings FOR SELECT
+  USING (owner_user_id = auth.uid());
+
+-- ============================================================================
+-- 4. Regular members see recordings shared into workspaces they belong to
+-- ============================================================================
+CREATE POLICY "Users can view recordings in their workspaces"
+  ON recordings FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM workspace_entries we
+      JOIN workspace_memberships wm ON wm.workspace_id = we.workspace_id
+      WHERE we.recording_id = recordings.id
+        AND wm.user_id = auth.uid()
+    )
+  );
+
+-- ============================================================================
+-- 5. Performance: index on workspace_entries(recording_id)
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_workspace_entries_recording_id
+  ON workspace_entries (recording_id);
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================


### PR DESCRIPTION
## Summary

- Adds org admin/owner override policy so admins retain full recording visibility
- Re-creates own-recordings policy (owners always see their own recordings)
- Re-creates workspace-scoped policy (regular members only see recordings in workspaces they belong to)
- Adds performance index on `workspace_entries(recording_id)` for the workspace membership join
- Drops all prior SELECT policies to ensure a clean policy set

## Context

The previous tightening migration (`20260303000000`) correctly dropped the broad org-member policy and added workspace-scoped access, but omitted the org admin/owner override. This migration completes the fix.

## Test plan

- [ ] Regular member cannot see recordings outside their workspace
- [ ] Org admin/owner can see all recordings in their organization
- [ ] Recording owner can always see their own recordings
- [ ] Verify `idx_workspace_entries_recording_id` index is created
- [ ] Existing frontend queries continue to work (no breaking changes)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)