### PR TITLE
fix: export static corsHeaders from cors.ts (#70)

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -14,6 +14,10 @@ const rawOrigins = Deno.env.get('ALLOWED_ORIGINS')
 
 const allowedOrigins = rawOrigins && rawOrigins.length > 0 ? rawOrigins : DEFAULT_ORIGINS;
 
+// Static default headers for imports that don't have access to the request origin.
+// Prefer getCorsHeaders(requestOrigin) in handlers where the request is available.
+export const corsHeaders = getCorsHeaders();
+
 export function getCorsHeaders(requestOrigin?: string | null): Record<string, string> {
   // Default to first allowed origin (never wildcard)
   let origin = allowedOrigins[0];


### PR DESCRIPTION
## Summary

- Adds `export const corsHeaders = getCorsHeaders()` to `supabase/functions/_shared/cors.ts` so that `response.ts` can import `corsHeaders` as a named export
- The other 5 items from the PR #61 review (webhook config.toml entries, Google Meet reference, Fathom env var names, dead chat-stream entry, JWT audit consistency) were already addressed in PR #61 before merge

## What was broken

`response.ts` imported `{ corsHeaders }` from `cors.ts`, but `cors.ts` only exported `getCorsHeaders()` as a function — no static `corsHeaders` constant existed.

## Fix

Added a static export that calls `getCorsHeaders()` with no origin (defaults to first allowed origin). Callers that have access to the request origin should still use `getCorsHeaders(requestOrigin)` directly for proper origin echoing.

## Verification

- `deno check` passes for both `cors.ts` and `response.ts`

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)