### PR TITLE
fix(57): recording deletion cascade — remove workspace entries before delete

### DIFF
--- a/src/services/recordings.service.ts
+++ b/src/services/recordings.service.ts
@@ -165,3 +165,37 @@ export async function getRecordingByLegacyId(legacyId: number): Promise<Recordin
 
   return data
 }
+
+/** Response shape from the delete_recording RPC */
+export interface DeleteRecordingResult {
+  success?: boolean
+  error?: string
+  deleted_recording_id?: string
+  cleaned_up?: {
+    workspace_entries: number
+    folder_assignments: number
+    call_tags: number
+  }
+}
+
+/**
+ * Deletes a recording and all related workspace entries, folder assignments,
+ * and call tags via the delete_recording RPC. The RPC runs as SECURITY DEFINER
+ * to bypass the RLS guard that blocks deletion when workspace_entries exist.
+ */
+export async function deleteRecording(recordingId: string): Promise<DeleteRecordingResult> {
+  const { data, error } = await supabase.rpc('delete_recording', {
+    p_recording_id: recordingId,
+  })
+
+  if (error) {
+    throw new Error(`Failed to delete recording: ${error.message}`)
+  }
+
+  const result = data as DeleteRecordingResult
+  if (result?.error) {
+    throw new Error(result.error)
+  }
+
+  return result
+}

--- a/supabase/migrations/20260308100000_delete_recording_rpc.sql
+++ b/supabase/migrations/20260308100000_delete_recording_rpc.sql
@@ -1,0 +1,100 @@
+-- Migration: Add delete_recording RPC
+-- Purpose: Provide a safe, cascading recording deletion that cleans up
+--          workspace_entries, folder_assignments, and call_tags before
+--          removing the recording itself. Replaces direct DELETE which was
+--          blocked by the RLS NOT EXISTS(workspace_entries) guard.
+-- Closes: #57
+-- Date: 2026-03-08
+
+-- ============================================================================
+-- 1. Create delete_recording RPC (SECURITY DEFINER)
+-- ============================================================================
+-- SECURITY DEFINER runs as the function owner (superuser), bypassing RLS.
+-- Authorization is enforced explicitly inside the function body.
+
+CREATE OR REPLACE FUNCTION public.delete_recording(p_recording_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner_user_id UUID;
+  v_deleted_workspace_entries INT;
+  v_deleted_folder_assignments INT;
+  v_deleted_call_tags INT;
+BEGIN
+  -- -----------------------------------------------------------------------
+  -- 1. Verify caller owns the recording
+  -- -----------------------------------------------------------------------
+  SELECT owner_user_id INTO v_owner_user_id
+  FROM recordings
+  WHERE id = p_recording_id;
+
+  IF v_owner_user_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Recording not found');
+  END IF;
+
+  IF v_owner_user_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('error', 'Not authorized — you do not own this recording');
+  END IF;
+
+  -- -----------------------------------------------------------------------
+  -- 2. Remove workspace_entries referencing this recording
+  -- -----------------------------------------------------------------------
+  DELETE FROM workspace_entries
+  WHERE recording_id = p_recording_id;
+
+  GET DIAGNOSTICS v_deleted_workspace_entries = ROW_COUNT;
+
+  -- -----------------------------------------------------------------------
+  -- 3. Remove folder_assignments referencing this recording (legacy FK)
+  --    folder_assignments uses legacy_recording_id (bigint), so look it up.
+  -- -----------------------------------------------------------------------
+  DELETE FROM folder_assignments fa
+  USING recordings r
+  WHERE r.id = p_recording_id
+    AND fa.call_recording_id = r.legacy_recording_id;
+
+  GET DIAGNOSTICS v_deleted_folder_assignments = ROW_COUNT;
+
+  -- -----------------------------------------------------------------------
+  -- 4. Remove call_tags referencing this recording (legacy FK)
+  -- -----------------------------------------------------------------------
+  DELETE FROM call_tags ct
+  USING recordings r
+  WHERE r.id = p_recording_id
+    AND ct.recording_id = r.legacy_recording_id;
+
+  GET DIAGNOSTICS v_deleted_call_tags = ROW_COUNT;
+
+  -- -----------------------------------------------------------------------
+  -- 5. Delete the recording itself
+  --    FK cascades on recordings will clean up:
+  --      - transcript_chunks (ON DELETE CASCADE via recording_id)
+  --      - Any other tables with direct FK to recordings.id
+  -- -----------------------------------------------------------------------
+  DELETE FROM recordings WHERE id = p_recording_id;
+
+  -- -----------------------------------------------------------------------
+  -- 6. Return summary
+  -- -----------------------------------------------------------------------
+  RETURN jsonb_build_object(
+    'success', true,
+    'deleted_recording_id', p_recording_id,
+    'cleaned_up', jsonb_build_object(
+      'workspace_entries', v_deleted_workspace_entries,
+      'folder_assignments', v_deleted_folder_assignments,
+      'call_tags', v_deleted_call_tags
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_recording(UUID) IS
+  'Safely deletes a recording and all related workspace_entries, folder_assignments, and call_tags. '
+  'Verifies caller ownership. SECURITY DEFINER bypasses RLS for cascade cleanup. Closes #57.';
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================


### PR DESCRIPTION
## Summary

- Adds `delete_recording(p_recording_id UUID)` RPC as SECURITY DEFINER that safely cascades through all related rows before deleting the recording
- Cleans up workspace_entries, folder_assignments, and call_tags before removing the recording itself
- Verifies caller ownership inside the RPC body (explicit authorization)
- Adds `deleteRecording()` service function in `src/services/recordings.service.ts` to call the RPC from the frontend
- Fixes the RLS `NOT EXISTS(workspace_entries)` guard that previously blocked deletion when any workspace entries existed

## Test plan

- [ ] Call `delete_recording(recording_id)` via Supabase SQL editor as the recording owner — verify all workspace_entries, folder_assignments, and call_tags are cleaned up
- [ ] Verify the recording row is deleted and transcript_chunks cascade via FK
- [ ] Call `delete_recording(recording_id)` as a non-owner — verify it returns an authorization error
- [ ] Call with a non-existent recording ID — verify it returns "Recording not found"
- [ ] Wire up `deleteRecording()` in the frontend and verify end-to-end deletion works

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)