### PR TITLE
chore(56): regenerate Supabase types + fix stale as-any casts

### DIFF
--- a/src/components/settings/WorkspaceManagement.tsx
+++ b/src/components/settings/WorkspaceManagement.tsx
@@ -70,9 +70,6 @@ interface WorkspaceQueryResult {
   }>
 }
 
-// Type-safe supabase client wrapper for tables not yet in generated types
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const db = supabase as any
 
 export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementProps) {
   const navigate = useNavigate()
@@ -86,7 +83,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
   const { data: workspaces, isLoading } = useQuery({
     queryKey: queryKeys.workspaces.list(orgId),
     queryFn: async (): Promise<WorkspaceQueryResult[]> => {
-      const { data, error } = await db
+      const { data, error } = await supabase
         .from('workspaces')
         .select(`
           id,
@@ -117,7 +114,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
   const createWorkspace = useMutation({
     mutationFn: async ({ name, type }: { name: string; type: WorkspaceType }) => {
       // Create workspace
-      const { data: workspace, error: workspaceError } = await db
+      const { data: workspace, error: workspaceError } = await supabase
         .from('workspaces')
         .insert({
           organization_id: orgId,
@@ -130,7 +127,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
       if (workspaceError) throw workspaceError
 
       // Create workspace membership for creator as owner
-      const { error: membershipError } = await db
+      const { error: membershipError } = await supabase
         .from('workspace_memberships')
         .insert({
           workspace_id: workspace.id,

--- a/src/components/transcripts/SyncTab.tsx
+++ b/src/components/transcripts/SyncTab.tsx
@@ -121,8 +121,7 @@ export function SyncTab() {
       // until then we use type assertions
       let useRecordings = false;
       if (activeOrganizationId) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { count: recordingsCount } = await (supabase as any)
+        const { count: recordingsCount } = await supabase
           .from('recordings')
           .select('*', { count: 'exact', head: true })
           .eq('organization_id', activeOrganizationId);

--- a/src/hooks/useCategorySync.ts
+++ b/src/hooks/useCategorySync.ts
@@ -35,7 +35,7 @@ export function useTagSync() {
 
       // Scope tags to the active organization/workspace
       if (activeOrgId) {
-        query = (query as any).eq("organization_id", activeOrgId);
+        query = query.eq("organization_id", activeOrgId);
       }
 
       const { data, error } = await query;

--- a/src/hooks/useOrganizationMutations.ts
+++ b/src/hooks/useOrganizationMutations.ts
@@ -16,9 +16,6 @@ import { toast } from 'sonner'
 import { useNavigate } from 'react-router-dom'
 import type { OrganizationWithMembership } from '@/types/workspace'
 
-// Type-safe supabase client wrapper for tables not yet in generated types
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const db = supabase as any
 
 // ─── Create Business Organization ───────────────────────────────────
 
@@ -54,7 +51,7 @@ export function useCreateBusinessOrganization() {
         throw new Error('Organization name must be between 3 and 50 characters')
       }
 
-      const { data: createResult, error: createError } = await db
+      const { data: createResult, error: createError } = await supabase
         .rpc('create_business_organization', {
           p_name: orgName,
           p_cross_org_default: input.crossOrganizationDefault || 'copy_only',
@@ -68,7 +65,7 @@ export function useCreateBusinessOrganization() {
         throw new Error('Business organization creation did not return an organization id')
       }
 
-      const { data: organization, error: orgError } = await db
+      const { data: organization, error: orgError } = await supabase
         .from('organizations')
         .select('*')
         .eq('id', createResult.organization_id)
@@ -148,7 +145,7 @@ export function useDeleteOrganization() {
         const personalOrg = organizations.find((b: OrganizationWithMembership) => b.type === 'personal')
         if (personalOrg) {
           // Update recordings to point to personal organization
-          const { error: moveError } = await db
+          const { error: moveError } = await supabase
             .from('recordings')
             .update({ organization_id: personalOrg.id })
             .eq('organization_id', input.organizationId)
@@ -158,7 +155,7 @@ export function useDeleteOrganization() {
       }
 
       // Delete the organization (cascading deletes handle workspaces, memberships, workspace_entries)
-      const { error: deleteError } = await db
+      const { error: deleteError } = await supabase
         .from('organizations')
         .delete()
         .eq('id', input.organizationId)

--- a/src/hooks/useSyncTabState.ts
+++ b/src/hooks/useSyncTabState.ts
@@ -108,7 +108,7 @@ export function useSyncTabState({
         .order("name");
 
       if (activeOrgId) {
-        query = (query as any).eq("organization_id", activeOrgId);
+        query = query.eq("organization_id", activeOrgId);
       }
 
       const { data, error } = await query;

--- a/src/hooks/useWorkspaceMemberMutations.ts
+++ b/src/hooks/useWorkspaceMemberMutations.ts
@@ -77,8 +77,7 @@ export function useGenerateWorkspaceInvite(workspaceId: string) {
       if (!user) throw new Error('Not authenticated')
 
       // Permission check: must be workspace_owner or workspace_admin
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: membership } = await (supabase as any)
+      const { data: membership } = await supabase
         .from('workspace_memberships')
         .select('role')
         .eq('workspace_id', workspaceId)
@@ -92,8 +91,7 @@ export function useGenerateWorkspaceInvite(workspaceId: string) {
 
       // Check if workspace already has a valid invite token
       // Preferred path: SECURITY DEFINER RPC handles permissions and token generation
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: rpcData, error: rpcError } = await (supabase as any).rpc('generate_workspace_invite', {
+      const { data: rpcData, error: rpcError } = await supabase.rpc('generate_workspace_invite', {
         p_workspace_id: workspaceId,
         p_force: !!options?.force,
       })
@@ -111,8 +109,7 @@ export function useGenerateWorkspaceInvite(workspaceId: string) {
       const inviteToken = generateInviteToken()
       const inviteExpiresAt = getInviteExpiration()
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error: updateError } = await (supabase as any)
+      const { error: updateError } = await supabase
         .from('workspaces')
         .update({
           invite_token: inviteToken,
@@ -190,8 +187,7 @@ export function useChangeRole(workspaceId: string) {
       }
 
       // Update the membership
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase as any)
+      const { error } = await supabase
         .from('workspace_memberships')
         .update({ role: newRole })
         .eq('id', membershipId)
@@ -239,8 +235,7 @@ export function useRemoveMember(workspaceId: string) {
         throw new Error('Cannot remove the workspace owner')
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase as any)
+      const { error } = await supabase
         .from('workspace_memberships')
         .delete()
         .eq('id', membershipId)
@@ -279,8 +274,7 @@ export function useLeaveWorkspace(workspaceId: string) {
 
       if (!user) throw new Error('Not authenticated')
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase as any)
+      const { error } = await supabase
         .from('workspace_memberships')
         .delete()
         .eq('id', membershipId)

--- a/src/hooks/useWorkspaceMutations.ts
+++ b/src/hooks/useWorkspaceMutations.ts
@@ -14,9 +14,9 @@ import { queryKeys } from '@/lib/query-config'
 import { toast } from 'sonner'
 import type { WorkspaceType, WorkspaceWithMeta } from '@/types/workspace'
 
-// Type-safe supabase client wrapper for tables not yet in generated types
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const db = supabase as any
+import type { Database } from '@/types/supabase'
+
+type WorkspaceInsert = Database['public']['Tables']['workspaces']['Insert']
 
 // ─── Create Workspace ───────────────────────────────────────────────────
 
@@ -42,7 +42,7 @@ export function useCreateWorkspace() {
       if (!user) throw new Error('Not authenticated')
 
       // Create workspace
-      const { data: workspace, error: workspaceError } = await db
+      const { data: workspace, error: workspaceError } = await supabase
         .from('workspaces')
         .insert({
           organization_id: input.orgId,
@@ -66,7 +66,7 @@ export function useCreateWorkspace() {
       if (workspaceError) throw workspaceError
 
       // Create workspace membership for creator as owner
-      const { error: membershipError } = await db
+      const { error: membershipError } = await supabase
         .from('workspace_memberships')
         .insert({
           workspace_id: workspace.id,
@@ -189,7 +189,7 @@ export function useUpdateWorkspace() {
         updates.default_sharelink_ttl_days = input.defaultShareLinkTtlDays
       }
 
-      const { data, error } = await db
+      const { data, error } = await supabase
         .from('workspaces')
         .update(updates)
         .eq('id', input.workspaceId)
@@ -228,8 +228,7 @@ export function useUpdateWorkspace() {
       // Optimistically update the detail cache
       queryClient.setQueryData(
         queryKeys.workspaces.detail(input.workspaceId),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (old: any) => {
+        (old: WorkspaceWithMeta | undefined) => {
           if (!old) return old
           return {
             ...old,
@@ -309,7 +308,7 @@ export function useDeleteWorkspace() {
         input.transferRecordingsToWorkspaceId &&
         input.transferRecordingsToWorkspaceId !== input.workspaceId
       ) {
-        const { error: transferError } = await db
+        const { error: transferError } = await supabase
           .from('workspace_entries')
           .update({ workspace_id: input.transferRecordingsToWorkspaceId })
           .eq('workspace_id', input.workspaceId)
@@ -317,7 +316,7 @@ export function useDeleteWorkspace() {
         if (transferError) throw transferError
       }
 
-      const { error } = await db
+      const { error } = await supabase
         .from('workspaces')
         .delete()
         .eq('id', input.workspaceId)
@@ -391,7 +390,7 @@ export function useSetDefaultWorkspace() {
       if (!user) throw new Error('Not authenticated')
 
       // 1. Get the organization_id for the target workspace
-      const { data: targetWs, error: fetchError } = await db
+      const { data: targetWs, error: fetchError } = await supabase
         .from('workspaces')
         .select('organization_id')
         .eq('id', input.workspaceId)
@@ -400,7 +399,7 @@ export function useSetDefaultWorkspace() {
       if (fetchError) throw fetchError
 
       // 2. Unset default for all workspaces in that organization
-      const { error: unsetError } = await db
+      const { error: unsetError } = await supabase
         .from('workspaces')
         .update({ is_default: false })
         .eq('organization_id', targetWs.organization_id)
@@ -408,7 +407,7 @@ export function useSetDefaultWorkspace() {
       if (unsetError) throw unsetError
 
       // 3. Set default for the target workspace
-      const { data: updatedWs, error: setError } = await db
+      const { data: updatedWs, error: setError } = await supabase
         .from('workspaces')
         .update({ is_default: true })
         .eq('id', input.workspaceId)

--- a/src/hooks/useWorkspaces.ts
+++ b/src/hooks/useWorkspaces.ts
@@ -85,13 +85,15 @@ export function useWorkspaces(orgId: string | null) {
       if (queryError) throw queryError
 
       // Filter to only workspaces in the specified organization
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const orgWorkspaces = (memberships || []).filter((m: any) => m.workspace && m.workspace.organization_id === orgId)
+      type MembershipWithWorkspace = (typeof memberships)[number]
+      const orgWorkspaces = (memberships || []).filter((m: MembershipWithWorkspace) => {
+        const ws = m.workspace as Record<string, unknown> | null
+        return ws && ws.organization_id === orgId
+      })
 
       // For each workspace, get member count
       const workspaceIds = orgWorkspaces
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map((m: any) => m.workspace?.id)
+        .map((m) => (m.workspace as Record<string, unknown> | null)?.id as string | undefined)
         .filter(Boolean) as string[]
 
       // Get member counts in a single query
@@ -111,15 +113,16 @@ export function useWorkspaces(orgId: string | null) {
       }
 
       // Transform to WorkspaceWithMeta format
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return orgWorkspaces.map((m: any) => ({
-        ...m.workspace,
-        member_count: memberCounts[m.workspace.id] || 0,
-        user_role: m.role as WorkspaceRole,
-        // Legacy fields for backward compatibility
-        organization_id: m.workspace.organization_id,
-        workspace_type: m.workspace.workspace_type,
-      })) as WorkspaceWithMeta[]
+      return orgWorkspaces.map((m) => {
+        const ws = m.workspace as Record<string, unknown>
+        return {
+          ...ws,
+          member_count: memberCounts[ws.id as string] || 0,
+          user_role: m.role as WorkspaceRole,
+          organization_id: ws.organization_id,
+          workspace_type: ws.workspace_type,
+        }
+      }) as WorkspaceWithMeta[]
     },
     enabled: !!user && !!orgId,
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -259,22 +262,23 @@ export function useWorkspaceDetail(workspaceId: string | null) {
       if (queryError) throw queryError
 
       // Transform to WorkspaceRecording format
-       
+      type EntryWithRecording = (typeof entries)[number]
       return (entries || [])
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .filter((e: any) => e.recording)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map((e: any) => ({
-          ...e.recording,
-          organization_id: e.recording.organization_id,
-          workspace_entry: {
-            id: e.id,
-            local_tags: e.local_tags,
-            scores: e.scores,
-            notes: e.notes,
-            folder_id: e.folder_id,
-          },
-        })) as WorkspaceRecording[]
+        .filter((e: EntryWithRecording) => e.recording)
+        .map((e: EntryWithRecording) => {
+          const rec = e.recording as Record<string, unknown>
+          return {
+            ...rec,
+            organization_id: rec.organization_id,
+            workspace_entry: {
+              id: e.id,
+              local_tags: e.local_tags,
+              scores: e.scores,
+              notes: e.notes,
+              folder_id: e.folder_id,
+            },
+          }
+        }) as WorkspaceRecording[]
     },
     enabled: !!user && !!workspaceId,
     staleTime: 5 * 60 * 1000,
@@ -304,8 +308,7 @@ export function useWorkspaceMembers(workspaceId: string | null) {
       if (!user || !workspaceId) return []
 
       // Fetch memberships for this workspace
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: memberships, error: memberError } = await (supabase as any)
+      const { data: memberships, error: memberError } = await supabase
         .from('workspace_memberships')
         .select('id, user_id, role, created_at')
         .eq('workspace_id', workspaceId)
@@ -314,12 +317,10 @@ export function useWorkspaceMembers(workspaceId: string | null) {
       if (!memberships || memberships.length === 0) return []
 
       // Fetch user profiles for each member
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const userIds = memberships.map((m: any) => m.user_id) as string[]
+      const userIds = memberships.map((m) => m.user_id)
 
       // Use user_profiles table if available, otherwise fall back to auth metadata
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: profiles, error: profileError } = await (supabase as any)
+      const { data: profiles, error: profileError } = await supabase
         .from('user_profiles')
         .select('id, email, display_name, avatar_url')
         .in('id', userIds)
@@ -327,8 +328,7 @@ export function useWorkspaceMembers(workspaceId: string | null) {
       // Build profile lookup
       const profileMap = new Map<string, { email: string | null; display_name: string | null; avatar_url: string | null }>()
       if (!profileError && profiles) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        for (const p of profiles as any[]) {
+        for (const p of profiles) {
           profileMap.set(p.id, {
             email: p.email || null,
             display_name: p.display_name || null,
@@ -338,8 +338,7 @@ export function useWorkspaceMembers(workspaceId: string | null) {
       }
 
       // Transform and sort by role hierarchy
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const members: WorkspaceMember[] = memberships.map((m: any) => {
+      const members: WorkspaceMember[] = memberships.map((m) => {
         const profile = profileMap.get(m.user_id)
         return {
           id: m.id,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -573,7 +573,7 @@ export type Database = {
             foreignKeyName: "call_speakers_recording_user_fkey"
             columns: ["call_recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
           {
@@ -632,7 +632,7 @@ export type Database = {
             foreignKeyName: "call_tag_assignments_recording_user_fkey"
             columns: ["call_recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -947,7 +947,7 @@ export type Database = {
             foreignKeyName: "contact_call_appearances_recording_id_user_id_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -1504,13 +1504,14 @@ export type Database = {
           },
         ]
       }
-      fathom_calls_archive: {
+      fathom_raw_calls: {
         Row: {
           ai_generated_title: string | null
           ai_title_generated_at: string | null
           auto_tags: string[] | null
           auto_tags_generated_at: string | null
           calendar_invitees: Json | null
+          canonical_recording_id: string | null
           created_at: string
           full_transcript: string | null
           fuzzy_match_score: number | null
@@ -1543,6 +1544,7 @@ export type Database = {
           auto_tags?: string[] | null
           auto_tags_generated_at?: string | null
           calendar_invitees?: Json | null
+          canonical_recording_id?: string | null
           created_at: string
           full_transcript?: string | null
           fuzzy_match_score?: number | null
@@ -1575,6 +1577,7 @@ export type Database = {
           auto_tags?: string[] | null
           auto_tags_generated_at?: string | null
           calendar_invitees?: Json | null
+          canonical_recording_id?: string | null
           created_at?: string
           full_transcript?: string | null
           fuzzy_match_score?: number | null
@@ -1601,9 +1604,17 @@ export type Database = {
           url?: string | null
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "fathom_raw_calls_canonical_recording_id_fkey"
+            columns: ["canonical_recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
       }
-      fathom_transcripts: {
+      fathom_raw_transcripts: {
         Row: {
           created_at: string | null
           edited_at: string | null
@@ -1664,10 +1675,37 @@ export type Database = {
             foreignKeyName: "fathom_transcripts_recording_user_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
+      }
+      feature_flags: {
+        Row: {
+          description: string | null
+          enabled_for_roles: string[] | null
+          id: string
+          is_enabled: boolean
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          description?: string | null
+          enabled_for_roles?: string[] | null
+          id: string
+          is_enabled?: boolean
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          description?: string | null
+          enabled_for_roles?: string[] | null
+          id?: string
+          is_enabled?: boolean
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
       }
       folder_assignments: {
         Row: {
@@ -1706,7 +1744,7 @@ export type Database = {
             foreignKeyName: "folder_assignments_call_recording_id_user_id_fkey"
             columns: ["call_recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
           {
@@ -1849,7 +1887,7 @@ export type Database = {
             foreignKeyName: "hooks_fathom_call_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -2111,7 +2149,7 @@ export type Database = {
             foreignKeyName: "insights_fathom_call_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -2273,6 +2311,7 @@ export type Database = {
           recording_end_time: string | null
           recording_start_time: string | null
           source_app: string | null
+          source_call_id: string | null
           source_metadata: Json | null
           summary: string | null
           synced_at: string | null
@@ -2293,6 +2332,7 @@ export type Database = {
           recording_end_time?: string | null
           recording_start_time?: string | null
           source_app?: string | null
+          source_call_id?: string | null
           source_metadata?: Json | null
           summary?: string | null
           synced_at?: string | null
@@ -2313,6 +2353,7 @@ export type Database = {
           recording_end_time?: string | null
           recording_start_time?: string | null
           source_app?: string | null
+          source_call_id?: string | null
           source_metadata?: Json | null
           summary?: string | null
           synced_at?: string | null
@@ -2745,6 +2786,7 @@ export type Database = {
           call_category: string | null
           call_date: string | null
           call_title: string | null
+          canonical_recording_id: string | null
           chunk_index: number
           chunk_text: string
           created_at: string | null
@@ -2771,6 +2813,7 @@ export type Database = {
           call_category?: string | null
           call_date?: string | null
           call_title?: string | null
+          canonical_recording_id?: string | null
           chunk_index: number
           chunk_text: string
           created_at?: string | null
@@ -2797,6 +2840,7 @@ export type Database = {
           call_category?: string | null
           call_date?: string | null
           call_title?: string | null
+          canonical_recording_id?: string | null
           chunk_index?: number
           chunk_text?: string
           created_at?: string | null
@@ -2821,6 +2865,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "transcript_chunks_canonical_recording_id_fkey"
+            columns: ["canonical_recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "transcript_chunks_recording_user_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
@@ -2831,7 +2882,7 @@ export type Database = {
             foreignKeyName: "transcript_chunks_recording_user_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -2870,7 +2921,7 @@ export type Database = {
             foreignKeyName: "transcript_tag_assignments_recording_user_fkey"
             columns: ["call_recording_id", "user_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls_archive"
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
           {
@@ -2908,6 +2959,112 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      trial_purchases: {
+        Row: {
+          amount: number | null
+          created_at: string | null
+          crm_contact_id: string | null
+          currency: string | null
+          email: string | null
+          id: string
+          name: string | null
+          source: string | null
+          status: string | null
+          stripe_customer_id: string | null
+          stripe_payment_intent: string | null
+          stripe_session_id: string | null
+        }
+        Insert: {
+          amount?: number | null
+          created_at?: string | null
+          crm_contact_id?: string | null
+          currency?: string | null
+          email?: string | null
+          id?: string
+          name?: string | null
+          source?: string | null
+          status?: string | null
+          stripe_customer_id?: string | null
+          stripe_payment_intent?: string | null
+          stripe_session_id?: string | null
+        }
+        Update: {
+          amount?: number | null
+          created_at?: string | null
+          crm_contact_id?: string | null
+          currency?: string | null
+          email?: string | null
+          id?: string
+          name?: string | null
+          source?: string | null
+          status?: string | null
+          stripe_customer_id?: string | null
+          stripe_payment_intent?: string | null
+          stripe_session_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trial_purchases_crm_contact_id_fkey"
+            columns: ["crm_contact_id"]
+            isOneToOne: false
+            referencedRelation: "crm_contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      upload_raw_files: {
+        Row: {
+          created_at: string
+          file_size: number | null
+          full_transcript: string | null
+          id: string
+          mime_type: string | null
+          original_filename: string
+          raw_payload: Json | null
+          recording_id: string | null
+          storage_path: string | null
+          transcription_language: string | null
+          user_id: string
+          whisper_model: string | null
+        }
+        Insert: {
+          created_at?: string
+          file_size?: number | null
+          full_transcript?: string | null
+          id?: string
+          mime_type?: string | null
+          original_filename: string
+          raw_payload?: Json | null
+          recording_id?: string | null
+          storage_path?: string | null
+          transcription_language?: string | null
+          user_id: string
+          whisper_model?: string | null
+        }
+        Update: {
+          created_at?: string
+          file_size?: number | null
+          full_transcript?: string | null
+          id?: string
+          mime_type?: string | null
+          original_filename?: string
+          raw_payload?: Json | null
+          recording_id?: string | null
+          storage_path?: string | null
+          transcription_language?: string | null
+          user_id?: string
+          whisper_model?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "upload_raw_files_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_contact_settings: {
         Row: {
@@ -3428,6 +3585,175 @@ export type Database = {
           },
         ]
       }
+      youtube_raw_calls: {
+        Row: {
+          created_at: string
+          full_transcript: string | null
+          id: string
+          import_source: string | null
+          raw_payload: Json | null
+          recording_id: string | null
+          user_id: string
+          youtube_category_id: string | null
+          youtube_channel_id: string | null
+          youtube_channel_title: string | null
+          youtube_comment_count: number | null
+          youtube_description: string | null
+          youtube_duration: string | null
+          youtube_like_count: number | null
+          youtube_published_at: string | null
+          youtube_subscriber_count: number | null
+          youtube_thumbnail: string | null
+          youtube_video_id: string
+          youtube_view_count: number | null
+        }
+        Insert: {
+          created_at?: string
+          full_transcript?: string | null
+          id?: string
+          import_source?: string | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          user_id: string
+          youtube_category_id?: string | null
+          youtube_channel_id?: string | null
+          youtube_channel_title?: string | null
+          youtube_comment_count?: number | null
+          youtube_description?: string | null
+          youtube_duration?: string | null
+          youtube_like_count?: number | null
+          youtube_published_at?: string | null
+          youtube_subscriber_count?: number | null
+          youtube_thumbnail?: string | null
+          youtube_video_id: string
+          youtube_view_count?: number | null
+        }
+        Update: {
+          created_at?: string
+          full_transcript?: string | null
+          id?: string
+          import_source?: string | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          user_id?: string
+          youtube_category_id?: string | null
+          youtube_channel_id?: string | null
+          youtube_channel_title?: string | null
+          youtube_comment_count?: number | null
+          youtube_description?: string | null
+          youtube_duration?: string | null
+          youtube_like_count?: number | null
+          youtube_published_at?: string | null
+          youtube_subscriber_count?: number | null
+          youtube_thumbnail?: string | null
+          youtube_video_id?: string
+          youtube_view_count?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "youtube_raw_calls_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      zoom_raw_calls: {
+        Row: {
+          account_id: string | null
+          created_at: string
+          duration: number | null
+          full_transcript: string | null
+          fuzzy_match_score: number | null
+          host_email: string | null
+          host_id: string | null
+          id: string
+          is_primary: boolean | null
+          meeting_fingerprint: string | null
+          meeting_type: number | null
+          merged_from: number[] | null
+          participants: Json | null
+          raw_payload: Json | null
+          recording_id: string | null
+          recording_url: string | null
+          share_url: string | null
+          start_time: string | null
+          synced_at: string | null
+          timezone: string | null
+          topic: string | null
+          transcript_url: string | null
+          user_id: string
+          zoom_meeting_id: string | null
+          zoom_meeting_uuid: string | null
+          zoom_numeric_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          created_at?: string
+          duration?: number | null
+          full_transcript?: string | null
+          fuzzy_match_score?: number | null
+          host_email?: string | null
+          host_id?: string | null
+          id?: string
+          is_primary?: boolean | null
+          meeting_fingerprint?: string | null
+          meeting_type?: number | null
+          merged_from?: number[] | null
+          participants?: Json | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          recording_url?: string | null
+          share_url?: string | null
+          start_time?: string | null
+          synced_at?: string | null
+          timezone?: string | null
+          topic?: string | null
+          transcript_url?: string | null
+          user_id: string
+          zoom_meeting_id?: string | null
+          zoom_meeting_uuid?: string | null
+          zoom_numeric_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          created_at?: string
+          duration?: number | null
+          full_transcript?: string | null
+          fuzzy_match_score?: number | null
+          host_email?: string | null
+          host_id?: string | null
+          id?: string
+          is_primary?: boolean | null
+          meeting_fingerprint?: string | null
+          meeting_type?: number | null
+          merged_from?: number[] | null
+          participants?: Json | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          recording_url?: string | null
+          share_url?: string | null
+          start_time?: string | null
+          synced_at?: string | null
+          timezone?: string | null
+          topic?: string | null
+          transcript_url?: string | null
+          user_id?: string
+          zoom_meeting_id?: string | null
+          zoom_meeting_uuid?: string | null
+          zoom_numeric_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "zoom_raw_calls_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       fathom_calls: {
@@ -3528,6 +3854,72 @@ export type Database = {
           user_id?: string | null
         }
         Relationships: []
+      }
+      fathom_transcripts: {
+        Row: {
+          created_at: string | null
+          edited_at: string | null
+          edited_by: string | null
+          edited_speaker_email: string | null
+          edited_speaker_name: string | null
+          edited_text: string | null
+          id: string | null
+          is_deleted: boolean | null
+          recording_id: number | null
+          speaker_email: string | null
+          speaker_name: string | null
+          text: string | null
+          timestamp: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          edited_at?: string | null
+          edited_by?: string | null
+          edited_speaker_email?: string | null
+          edited_speaker_name?: string | null
+          edited_text?: string | null
+          id?: string | null
+          is_deleted?: boolean | null
+          recording_id?: number | null
+          speaker_email?: string | null
+          speaker_name?: string | null
+          text?: string | null
+          timestamp?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          edited_at?: string | null
+          edited_by?: string | null
+          edited_speaker_email?: string | null
+          edited_speaker_name?: string | null
+          edited_text?: string | null
+          id?: string | null
+          is_deleted?: boolean | null
+          recording_id?: number | null
+          speaker_email?: string | null
+          speaker_name?: string | null
+          text?: string | null
+          timestamp?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fathom_transcripts_recording_user_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
+            foreignKeyName: "fathom_transcripts_recording_user_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+        ]
       }
       recurring_call_titles: {
         Row: {
@@ -3759,6 +4151,10 @@ export type Database = {
           role: string
           workspace_name: string
         }[]
+      }
+      get_workspace_organization_id: {
+        Args: { p_workspace_id: string }
+        Returns: string
       }
       has_role: {
         Args: {
@@ -4044,3 +4440,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/src/pages/SharedWithMe.tsx
+++ b/src/pages/SharedWithMe.tsx
@@ -125,8 +125,7 @@ function useSharedWithMe(options: UseSharedWithMeOptions) {
     queryKey: queryKeys.sharing.sharedWithMe(),
     queryFn: async () => {
       // Preferred path: RPC backed by SECURITY DEFINER function
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rpcResult = await (supabase as any).rpc("get_calls_shared_with_me_v2", {
+      const rpcResult = await supabase.rpc("get_calls_shared_with_me_v2", {
         p_include_expired: false,
       });
 

--- a/src/pages/WorkspaceJoin.tsx
+++ b/src/pages/WorkspaceJoin.tsx
@@ -49,7 +49,7 @@ export default function WorkspaceJoin() {
 
       try {
         // 1. Try email-based invitation first (via RPC)
-        const { data: inviteDetails, error: rpcError } = await (supabase as any).rpc('get_workspace_invite_details', {
+        const { data: inviteDetails, error: rpcError } = await supabase.rpc('get_workspace_invite_details', {
           p_token: token,
         })
 
@@ -72,7 +72,7 @@ export default function WorkspaceJoin() {
 
         // 2. Fallback to shareable link (stored on workspaces table)
         const { data: workspace, error: workspaceError } = await supabase
-          .from('workspaces' as any)
+          .from('workspaces')
           .select(`
             id, 
             name, 
@@ -129,7 +129,7 @@ export default function WorkspaceJoin() {
     try {
       if (inviteData.is_email_invite) {
         // Use RPC to accept email-based invite
-        const { data, error } = await (supabase as any).rpc('accept_workspace_invite', {
+        const { data, error } = await supabase.rpc('accept_workspace_invite', {
           p_token: token,
           p_user_id: user.id
         })
@@ -137,7 +137,7 @@ export default function WorkspaceJoin() {
         if (error || (data && data.error)) throw new Error(error?.message || data?.error)
       } else {
         // Directly insert for shareable links
-        const { error: joinError } = await (supabase as any)
+        const { error: joinError } = await supabase
           .from('workspace_memberships')
           .insert({
             workspace_id: inviteData.workspace_id,

--- a/src/services/data-movement.service.ts
+++ b/src/services/data-movement.service.ts
@@ -30,7 +30,7 @@ export async function moveRecordingsToWorkspace(
     recording_id: id,
   }))
 
-  const { error: insertError } = await (supabase as any)
+  const { error: insertError } = await supabase
     .from('workspace_entries')
     .upsert(entries, { onConflict: 'workspace_id,recording_id' })
 
@@ -38,7 +38,7 @@ export async function moveRecordingsToWorkspace(
 
   // 2. Remove from source workspace if requested and not the same as target
   if (!keepInSource && sourceWorkspaceId && sourceWorkspaceId !== targetWorkspaceId) {
-    const { error: deleteError } = await (supabase as any)
+    const { error: deleteError } = await supabase
       .from('workspace_entries')
       .delete()
       .eq('workspace_id', sourceWorkspaceId)
@@ -65,6 +65,7 @@ export async function copyRecordingsToOrganization(
   const { removeSource = false } = options
 
   // For now, we'll use an RPC for this complex operation
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (supabase as any).rpc('copy_recordings_to_organization', {
     p_recording_ids: recordingIds,
     p_target_organization_id: targetOrgId,

--- a/src/services/folders.service.ts
+++ b/src/services/folders.service.ts
@@ -6,10 +6,6 @@ import type { Folder } from '@/types/workspace'
  *
  * All queries use supabase.from('folders') scoped by workspaceId.
  *
- * IMPORTANT: folders table has columns added in Phase 16 migration that are
- * not yet in generated supabase.ts types (is_archived, archived_at). We use
- * the Folder interface from @/types/workspace and cast to `any` where needed.
- *
  * NOTE: The DB uses `parent_id` (not `parent_folder_id`) — this is the actual
  * FK column on the folders table.
  *
@@ -30,8 +26,7 @@ export async function getFolders(
   workspaceId: string,
   includeArchived = false
 ): Promise<Folder[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let query = (supabase as any)
+  let query = supabase
     .from('folders')
     .select(
       'id, name, user_id, organization_id, workspace_id, parent_id, description, color, icon, visibility, position, is_archived, archived_at, created_at, updated_at'
@@ -51,8 +46,7 @@ export async function getFolders(
   }
 
   // Map parent_id to parent_folder_id for Folder interface compatibility
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (data ?? []).map((row: any) => ({
+  return (data ?? []).map((row) => ({
     id: row.id,
     name: row.name,
     user_id: row.user_id,
@@ -77,8 +71,7 @@ export async function getFolders(
  * Ordered by archived_at DESC (most recently archived first).
  */
 export async function getArchivedFolders(workspaceId: string): Promise<Folder[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any)
+  const { data, error } = await supabase
     .from('folders')
     .select(
       'id, name, user_id, organization_id, workspace_id, parent_id, description, color, icon, visibility, position, is_archived, archived_at, created_at, updated_at'
@@ -91,8 +84,7 @@ export async function getArchivedFolders(workspaceId: string): Promise<Folder[]>
     throw new Error(`Failed to fetch archived folders: ${error.message}`)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (data ?? []).map((row: any) => ({
+  return (data ?? []).map((row) => ({
     id: row.id,
     name: row.name,
     user_id: row.user_id,
@@ -126,7 +118,7 @@ export async function getFolderAssignments({
   if (!workspaceId && !organizationId) return {}
 
   // 1. Get all folder IDs for this scope
-  let folderQuery = (supabase as any)
+  let folderQuery = supabase
     .from('folders')
     .select('id')
     
@@ -138,7 +130,7 @@ export async function getFolderAssignments({
 
   const { data: folderIdsData } = await folderQuery
 
-  const folderIds = (folderIdsData ?? []).map((f: any) => f.id)
+  const folderIds = (folderIdsData ?? []).map((f) => f.id)
 
   if (folderIds.length === 0) return {}
 
@@ -187,8 +179,7 @@ export async function createFolder(
 ): Promise<Folder> {
   // Enforce depth limit: if a parent is provided, verify it has no parent
   if (parentFolderId) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: parent, error: parentError } = await (supabase as any)
+    const { data: parent, error: parentError } = await supabase
       .from('folders')
       .select('id, parent_id')
       .eq('id', parentFolderId)
@@ -208,8 +199,7 @@ export async function createFolder(
   }
 
   // Calculate next position for siblings
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let positionQuery = (supabase as any)
+  let positionQuery = supabase
     .from('folders')
     .select('position')
     .eq('workspace_id', workspaceId)
@@ -240,8 +230,7 @@ export async function createFolder(
     insertPayload.parent_id = parentFolderId
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any)
+  const { data, error } = await supabase
     .from('folders')
     .insert(insertPayload)
     .select(
@@ -275,8 +264,7 @@ export async function updateFolder(
   folderId: string,
   updates: Partial<Pick<Folder, 'name' | 'description' | 'color' | 'icon' | 'visibility' | 'parent_id' | 'position'>>
 ): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase as any)
+  const { error } = await supabase
     .from('folders')
     .update(updates)
     .eq('id', folderId)
@@ -301,8 +289,7 @@ export async function renameFolder(folderId: string, name: string): Promise<void
  * from main sidebar view. Can be fully restored."
  */
 export async function archiveFolder(folderId: string): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase as any)
+  const { error } = await supabase
     .from('folders')
     .update({ is_archived: true, archived_at: new Date().toISOString() })
     .eq('id', folderId)
@@ -317,8 +304,7 @@ export async function archiveFolder(folderId: string): Promise<void> {
  * Sets is_archived = false and archived_at = null.
  */
 export async function restoreFolder(folderId: string): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase as any)
+  const { error } = await supabase
     .from('folders')
     .update({ is_archived: false, archived_at: null })
     .eq('id', folderId)
@@ -402,7 +388,7 @@ export async function assignCallToFolder(
     .maybeSingle()
 
   if (rec && workspaceId) {
-    const { error: entryError } = await (supabase as any)
+    const { error: entryError } = await supabase
       .from('workspace_entries')
       .update({ folder_id: folderId })
       .eq('recording_id', rec.id)
@@ -482,7 +468,7 @@ export async function moveCallToFolder(
     .maybeSingle()
 
   if (rec && workspaceId) {
-    const { error: entryError } = await (supabase as any)
+    const { error: entryError } = await supabase
       .from('workspace_entries')
       .update({ folder_id: toFolderId })
       .eq('recording_id', rec.id)

--- a/src/services/invitations.service.ts
+++ b/src/services/invitations.service.ts
@@ -8,10 +8,6 @@
  * (no Resend, no Mailgun) as of Phase 16. Creating an invitation generates
  * the DB record and produces a shareable link. Email delivery is deferred
  * to Phase 17+ or via Supabase webhooks.
- *
- * All queries use supabase.from('workspace_invitations') — this table was
- * created in the Phase 16-01 migration and is not yet in the generated
- * supabase.ts types, so we cast via `as any` where needed.
  */
 
 import { supabase } from '@/integrations/supabase/client'
@@ -22,8 +18,7 @@ import type { WorkspaceInvitation, WorkspaceInviteDetails } from '@/types/worksp
  * Returns invitations with status = 'pending' (not accepted, revoked, or expired).
  */
 export async function getInvitations(workspaceId: string): Promise<WorkspaceInvitation[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any)
+  const { data, error } = await supabase
     .from('workspace_invitations')
     .select('id, workspace_id, invited_by, email, role, token, status, expires_at, created_at, accepted_at')
     .eq('workspace_id', workspaceId)
@@ -48,8 +43,7 @@ export async function createInvitation(
   email: string,
   role: WorkspaceInvitation['role']
 ): Promise<WorkspaceInvitation> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any)
+  const { data, error } = await supabase
     .from('workspace_invitations')
     .insert({
       workspace_id: workspaceId,
@@ -72,8 +66,7 @@ export async function createInvitation(
  * Revoked invitations cannot be accepted.
  */
 export async function revokeInvitation(invitationId: string): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase as any)
+  const { error } = await supabase
     .from('workspace_invitations')
     .update({ status: 'revoked' })
     .eq('id', invitationId)
@@ -91,8 +84,7 @@ export async function resendInvitation(invitationId: string): Promise<void> {
   const newExpiry = new Date()
   newExpiry.setDate(newExpiry.getDate() + 7)
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase as any)
+  const { error } = await supabase
     .from('workspace_invitations')
     .update({ expires_at: newExpiry.toISOString() })
     .eq('id', invitationId)
@@ -108,8 +100,7 @@ export async function resendInvitation(invitationId: string): Promise<void> {
  * Returns workspace name, org name, inviter name, role, and expiry.
  */
 export async function getInviteDetails(token: string): Promise<WorkspaceInviteDetails> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any).rpc('get_workspace_invite_details', { p_token: token })
+  const { data, error } = await supabase.rpc('get_workspace_invite_details', { p_token: token })
 
   if (error) {
     throw new Error(`Failed to get invite details: ${error.message}`)
@@ -119,7 +110,7 @@ export async function getInviteDetails(token: string): Promise<WorkspaceInviteDe
     throw new Error('Invitation not found or has expired')
   }
 
-  // RPC may return an array (single row) or a single object depending on definition
+  // RPC returns an array; take the first row
   const result = Array.isArray(data) ? data[0] : data
 
   if (!result) {
@@ -135,8 +126,7 @@ export async function getInviteDetails(token: string): Promise<WorkspaceInviteDe
  * The invitation status is updated to 'accepted'.
  */
 export async function acceptInvite(token: string, userId: string): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase as any).rpc('accept_workspace_invite', {
+  const { error } = await supabase.rpc('accept_workspace_invite', {
     p_token: token,
     p_user_id: userId,
   })

--- a/src/services/recordings.service.ts
+++ b/src/services/recordings.service.ts
@@ -51,8 +51,7 @@ export async function getRecordings(): Promise<RecordingListItem[]> {
  */
 export async function getRecordingsByWorkspace(workspaceId: string): Promise<RecordingListItem[]> {
   // Step 1: Get recording IDs from workspace_entries
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: entries, error: entriesError } = await (supabase as any)
+  const { data: entries, error: entriesError } = await supabase
     .from('workspace_entries')
     .select('recording_id')
     .eq('workspace_id', workspaceId)

--- a/src/services/workspaces.service.ts
+++ b/src/services/workspaces.service.ts
@@ -3,6 +3,7 @@ import type { Database } from '@/types/supabase'
 import type { Workspace } from '@/types/workspace'
 
 type WorkspaceMembershipRow = Database['public']['Tables']['workspace_memberships']['Row']
+type WorkspaceInsert = Database['public']['Tables']['workspaces']['Insert']
 
 /**
  * Workspace member with profile information for UI display.
@@ -29,7 +30,7 @@ export async function getWorkspaces(orgId: string): Promise<Workspace[]> {
   const { data, error } = await supabase
     .from('workspaces')
     .select(
-      'id, name, organization_id:organization_id, workspace_type:workspace_type, default_sharelink_ttl_days, created_at, updated_at'
+      'id, name, organization_id, workspace_type, default_sharelink_ttl_days, is_default, created_at, updated_at'
     )
     .eq('organization_id', orgId)
     .order('name', { ascending: true })
@@ -38,10 +39,8 @@ export async function getWorkspaces(orgId: string): Promise<Workspace[]> {
     throw new Error(`Failed to fetch workspaces: ${error.message}`)
   }
 
-  // Sort client-side: is_default first (not in generated types yet), then by name
-  // is_default column added via Phase 16 migration; cast to any for access
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const workspaces = (data ?? []) as any[]
+  // Sort client-side: is_default first, then by name
+  const workspaces = data ?? []
   workspaces.sort((a, b) => {
     if (a.is_default && !b.is_default) return -1
     if (!a.is_default && b.is_default) return 1
@@ -83,18 +82,16 @@ export async function createWorkspace(
   isDefault = false
 ): Promise<Workspace> {
   // 1. Insert the workspace (DB uses organization_id and workspace_type)
-  const insertPayload: Record<string, unknown> = {
+  const insertPayload: WorkspaceInsert = {
     organization_id: orgId,
     name,
     workspace_type: 'team', // default to team for business orgs
-  }
-  if (isDefault) {
-    insertPayload.is_default = true
+    ...(isDefault ? { is_default: true } : {}),
   }
 
   const { data: workspace, error: workspaceError } = await supabase
     .from('workspaces')
-    .insert(insertPayload as any)
+    .insert(insertPayload)
     .select(
       'id, name, organization_id:organization_id, workspace_type:workspace_type, default_sharelink_ttl_days, created_at, updated_at'
     )
@@ -141,8 +138,7 @@ export async function getWorkspaceMembers(workspaceId: string): Promise<Workspac
   }
 
   // Map to WorkspaceMember shape
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (data ?? []).map((row: any) => ({
+  return (data ?? []).map((row) => ({
     id: row.id,
     userId: row.user_id,
     workspaceId: row.workspace_id,
@@ -190,4 +186,3 @@ export async function removeMember(workspaceId: string, userId: string): Promise
 
 // Re-export type so consumers don't need a separate import
 export type { WorkspaceMembershipRow }
-export type WorkspaceMembershipRow = WorkspaceMembershipRow // Legacy alias

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -12,33 +12,61 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "13.0.5"
   }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
+      agents: {
+        Row: {
+          context_window_max: number | null
+          context_window_used: number | null
+          created_at: string | null
+          fallback_models: Json | null
+          gateway_url: string | null
+          id: string
+          last_active_at: string | null
+          name: string
+          primary_model: string | null
+          role: string | null
+          status: string | null
+          tenant_id: string | null
+        }
+        Insert: {
+          context_window_max?: number | null
+          context_window_used?: number | null
+          created_at?: string | null
+          fallback_models?: Json | null
+          gateway_url?: string | null
+          id?: string
+          last_active_at?: string | null
+          name: string
+          primary_model?: string | null
+          role?: string | null
+          status?: string | null
+          tenant_id?: string | null
+        }
+        Update: {
+          context_window_max?: number | null
+          context_window_used?: number | null
+          created_at?: string | null
+          fallback_models?: Json | null
+          gateway_url?: string | null
+          id?: string
+          last_active_at?: string | null
+          name?: string
+          primary_model?: string | null
+          role?: string | null
+          status?: string | null
+          tenant_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "agents_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ai_models: {
         Row: {
           context_length: number | null
@@ -343,65 +371,6 @@ export type Database = {
         }
         Relationships: []
       }
-      bank_memberships: {
-        Row: {
-          bank_id: string
-          created_at: string
-          id: string
-          role: string
-          user_id: string
-        }
-        Insert: {
-          bank_id: string
-          created_at?: string
-          id?: string
-          role: string
-          user_id: string
-        }
-        Update: {
-          bank_id?: string
-          created_at?: string
-          id?: string
-          role?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "bank_memberships_bank_id_fkey"
-            columns: ["bank_id"]
-            isOneToOne: false
-            referencedRelation: "banks"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      banks: {
-        Row: {
-          created_at: string
-          cross_org_default: string | null
-          id: string
-          name: string
-          type: string
-          updated_at: string
-        }
-        Insert: {
-          created_at?: string
-          cross_org_default?: string | null
-          id?: string
-          name: string
-          type: string
-          updated_at?: string
-        }
-        Update: {
-          created_at?: string
-          cross_org_default?: string | null
-          id?: string
-          name?: string
-          type?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
       business_profiles: {
         Row: {
           average_order_value: number | null
@@ -531,6 +500,45 @@ export type Database = {
         }
         Relationships: []
       }
+      call_share_links: {
+        Row: {
+          call_recording_id: number
+          created_at: string
+          created_by_user_id: string | null
+          expires_at: string | null
+          id: string
+          recipient_email: string | null
+          revoked_at: string | null
+          share_token: string | null
+          status: string
+          user_id: string
+        }
+        Insert: {
+          call_recording_id: number
+          created_at?: string
+          created_by_user_id?: string | null
+          expires_at?: string | null
+          id?: string
+          recipient_email?: string | null
+          revoked_at?: string | null
+          share_token?: string | null
+          status?: string
+          user_id: string
+        }
+        Update: {
+          call_recording_id?: number
+          created_at?: string
+          created_by_user_id?: string | null
+          expires_at?: string | null
+          id?: string
+          recipient_email?: string | null
+          revoked_at?: string | null
+          share_token?: string | null
+          status?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       call_speakers: {
         Row: {
           call_recording_id: number
@@ -559,6 +567,13 @@ export type Database = {
             columns: ["call_recording_id", "user_id"]
             isOneToOne: false
             referencedRelation: "fathom_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
+            foreignKeyName: "call_speakers_recording_user_fkey"
+            columns: ["call_recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
           {
@@ -613,6 +628,13 @@ export type Database = {
             referencedRelation: "fathom_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
+          {
+            foreignKeyName: "call_tag_assignments_recording_user_fkey"
+            columns: ["call_recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
         ]
       }
       call_tags: {
@@ -624,6 +646,7 @@ export type Database = {
           id: string
           is_system: boolean | null
           name: string
+          organization_id: string
           updated_at: string | null
           user_id: string | null
         }
@@ -635,6 +658,7 @@ export type Database = {
           id?: string
           is_system?: boolean | null
           name: string
+          organization_id: string
           updated_at?: string | null
           user_id?: string | null
         }
@@ -646,10 +670,19 @@ export type Database = {
           id?: string
           is_system?: boolean | null
           name?: string
+          organization_id?: string
           updated_at?: string | null
           user_id?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "call_tags_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       chat_messages: {
         Row: {
@@ -719,6 +752,7 @@ export type Database = {
           is_pinned: boolean | null
           last_message_at: string | null
           message_count: number | null
+          organization_id: string
           title: string | null
           updated_at: string | null
           user_id: string
@@ -737,6 +771,7 @@ export type Database = {
           is_pinned?: boolean | null
           last_message_at?: string | null
           message_count?: number | null
+          organization_id: string
           title?: string | null
           updated_at?: string | null
           user_id: string
@@ -755,11 +790,20 @@ export type Database = {
           is_pinned?: boolean | null
           last_message_at?: string | null
           message_count?: number | null
+          organization_id?: string
           title?: string | null
           updated_at?: string | null
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "chat_sessions_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       chat_tool_calls: {
         Row: {
@@ -824,6 +868,47 @@ export type Database = {
           },
         ]
       }
+      connections: {
+        Row: {
+          account_identifier: string | null
+          composio_connection_id: string | null
+          connected_at: string | null
+          id: string
+          last_used_at: string | null
+          service: string
+          status: string | null
+          tenant_id: string | null
+        }
+        Insert: {
+          account_identifier?: string | null
+          composio_connection_id?: string | null
+          connected_at?: string | null
+          id?: string
+          last_used_at?: string | null
+          service: string
+          status?: string | null
+          tenant_id?: string | null
+        }
+        Update: {
+          account_identifier?: string | null
+          composio_connection_id?: string | null
+          connected_at?: string | null
+          id?: string
+          last_used_at?: string | null
+          service?: string
+          status?: string | null
+          tenant_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "connections_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       contact_call_appearances: {
         Row: {
           appeared_at: string | null
@@ -856,6 +941,13 @@ export type Database = {
             columns: ["recording_id", "user_id"]
             isOneToOne: false
             referencedRelation: "fathom_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
+            foreignKeyName: "contact_call_appearances_recording_id_user_id_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -919,6 +1011,7 @@ export type Database = {
           email_subject: string | null
           hook_id: string | null
           id: string
+          organization_id: string
           status: string | null
           updated_at: string | null
           used_at: string | null
@@ -931,6 +1024,7 @@ export type Database = {
           email_subject?: string | null
           hook_id?: string | null
           id?: string
+          organization_id: string
           status?: string | null
           updated_at?: string | null
           used_at?: string | null
@@ -943,12 +1037,20 @@ export type Database = {
           email_subject?: string | null
           hook_id?: string | null
           id?: string
+          organization_id?: string
           status?: string | null
           updated_at?: string | null
           used_at?: string | null
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "content_items_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "content_items_hook_id_fkey"
             columns: ["hook_id"]
@@ -965,6 +1067,7 @@ export type Database = {
           created_at: string | null
           id: string
           metadata: Json | null
+          organization_id: string
           tags: string[] | null
           team_id: string | null
           title: string
@@ -978,6 +1081,7 @@ export type Database = {
           created_at?: string | null
           id?: string
           metadata?: Json | null
+          organization_id: string
           tags?: string[] | null
           team_id?: string | null
           title: string
@@ -991,6 +1095,7 @@ export type Database = {
           created_at?: string | null
           id?: string
           metadata?: Json | null
+          organization_id?: string
           tags?: string[] | null
           team_id?: string | null
           title?: string
@@ -1000,10 +1105,158 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "content_library_team_id_fkey"
-            columns: ["team_id"]
+            foreignKeyName: "content_library_bank_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: "teams"
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      crm_contacts: {
+        Row: {
+          company: string | null
+          contact_frequency_days: number | null
+          created_at: string | null
+          email: string | null
+          enrichment_data: Json | null
+          enrichment_status: string | null
+          full_name: string | null
+          id: string
+          last_contact_date: string | null
+          notes: string | null
+          phone: string | null
+          relationship_score: number | null
+          source: string | null
+          source_detail: string | null
+          status: string | null
+          tenant_id: string | null
+          title: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          company?: string | null
+          contact_frequency_days?: number | null
+          created_at?: string | null
+          email?: string | null
+          enrichment_data?: Json | null
+          enrichment_status?: string | null
+          full_name?: string | null
+          id?: string
+          last_contact_date?: string | null
+          notes?: string | null
+          phone?: string | null
+          relationship_score?: number | null
+          source?: string | null
+          source_detail?: string | null
+          status?: string | null
+          tenant_id?: string | null
+          title?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          company?: string | null
+          contact_frequency_days?: number | null
+          created_at?: string | null
+          email?: string | null
+          enrichment_data?: Json | null
+          enrichment_status?: string | null
+          full_name?: string | null
+          id?: string
+          last_contact_date?: string | null
+          notes?: string | null
+          phone?: string | null
+          relationship_score?: number | null
+          source?: string | null
+          source_detail?: string | null
+          status?: string | null
+          tenant_id?: string | null
+          title?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "crm_contacts_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      crm_interactions: {
+        Row: {
+          contact_id: string | null
+          created_at: string | null
+          id: string
+          occurred_at: string | null
+          source_id: string | null
+          summary: string | null
+          tenant_id: string | null
+          type: string
+        }
+        Insert: {
+          contact_id?: string | null
+          created_at?: string | null
+          id?: string
+          occurred_at?: string | null
+          source_id?: string | null
+          summary?: string | null
+          tenant_id?: string | null
+          type: string
+        }
+        Update: {
+          contact_id?: string | null
+          created_at?: string | null
+          id?: string
+          occurred_at?: string | null
+          source_id?: string | null
+          summary?: string | null
+          tenant_id?: string | null
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "crm_interactions_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "crm_contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "crm_interactions_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      crm_tags: {
+        Row: {
+          contact_id: string | null
+          created_at: string | null
+          id: string
+          tag: string
+        }
+        Insert: {
+          contact_id?: string | null
+          created_at?: string | null
+          id?: string
+          tag: string
+        }
+        Update: {
+          contact_id?: string | null
+          created_at?: string | null
+          id?: string
+          tag?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "crm_tags_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "crm_contacts"
             referencedColumns: ["id"]
           },
         ]
@@ -1203,13 +1456,62 @@ export type Database = {
           },
         ]
       }
-      fathom_calls: {
+      enrichment_queue: {
+        Row: {
+          contact_id: string | null
+          id: string
+          priority: number | null
+          processed_at: string | null
+          queued_at: string | null
+          result: Json | null
+          status: string | null
+          tenant_id: string | null
+        }
+        Insert: {
+          contact_id?: string | null
+          id?: string
+          priority?: number | null
+          processed_at?: string | null
+          queued_at?: string | null
+          result?: Json | null
+          status?: string | null
+          tenant_id?: string | null
+        }
+        Update: {
+          contact_id?: string | null
+          id?: string
+          priority?: number | null
+          processed_at?: string | null
+          queued_at?: string | null
+          result?: Json | null
+          status?: string | null
+          tenant_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "enrichment_queue_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "crm_contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "enrichment_queue_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fathom_raw_calls: {
         Row: {
           ai_generated_title: string | null
           ai_title_generated_at: string | null
           auto_tags: string[] | null
           auto_tags_generated_at: string | null
           calendar_invitees: Json | null
+          canonical_recording_id: string | null
           created_at: string
           full_transcript: string | null
           fuzzy_match_score: number | null
@@ -1242,6 +1544,7 @@ export type Database = {
           auto_tags?: string[] | null
           auto_tags_generated_at?: string | null
           calendar_invitees?: Json | null
+          canonical_recording_id?: string | null
           created_at: string
           full_transcript?: string | null
           fuzzy_match_score?: number | null
@@ -1274,6 +1577,7 @@ export type Database = {
           auto_tags?: string[] | null
           auto_tags_generated_at?: string | null
           calendar_invitees?: Json | null
+          canonical_recording_id?: string | null
           created_at?: string
           full_transcript?: string | null
           fuzzy_match_score?: number | null
@@ -1300,9 +1604,17 @@ export type Database = {
           url?: string | null
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "fathom_raw_calls_canonical_recording_id_fkey"
+            columns: ["canonical_recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
       }
-      fathom_transcripts: {
+      fathom_raw_transcripts: {
         Row: {
           created_at: string | null
           edited_at: string | null
@@ -1359,7 +1671,41 @@ export type Database = {
             referencedRelation: "fathom_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
+          {
+            foreignKeyName: "fathom_transcripts_recording_user_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
         ]
+      }
+      feature_flags: {
+        Row: {
+          description: string | null
+          enabled_for_roles: string[] | null
+          id: string
+          is_enabled: boolean
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          description?: string | null
+          enabled_for_roles?: string[] | null
+          id: string
+          is_enabled?: boolean
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          description?: string | null
+          enabled_for_roles?: string[] | null
+          id?: string
+          is_enabled?: boolean
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
       }
       folder_assignments: {
         Row: {
@@ -1395,6 +1741,13 @@ export type Database = {
             referencedColumns: ["recording_id", "user_id"]
           },
           {
+            foreignKeyName: "folder_assignments_call_recording_id_user_id_fkey"
+            columns: ["call_recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
             foreignKeyName: "folder_assignments_folder_id_fkey"
             columns: ["folder_id"]
             isOneToOne: false
@@ -1405,47 +1758,76 @@ export type Database = {
       }
       folders: {
         Row: {
+          archived_at: string | null
           color: string | null
           created_at: string | null
           description: string | null
           icon: string | null
           id: string
+          is_archived: boolean
           name: string
+          organization_id: string
           parent_id: string | null
           position: number | null
           updated_at: string | null
           user_id: string
+          visibility: string | null
+          workspace_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           color?: string | null
           created_at?: string | null
           description?: string | null
           icon?: string | null
           id?: string
+          is_archived?: boolean
           name: string
+          organization_id: string
           parent_id?: string | null
           position?: number | null
           updated_at?: string | null
           user_id: string
+          visibility?: string | null
+          workspace_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           color?: string | null
           created_at?: string | null
           description?: string | null
           icon?: string | null
           id?: string
+          is_archived?: boolean
           name?: string
+          organization_id?: string
           parent_id?: string | null
           position?: number | null
           updated_at?: string | null
           user_id?: string
+          visibility?: string | null
+          workspace_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "folders_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "folders_parent_id_fkey"
             columns: ["parent_id"]
             isOneToOne: false
             referencedRelation: "folders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "folders_vault_id_fkey"
+            columns: ["workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
             referencedColumns: ["id"]
           },
         ]
@@ -1501,7 +1883,213 @@ export type Database = {
             referencedRelation: "fathom_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
+          {
+            foreignKeyName: "hooks_fathom_call_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
         ]
+      }
+      human_tasks: {
+        Row: {
+          added_by: string | null
+          completed_at: string | null
+          created_at: string | null
+          due_date: string | null
+          id: string
+          notes: string | null
+          priority: string | null
+          status: string | null
+          tenant_id: string | null
+          title: string
+          updated_at: string | null
+        }
+        Insert: {
+          added_by?: string | null
+          completed_at?: string | null
+          created_at?: string | null
+          due_date?: string | null
+          id?: string
+          notes?: string | null
+          priority?: string | null
+          status?: string | null
+          tenant_id?: string | null
+          title: string
+          updated_at?: string | null
+        }
+        Update: {
+          added_by?: string | null
+          completed_at?: string | null
+          created_at?: string | null
+          due_date?: string | null
+          id?: string
+          notes?: string | null
+          priority?: string | null
+          status?: string | null
+          tenant_id?: string | null
+          title?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "human_tasks_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      import_routing_defaults: {
+        Row: {
+          organization_id: string
+          target_folder_id: string | null
+          target_workspace_id: string
+          updated_at: string
+          updated_by: string
+        }
+        Insert: {
+          organization_id: string
+          target_folder_id?: string | null
+          target_workspace_id: string
+          updated_at?: string
+          updated_by: string
+        }
+        Update: {
+          organization_id?: string
+          target_folder_id?: string | null
+          target_workspace_id?: string
+          updated_at?: string
+          updated_by?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "import_routing_defaults_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: true
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "import_routing_defaults_target_folder_id_fkey"
+            columns: ["target_folder_id"]
+            isOneToOne: false
+            referencedRelation: "folders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "import_routing_defaults_target_vault_id_fkey"
+            columns: ["target_workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      import_routing_rules: {
+        Row: {
+          conditions: Json
+          created_at: string
+          created_by: string
+          enabled: boolean
+          id: string
+          logic_operator: string
+          name: string
+          organization_id: string
+          priority: number
+          target_folder_id: string | null
+          target_workspace_id: string
+          updated_at: string
+        }
+        Insert: {
+          conditions?: Json
+          created_at?: string
+          created_by: string
+          enabled?: boolean
+          id?: string
+          logic_operator?: string
+          name: string
+          organization_id: string
+          priority?: number
+          target_folder_id?: string | null
+          target_workspace_id: string
+          updated_at?: string
+        }
+        Update: {
+          conditions?: Json
+          created_at?: string
+          created_by?: string
+          enabled?: boolean
+          id?: string
+          logic_operator?: string
+          name?: string
+          organization_id?: string
+          priority?: number
+          target_folder_id?: string | null
+          target_workspace_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "import_routing_rules_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "import_routing_rules_target_folder_id_fkey"
+            columns: ["target_folder_id"]
+            isOneToOne: false
+            referencedRelation: "folders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "import_routing_rules_target_vault_id_fkey"
+            columns: ["target_workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      import_sources: {
+        Row: {
+          account_email: string | null
+          created_at: string
+          error_message: string | null
+          id: string
+          is_active: boolean
+          last_sync_at: string | null
+          source_app: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_email?: string | null
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          is_active?: boolean
+          last_sync_at?: string | null
+          source_app: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_email?: string | null
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          is_active?: boolean
+          last_sync_at?: string | null
+          source_app?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
       }
       insights: {
         Row: {
@@ -1557,45 +2145,76 @@ export type Database = {
             referencedRelation: "fathom_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
+          {
+            foreignKeyName: "insights_fathom_call_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
         ]
       }
-      manager_notes: {
+      organization_memberships: {
         Row: {
-          call_recording_id: number
-          created_at: string | null
+          created_at: string
           id: string
-          manager_user_id: string
-          note: string
-          updated_at: string | null
+          organization_id: string
+          role: string
           user_id: string
         }
         Insert: {
-          call_recording_id: number
-          created_at?: string | null
+          created_at?: string
           id?: string
-          manager_user_id: string
-          note: string
-          updated_at?: string | null
+          organization_id: string
+          role: string
           user_id: string
         }
         Update: {
-          call_recording_id?: number
-          created_at?: string | null
+          created_at?: string
           id?: string
-          manager_user_id?: string
-          note?: string
-          updated_at?: string | null
+          organization_id?: string
+          role?: string
           user_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "manager_notes_call_recording_id_user_id_fkey"
-            columns: ["call_recording_id", "user_id"]
+            foreignKeyName: "bank_memberships_bank_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: "fathom_calls"
-            referencedColumns: ["recording_id", "user_id"]
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
         ]
+      }
+      organizations: {
+        Row: {
+          created_at: string
+          cross_org_default: string | null
+          id: string
+          logo_url: string | null
+          name: string
+          type: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          cross_org_default?: string | null
+          id?: string
+          logo_url?: string | null
+          name: string
+          type: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          cross_org_default?: string | null
+          id?: string
+          logo_url?: string | null
+          name?: string
+          type?: string
+          updated_at?: string
+        }
+        Relationships: []
       }
       processed_webhooks: {
         Row: {
@@ -1678,6 +2297,80 @@ export type Database = {
         }
         Relationships: []
       }
+      recordings: {
+        Row: {
+          audio_url: string | null
+          created_at: string
+          duration: number | null
+          full_transcript: string | null
+          global_tags: string[] | null
+          id: string
+          legacy_recording_id: number | null
+          organization_id: string
+          owner_user_id: string
+          recording_end_time: string | null
+          recording_start_time: string | null
+          source_app: string | null
+          source_call_id: string | null
+          source_metadata: Json | null
+          summary: string | null
+          synced_at: string | null
+          title: string
+          updated_at: string
+          video_url: string | null
+        }
+        Insert: {
+          audio_url?: string | null
+          created_at?: string
+          duration?: number | null
+          full_transcript?: string | null
+          global_tags?: string[] | null
+          id?: string
+          legacy_recording_id?: number | null
+          organization_id: string
+          owner_user_id: string
+          recording_end_time?: string | null
+          recording_start_time?: string | null
+          source_app?: string | null
+          source_call_id?: string | null
+          source_metadata?: Json | null
+          summary?: string | null
+          synced_at?: string | null
+          title: string
+          updated_at?: string
+          video_url?: string | null
+        }
+        Update: {
+          audio_url?: string | null
+          created_at?: string
+          duration?: number | null
+          full_transcript?: string | null
+          global_tags?: string[] | null
+          id?: string
+          legacy_recording_id?: number | null
+          organization_id?: string
+          owner_user_id?: string
+          recording_end_time?: string | null
+          recording_start_time?: string | null
+          source_app?: string | null
+          source_call_id?: string | null
+          source_metadata?: Json | null
+          summary?: string | null
+          synced_at?: string | null
+          title?: string
+          updated_at?: string
+          video_url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recordings_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       speakers: {
         Row: {
           created_at: string | null
@@ -1716,6 +2409,7 @@ export type Database = {
           progress_current: number | null
           progress_total: number | null
           recording_ids: number[] | null
+          skipped_count: number | null
           started_at: string | null
           status: string
           synced_ids: number[] | null
@@ -1733,6 +2427,7 @@ export type Database = {
           progress_current?: number | null
           progress_total?: number | null
           recording_ids?: number[] | null
+          skipped_count?: number | null
           started_at?: string | null
           status: string
           synced_ids?: number[] | null
@@ -1750,6 +2445,7 @@ export type Database = {
           progress_current?: number | null
           progress_total?: number | null
           recording_ids?: number[] | null
+          skipped_count?: number | null
           started_at?: string | null
           status?: string
           synced_ids?: number[] | null
@@ -1882,156 +2578,68 @@ export type Database = {
           },
         ]
       }
-      team_memberships: {
+      tasks: {
         Row: {
+          agent_id: string | null
+          completed_at: string | null
           created_at: string | null
+          description: string | null
           id: string
-          invite_expires_at: string | null
-          invite_token: string | null
-          invited_by_user_id: string | null
-          joined_at: string | null
-          manager_membership_id: string | null
-          onboarding_complete: boolean | null
-          role: string | null
+          priority: string | null
+          prompt_quality_score: number | null
           status: string | null
-          team_id: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string | null
-          id?: string
-          invite_expires_at?: string | null
-          invite_token?: string | null
-          invited_by_user_id?: string | null
-          joined_at?: string | null
-          manager_membership_id?: string | null
-          onboarding_complete?: boolean | null
-          role?: string | null
-          status?: string | null
-          team_id: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string | null
-          id?: string
-          invite_expires_at?: string | null
-          invite_token?: string | null
-          invited_by_user_id?: string | null
-          joined_at?: string | null
-          manager_membership_id?: string | null
-          onboarding_complete?: boolean | null
-          role?: string | null
-          status?: string | null
-          team_id?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "team_memberships_manager_membership_id_fkey"
-            columns: ["manager_membership_id"]
-            isOneToOne: false
-            referencedRelation: "team_memberships"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "team_memberships_team_id_fkey"
-            columns: ["team_id"]
-            isOneToOne: false
-            referencedRelation: "teams"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      team_shares: {
-        Row: {
-          created_at: string | null
-          folder_id: string | null
-          id: string
-          owner_user_id: string
-          recipient_user_id: string
-          share_type: string
-          tag_id: string | null
-          team_id: string
-        }
-        Insert: {
-          created_at?: string | null
-          folder_id?: string | null
-          id?: string
-          owner_user_id: string
-          recipient_user_id: string
-          share_type: string
-          tag_id?: string | null
-          team_id: string
-        }
-        Update: {
-          created_at?: string | null
-          folder_id?: string | null
-          id?: string
-          owner_user_id?: string
-          recipient_user_id?: string
-          share_type?: string
-          tag_id?: string | null
-          team_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "team_shares_folder_id_fkey"
-            columns: ["folder_id"]
-            isOneToOne: false
-            referencedRelation: "folders"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "team_shares_tag_id_fkey"
-            columns: ["tag_id"]
-            isOneToOne: false
-            referencedRelation: "call_tags"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "team_shares_team_id_fkey"
-            columns: ["team_id"]
-            isOneToOne: false
-            referencedRelation: "teams"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      teams: {
-        Row: {
-          admin_sees_all: boolean | null
-          created_at: string | null
-          domain_auto_join: string | null
-          id: string
-          invite_expires_at: string | null
-          invite_token: string | null
-          name: string
-          owner_user_id: string
+          tenant_id: string | null
+          title: string
+          token_actual: number | null
+          token_estimate: number | null
           updated_at: string | null
         }
         Insert: {
-          admin_sees_all?: boolean | null
+          agent_id?: string | null
+          completed_at?: string | null
           created_at?: string | null
-          domain_auto_join?: string | null
+          description?: string | null
           id?: string
-          invite_expires_at?: string | null
-          invite_token?: string | null
-          name: string
-          owner_user_id: string
+          priority?: string | null
+          prompt_quality_score?: number | null
+          status?: string | null
+          tenant_id?: string | null
+          title: string
+          token_actual?: number | null
+          token_estimate?: number | null
           updated_at?: string | null
         }
         Update: {
-          admin_sees_all?: boolean | null
+          agent_id?: string | null
+          completed_at?: string | null
           created_at?: string | null
-          domain_auto_join?: string | null
+          description?: string | null
           id?: string
-          invite_expires_at?: string | null
-          invite_token?: string | null
-          name?: string
-          owner_user_id?: string
+          priority?: string | null
+          prompt_quality_score?: number | null
+          status?: string | null
+          tenant_id?: string | null
+          title?: string
+          token_actual?: number | null
+          token_estimate?: number | null
           updated_at?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "tasks_agent_id_fkey"
+            columns: ["agent_id"]
+            isOneToOne: false
+            referencedRelation: "agents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tasks_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       templates: {
         Row: {
@@ -2041,6 +2649,7 @@ export type Database = {
           id: string
           is_shared: boolean | null
           name: string
+          organization_id: string
           team_id: string | null
           template_content: string
           updated_at: string | null
@@ -2055,6 +2664,7 @@ export type Database = {
           id?: string
           is_shared?: boolean | null
           name: string
+          organization_id: string
           team_id?: string | null
           template_content: string
           updated_at?: string | null
@@ -2069,6 +2679,7 @@ export type Database = {
           id?: string
           is_shared?: boolean | null
           name?: string
+          organization_id?: string
           team_id?: string | null
           template_content?: string
           updated_at?: string | null
@@ -2078,10 +2689,94 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "templates_team_id_fkey"
-            columns: ["team_id"]
+            foreignKeyName: "templates_bank_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: "teams"
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tenants: {
+        Row: {
+          business_name: string | null
+          composio_entity_id: string | null
+          created_at: string | null
+          id: string
+          is_admin: boolean | null
+          name: string
+        }
+        Insert: {
+          business_name?: string | null
+          composio_entity_id?: string | null
+          created_at?: string | null
+          id?: string
+          is_admin?: boolean | null
+          name: string
+        }
+        Update: {
+          business_name?: string | null
+          composio_entity_id?: string | null
+          created_at?: string | null
+          id?: string
+          is_admin?: boolean | null
+          name?: string
+        }
+        Relationships: []
+      }
+      token_usage: {
+        Row: {
+          agent_id: string | null
+          cost_usd: number | null
+          created_at: string | null
+          error_reason: string | null
+          id: string
+          input_tokens: number | null
+          is_subscription: boolean | null
+          model: string
+          output_tokens: number | null
+          session_date: string | null
+          tenant_id: string | null
+        }
+        Insert: {
+          agent_id?: string | null
+          cost_usd?: number | null
+          created_at?: string | null
+          error_reason?: string | null
+          id?: string
+          input_tokens?: number | null
+          is_subscription?: boolean | null
+          model: string
+          output_tokens?: number | null
+          session_date?: string | null
+          tenant_id?: string | null
+        }
+        Update: {
+          agent_id?: string | null
+          cost_usd?: number | null
+          created_at?: string | null
+          error_reason?: string | null
+          id?: string
+          input_tokens?: number | null
+          is_subscription?: boolean | null
+          model?: string
+          output_tokens?: number | null
+          session_date?: string | null
+          tenant_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "token_usage_agent_id_fkey"
+            columns: ["agent_id"]
+            isOneToOne: false
+            referencedRelation: "agents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "token_usage_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
             referencedColumns: ["id"]
           },
         ]
@@ -2091,6 +2786,7 @@ export type Database = {
           call_category: string | null
           call_date: string | null
           call_title: string | null
+          canonical_recording_id: string | null
           chunk_index: number
           chunk_text: string
           created_at: string | null
@@ -2117,6 +2813,7 @@ export type Database = {
           call_category?: string | null
           call_date?: string | null
           call_title?: string | null
+          canonical_recording_id?: string | null
           chunk_index: number
           chunk_text: string
           created_at?: string | null
@@ -2143,6 +2840,7 @@ export type Database = {
           call_category?: string | null
           call_date?: string | null
           call_title?: string | null
+          canonical_recording_id?: string | null
           chunk_index?: number
           chunk_text?: string
           created_at?: string | null
@@ -2167,10 +2865,24 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "transcript_chunks_canonical_recording_id_fkey"
+            columns: ["canonical_recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "transcript_chunks_recording_user_fkey"
             columns: ["recording_id", "user_id"]
             isOneToOne: false
             referencedRelation: "fathom_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
+            foreignKeyName: "transcript_chunks_recording_user_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
         ]
@@ -2203,6 +2915,13 @@ export type Database = {
             columns: ["call_recording_id", "user_id"]
             isOneToOne: false
             referencedRelation: "fathom_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
+            foreignKeyName: "transcript_tag_assignments_recording_user_fkey"
+            columns: ["call_recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
             referencedColumns: ["recording_id", "user_id"]
           },
           {
@@ -2240,6 +2959,112 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      trial_purchases: {
+        Row: {
+          amount: number | null
+          created_at: string | null
+          crm_contact_id: string | null
+          currency: string | null
+          email: string | null
+          id: string
+          name: string | null
+          source: string | null
+          status: string | null
+          stripe_customer_id: string | null
+          stripe_payment_intent: string | null
+          stripe_session_id: string | null
+        }
+        Insert: {
+          amount?: number | null
+          created_at?: string | null
+          crm_contact_id?: string | null
+          currency?: string | null
+          email?: string | null
+          id?: string
+          name?: string | null
+          source?: string | null
+          status?: string | null
+          stripe_customer_id?: string | null
+          stripe_payment_intent?: string | null
+          stripe_session_id?: string | null
+        }
+        Update: {
+          amount?: number | null
+          created_at?: string | null
+          crm_contact_id?: string | null
+          currency?: string | null
+          email?: string | null
+          id?: string
+          name?: string | null
+          source?: string | null
+          status?: string | null
+          stripe_customer_id?: string | null
+          stripe_payment_intent?: string | null
+          stripe_session_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trial_purchases_crm_contact_id_fkey"
+            columns: ["crm_contact_id"]
+            isOneToOne: false
+            referencedRelation: "crm_contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      upload_raw_files: {
+        Row: {
+          created_at: string
+          file_size: number | null
+          full_transcript: string | null
+          id: string
+          mime_type: string | null
+          original_filename: string
+          raw_payload: Json | null
+          recording_id: string | null
+          storage_path: string | null
+          transcription_language: string | null
+          user_id: string
+          whisper_model: string | null
+        }
+        Insert: {
+          created_at?: string
+          file_size?: number | null
+          full_transcript?: string | null
+          id?: string
+          mime_type?: string | null
+          original_filename: string
+          raw_payload?: Json | null
+          recording_id?: string | null
+          storage_path?: string | null
+          transcription_language?: string | null
+          user_id: string
+          whisper_model?: string | null
+        }
+        Update: {
+          created_at?: string
+          file_size?: number | null
+          full_transcript?: string | null
+          id?: string
+          mime_type?: string | null
+          original_filename?: string
+          raw_payload?: Json | null
+          recording_id?: string | null
+          storage_path?: string | null
+          transcription_language?: string | null
+          user_id?: string
+          whisper_model?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "upload_raw_files_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_contact_settings: {
         Row: {
@@ -2494,82 +3319,39 @@ export type Database = {
           zoom_oauth_state?: string | null
           zoom_oauth_token_expires?: number | null
         }
-        Relationships: [
-          {
-            foreignKeyName: "user_settings_active_team_id_fkey"
-            columns: ["active_team_id"]
-            isOneToOne: false
-            referencedRelation: "teams"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
-      vault_memberships: {
+      users: {
         Row: {
-          created_at: string
+          created_at: string | null
+          email: string | null
           id: string
-          role: string
-          user_id: string
-          vault_id: string
+          password_hash: string
+          tenant_id: string | null
+          username: string
         }
         Insert: {
-          created_at?: string
+          created_at?: string | null
+          email?: string | null
           id?: string
-          role: string
-          user_id: string
-          vault_id: string
+          password_hash: string
+          tenant_id?: string | null
+          username: string
         }
         Update: {
-          created_at?: string
+          created_at?: string | null
+          email?: string | null
           id?: string
-          role?: string
-          user_id?: string
-          vault_id?: string
+          password_hash?: string
+          tenant_id?: string | null
+          username?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vault_memberships_vault_id_fkey"
-            columns: ["vault_id"]
+            foreignKeyName: "users_tenant_id_fkey"
+            columns: ["tenant_id"]
             isOneToOne: false
-            referencedRelation: "vaults"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      vaults: {
-        Row: {
-          bank_id: string
-          created_at: string
-          default_sharelink_ttl_days: number | null
-          id: string
-          name: string
-          updated_at: string
-          vault_type: string
-        }
-        Insert: {
-          bank_id: string
-          created_at?: string
-          default_sharelink_ttl_days?: number | null
-          id?: string
-          name: string
-          updated_at?: string
-          vault_type: string
-        }
-        Update: {
-          bank_id?: string
-          created_at?: string
-          default_sharelink_ttl_days?: number | null
-          id?: string
-          name?: string
-          updated_at?: string
-          vault_type?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "vaults_bank_id_fkey"
-            columns: ["bank_id"]
-            isOneToOne: false
-            referencedRelation: "banks"
+            referencedRelation: "tenants"
             referencedColumns: ["id"]
           },
         ]
@@ -2619,8 +3401,526 @@ export type Database = {
         }
         Relationships: []
       }
+      workspace_entries: {
+        Row: {
+          created_at: string
+          folder_id: string | null
+          id: string
+          local_tags: string[] | null
+          notes: string | null
+          recording_id: string
+          scores: Json | null
+          updated_at: string
+          workspace_id: string
+        }
+        Insert: {
+          created_at?: string
+          folder_id?: string | null
+          id?: string
+          local_tags?: string[] | null
+          notes?: string | null
+          recording_id: string
+          scores?: Json | null
+          updated_at?: string
+          workspace_id: string
+        }
+        Update: {
+          created_at?: string
+          folder_id?: string | null
+          id?: string
+          local_tags?: string[] | null
+          notes?: string | null
+          recording_id?: string
+          scores?: Json | null
+          updated_at?: string
+          workspace_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vault_entries_folder_id_fkey"
+            columns: ["folder_id"]
+            isOneToOne: false
+            referencedRelation: "folders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vault_entries_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vault_entries_vault_id_fkey"
+            columns: ["workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workspace_invitations: {
+        Row: {
+          accepted_at: string | null
+          created_at: string
+          email: string
+          expires_at: string
+          id: string
+          invited_by: string
+          role: string
+          status: string
+          token: string
+          workspace_id: string
+        }
+        Insert: {
+          accepted_at?: string | null
+          created_at?: string
+          email: string
+          expires_at?: string
+          id?: string
+          invited_by: string
+          role: string
+          status?: string
+          token?: string
+          workspace_id: string
+        }
+        Update: {
+          accepted_at?: string | null
+          created_at?: string
+          email?: string
+          expires_at?: string
+          id?: string
+          invited_by?: string
+          role?: string
+          status?: string
+          token?: string
+          workspace_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workspace_invitations_workspace_id_fkey"
+            columns: ["workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workspace_memberships: {
+        Row: {
+          created_at: string
+          id: string
+          role: string
+          user_id: string
+          workspace_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          role: string
+          user_id: string
+          workspace_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          role?: string
+          user_id?: string
+          workspace_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vault_memberships_vault_id_fkey"
+            columns: ["workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workspaces: {
+        Row: {
+          created_at: string
+          default_sharelink_ttl_days: number | null
+          id: string
+          invite_expires_at: string | null
+          invite_token: string | null
+          is_default: boolean
+          name: string
+          organization_id: string
+          updated_at: string
+          workspace_type: string
+        }
+        Insert: {
+          created_at?: string
+          default_sharelink_ttl_days?: number | null
+          id?: string
+          invite_expires_at?: string | null
+          invite_token?: string | null
+          is_default?: boolean
+          name: string
+          organization_id: string
+          updated_at?: string
+          workspace_type: string
+        }
+        Update: {
+          created_at?: string
+          default_sharelink_ttl_days?: number | null
+          id?: string
+          invite_expires_at?: string | null
+          invite_token?: string | null
+          is_default?: boolean
+          name?: string
+          organization_id?: string
+          updated_at?: string
+          workspace_type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vaults_bank_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      youtube_raw_calls: {
+        Row: {
+          created_at: string
+          full_transcript: string | null
+          id: string
+          import_source: string | null
+          raw_payload: Json | null
+          recording_id: string | null
+          user_id: string
+          youtube_category_id: string | null
+          youtube_channel_id: string | null
+          youtube_channel_title: string | null
+          youtube_comment_count: number | null
+          youtube_description: string | null
+          youtube_duration: string | null
+          youtube_like_count: number | null
+          youtube_published_at: string | null
+          youtube_subscriber_count: number | null
+          youtube_thumbnail: string | null
+          youtube_video_id: string
+          youtube_view_count: number | null
+        }
+        Insert: {
+          created_at?: string
+          full_transcript?: string | null
+          id?: string
+          import_source?: string | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          user_id: string
+          youtube_category_id?: string | null
+          youtube_channel_id?: string | null
+          youtube_channel_title?: string | null
+          youtube_comment_count?: number | null
+          youtube_description?: string | null
+          youtube_duration?: string | null
+          youtube_like_count?: number | null
+          youtube_published_at?: string | null
+          youtube_subscriber_count?: number | null
+          youtube_thumbnail?: string | null
+          youtube_video_id: string
+          youtube_view_count?: number | null
+        }
+        Update: {
+          created_at?: string
+          full_transcript?: string | null
+          id?: string
+          import_source?: string | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          user_id?: string
+          youtube_category_id?: string | null
+          youtube_channel_id?: string | null
+          youtube_channel_title?: string | null
+          youtube_comment_count?: number | null
+          youtube_description?: string | null
+          youtube_duration?: string | null
+          youtube_like_count?: number | null
+          youtube_published_at?: string | null
+          youtube_subscriber_count?: number | null
+          youtube_thumbnail?: string | null
+          youtube_video_id?: string
+          youtube_view_count?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "youtube_raw_calls_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      zoom_raw_calls: {
+        Row: {
+          account_id: string | null
+          created_at: string
+          duration: number | null
+          full_transcript: string | null
+          fuzzy_match_score: number | null
+          host_email: string | null
+          host_id: string | null
+          id: string
+          is_primary: boolean | null
+          meeting_fingerprint: string | null
+          meeting_type: number | null
+          merged_from: number[] | null
+          participants: Json | null
+          raw_payload: Json | null
+          recording_id: string | null
+          recording_url: string | null
+          share_url: string | null
+          start_time: string | null
+          synced_at: string | null
+          timezone: string | null
+          topic: string | null
+          transcript_url: string | null
+          user_id: string
+          zoom_meeting_id: string | null
+          zoom_meeting_uuid: string | null
+          zoom_numeric_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          created_at?: string
+          duration?: number | null
+          full_transcript?: string | null
+          fuzzy_match_score?: number | null
+          host_email?: string | null
+          host_id?: string | null
+          id?: string
+          is_primary?: boolean | null
+          meeting_fingerprint?: string | null
+          meeting_type?: number | null
+          merged_from?: number[] | null
+          participants?: Json | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          recording_url?: string | null
+          share_url?: string | null
+          start_time?: string | null
+          synced_at?: string | null
+          timezone?: string | null
+          topic?: string | null
+          transcript_url?: string | null
+          user_id: string
+          zoom_meeting_id?: string | null
+          zoom_meeting_uuid?: string | null
+          zoom_numeric_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          created_at?: string
+          duration?: number | null
+          full_transcript?: string | null
+          fuzzy_match_score?: number | null
+          host_email?: string | null
+          host_id?: string | null
+          id?: string
+          is_primary?: boolean | null
+          meeting_fingerprint?: string | null
+          meeting_type?: number | null
+          merged_from?: number[] | null
+          participants?: Json | null
+          raw_payload?: Json | null
+          recording_id?: string | null
+          recording_url?: string | null
+          share_url?: string | null
+          start_time?: string | null
+          synced_at?: string | null
+          timezone?: string | null
+          topic?: string | null
+          transcript_url?: string | null
+          user_id?: string
+          zoom_meeting_id?: string | null
+          zoom_meeting_uuid?: string | null
+          zoom_numeric_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "zoom_raw_calls_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
+      fathom_calls: {
+        Row: {
+          ai_generated_title: string | null
+          ai_title_generated_at: string | null
+          auto_tags: string[] | null
+          auto_tags_generated_at: string | null
+          calendar_invitees: Json | null
+          created_at: string | null
+          full_transcript: string | null
+          fuzzy_match_score: number | null
+          google_calendar_event_id: string | null
+          google_drive_file_id: string | null
+          is_primary: boolean | null
+          meeting_fingerprint: string | null
+          merged_from: number[] | null
+          metadata: Json | null
+          recorded_by_email: string | null
+          recorded_by_name: string | null
+          recording_end_time: string | null
+          recording_id: number | null
+          recording_start_time: string | null
+          sentiment_cache: Json | null
+          share_url: string | null
+          source_platform: string | null
+          summary: string | null
+          summary_edited_by_user: boolean | null
+          synced_at: string | null
+          title: string | null
+          title_edited_by_user: boolean | null
+          transcript_source: string | null
+          url: string | null
+          user_id: string | null
+        }
+        Insert: {
+          ai_generated_title?: string | null
+          ai_title_generated_at?: string | null
+          auto_tags?: string[] | null
+          auto_tags_generated_at?: string | null
+          calendar_invitees?: Json | null
+          created_at?: string | null
+          full_transcript?: string | null
+          fuzzy_match_score?: number | null
+          google_calendar_event_id?: string | null
+          google_drive_file_id?: string | null
+          is_primary?: boolean | null
+          meeting_fingerprint?: string | null
+          merged_from?: number[] | null
+          metadata?: Json | null
+          recorded_by_email?: string | null
+          recorded_by_name?: string | null
+          recording_end_time?: string | null
+          recording_id?: number | null
+          recording_start_time?: string | null
+          sentiment_cache?: Json | null
+          share_url?: string | null
+          source_platform?: string | null
+          summary?: string | null
+          summary_edited_by_user?: boolean | null
+          synced_at?: string | null
+          title?: string | null
+          title_edited_by_user?: boolean | null
+          transcript_source?: string | null
+          url?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          ai_generated_title?: string | null
+          ai_title_generated_at?: string | null
+          auto_tags?: string[] | null
+          auto_tags_generated_at?: string | null
+          calendar_invitees?: Json | null
+          created_at?: string | null
+          full_transcript?: string | null
+          fuzzy_match_score?: number | null
+          google_calendar_event_id?: string | null
+          google_drive_file_id?: string | null
+          is_primary?: boolean | null
+          meeting_fingerprint?: string | null
+          merged_from?: number[] | null
+          metadata?: Json | null
+          recorded_by_email?: string | null
+          recorded_by_name?: string | null
+          recording_end_time?: string | null
+          recording_id?: number | null
+          recording_start_time?: string | null
+          sentiment_cache?: Json | null
+          share_url?: string | null
+          source_platform?: string | null
+          summary?: string | null
+          summary_edited_by_user?: boolean | null
+          synced_at?: string | null
+          title?: string | null
+          title_edited_by_user?: boolean | null
+          transcript_source?: string | null
+          url?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+      fathom_transcripts: {
+        Row: {
+          created_at: string | null
+          edited_at: string | null
+          edited_by: string | null
+          edited_speaker_email: string | null
+          edited_speaker_name: string | null
+          edited_text: string | null
+          id: string | null
+          is_deleted: boolean | null
+          recording_id: number | null
+          speaker_email: string | null
+          speaker_name: string | null
+          text: string | null
+          timestamp: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          edited_at?: string | null
+          edited_by?: string | null
+          edited_speaker_email?: string | null
+          edited_speaker_name?: string | null
+          edited_text?: string | null
+          id?: string | null
+          is_deleted?: boolean | null
+          recording_id?: number | null
+          speaker_email?: string | null
+          speaker_name?: string | null
+          text?: string | null
+          timestamp?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          edited_at?: string | null
+          edited_by?: string | null
+          edited_speaker_email?: string | null
+          edited_speaker_name?: string | null
+          edited_text?: string | null
+          id?: string | null
+          is_deleted?: boolean | null
+          recording_id?: number | null
+          speaker_email?: string | null
+          speaker_name?: string | null
+          text?: string | null
+          timestamp?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fathom_transcripts_recording_user_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+          {
+            foreignKeyName: "fathom_transcripts_recording_user_fkey"
+            columns: ["recording_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "fathom_raw_calls"
+            referencedColumns: ["recording_id", "user_id"]
+          },
+        ]
+      }
       recurring_call_titles: {
         Row: {
           current_tags: string[] | null
@@ -2634,6 +3934,10 @@ export type Database = {
       }
     }
     Functions: {
+      accept_workspace_invite: {
+        Args: { p_token: string; p_user_id: string }
+        Returns: Json
+      }
       apply_tag_rules: {
         Args: { p_dry_run?: boolean; p_recording_id: number; p_user_id: string }
         Returns: {
@@ -2687,7 +3991,19 @@ export type Database = {
           user_id: string
         }[]
       }
-      ensure_personal_bank: {
+      create_business_organization: {
+        Args: {
+          p_cross_org_default?: string
+          p_default_workspace_name?: string
+          p_logo_url?: string
+          p_name: string
+        }
+        Returns: {
+          organization_id: string
+          workspace_id: string
+        }[]
+      }
+      ensure_personal_organization: {
         Args: { p_user_id: string }
         Returns: string
       }
@@ -2695,6 +4011,13 @@ export type Database = {
       generate_automation_webhook_secret: {
         Args: { p_user_id: string }
         Returns: string
+      }
+      generate_workspace_invite: {
+        Args: { p_force?: boolean; p_workspace_id: string }
+        Returns: {
+          invite_expires_at: string
+          invite_token: string
+        }[]
       }
       get_admin_cost_summary: {
         Args: { p_period?: string }
@@ -2705,6 +4028,37 @@ export type Database = {
           total_requests: number
           total_tokens: number
           user_breakdown: Json
+        }[]
+      }
+      get_available_metadata: {
+        Args: { p_metadata_type: string; p_user_id: string }
+        Returns: {
+          count: number
+          value: string
+        }[]
+      }
+      get_calls_shared_with_me: {
+        Args: never
+        Returns: {
+          call_name: string
+          duration: string
+          owner_user_id: string
+          recording_id: number
+          recording_start_time: string
+          source_label: string
+          source_type: string
+        }[]
+      }
+      get_calls_shared_with_me_v2: {
+        Args: { p_include_expired?: boolean }
+        Returns: {
+          call_name: string
+          duration: string
+          owner_user_id: string
+          recording_id: number
+          recording_start_time: string
+          source_label: string
+          source_type: string
         }[]
       }
       get_embedding_cost_summary: {
@@ -2718,11 +4072,27 @@ export type Database = {
           total_tokens: number
         }[]
       }
+      get_import_counts: {
+        Args: { p_user_id: string }
+        Returns: {
+          call_count: number
+          source_app: string
+        }[]
+      }
       get_indexed_recording_count: {
         Args: { p_user_id: string }
         Returns: {
           indexed_count: number
           total_chunks: number
+        }[]
+      }
+      get_migration_progress: {
+        Args: never
+        Returns: {
+          migrated_recordings: number
+          percent_complete: number
+          remaining: number
+          total_fathom_calls: number
         }[]
       }
       get_recording_embedding_costs: {
@@ -2735,6 +4105,10 @@ export type Database = {
           total_cost_cents: number
           total_tokens: number
         }[]
+      }
+      get_recording_organization_id: {
+        Args: { p_recording_id: string }
+        Returns: string
       }
       get_unindexed_recording_ids: {
         Args: { p_user_id: string }
@@ -2749,6 +4123,7 @@ export type Database = {
           category: string
         }[]
       }
+      get_user_email: { Args: { user_id: string }; Returns: string }
       get_user_role: {
         Args: { _user_id: string }
         Returns: Database["public"]["Enums"]["app_role"]
@@ -2762,7 +4137,25 @@ export type Database = {
           speaker_name: string
         }[]
       }
-      get_vault_bank_id: { Args: { p_vault_id: string }; Returns: string }
+      get_vault_organization_id: {
+        Args: { p_workspace_id: string }
+        Returns: string
+      }
+      get_workspace_invite_details: {
+        Args: { p_token: string }
+        Returns: {
+          expires_at: string
+          invitation_id: string
+          inviter_display_name: string
+          organization_name: string
+          role: string
+          workspace_name: string
+        }[]
+      }
+      get_workspace_organization_id: {
+        Args: { p_workspace_id: string }
+        Returns: string
+      }
       has_role: {
         Args: {
           _role: Database["public"]["Enums"]["app_role"]
@@ -2770,84 +4163,92 @@ export type Database = {
         }
         Returns: boolean
       }
-      hybrid_search_transcripts:
-        | {
-            Args: {
-              filter_categories?: string[]
-              filter_date_end?: string
-              filter_date_start?: string
-              filter_intent?: string[]
-              filter_recording_ids?: number[]
-              filter_sentiment?: string
-              filter_speakers?: string[]
-              filter_topics?: string[]
-              filter_user_id?: string
-              full_text_weight?: number
-              match_count?: number
-              query_embedding: string
-              query_text: string
-              rrf_k?: number
-              semantic_weight?: number
-            }
-            Returns: {
-              call_category: string
-              call_date: string
-              call_title: string
-              chunk_id: string
-              chunk_index: number
-              chunk_text: string
-              fts_rank: number
-              intent_signals: string[]
-              recording_id: number
-              rrf_score: number
-              sentiment: string
-              similarity_score: number
-              speaker_email: string
-              speaker_name: string
-              topics: string[]
-            }[]
-          }
-        | {
-            Args: {
-              filter_categories?: string[]
-              filter_date_end?: string
-              filter_date_start?: string
-              filter_intent_signals?: string[]
-              filter_recording_ids?: number[]
-              filter_sentiment?: string
-              filter_source_platforms?: string[]
-              filter_speakers?: string[]
-              filter_topics?: string[]
-              filter_user_id?: string
-              filter_user_tags?: string[]
-              full_text_weight?: number
-              match_count?: number
-              query_embedding: string
-              query_text: string
-              rrf_k?: number
-              semantic_weight?: number
-            }
-            Returns: {
-              call_category: string
-              call_date: string
-              call_title: string
-              chunk_id: string
-              chunk_index: number
-              chunk_text: string
-              entities: Json
-              fts_rank: number
-              intent_signals: string[]
-              recording_id: number
-              rrf_score: number
-              sentiment: string
-              similarity_score: number
-              source_platform: string
-              speaker_email: string
-              speaker_name: string
-              topics: string[]
-              user_tags: string[]
-            }[]
-          }
+      hybrid_search_transcripts: {
+        Args: {
+          filter_categories?: string[]
+          filter_date_end?: string
+          filter_date_start?: string
+          filter_intent_signals?: string[]
+          filter_organization_id?: string
+          filter_recording_ids?: number[]
+          filter_sentiment?: string
+          filter_source_platforms?: string[]
+          filter_speakers?: string[]
+          filter_topics?: string[]
+          filter_user_id?: string
+          filter_user_tags?: string[]
+          full_text_weight?: number
+          match_count?: number
+          query_embedding: string
+          query_text: string
+          rrf_k?: number
+          semantic_weight?: number
+        }
+        Returns: {
+          call_category: string
+          call_date: string
+          call_title: string
+          chunk_id: string
+          chunk_index: number
+          chunk_text: string
+          entities: Json
+          fts_rank: number
+          intent_signals: string[]
+          recording_id: number
+          rrf_score: number
+          sentiment: string
+          similarity_score: number
+          source_platform: string
+          speaker_email: string
+          speaker_name: string
+          topics: string[]
+          user_tags: string[]
+        }[]
+      }
+      hybrid_search_transcripts_scoped: {
+        Args: {
+          filter_categories?: string[]
+          filter_date_end?: string
+          filter_date_start?: string
+          filter_intent_signals?: string[]
+          filter_organization_id?: string
+          filter_recording_ids?: number[]
+          filter_sentiment?: string
+          filter_speakers?: string[]
+          filter_topics?: string[]
+          filter_user_id?: string
+          filter_user_tags?: string[]
+          filter_workspace_id?: string
+          full_text_weight?: number
+          match_count: number
+          query_embedding: string
+          query_text: string
+          rrf_k?: number
+          semantic_weight?: number
+        }
+        Returns: {
+          call_category: string
+          call_date: string
+          call_title: string
+          chunk_id: string
+          chunk_index: number
+          chunk_text: string
+          entities: Json
+          fts_rank: number
+          intent_signals: string[]
+          recording_id: number
+          rrf_score: number
+          sentiment: string
+          similarity_score: number
+          source_platform: string
+          speaker_email: string
+          speaker_name: string
+          topics: string[]
+          user_tags: string[]
+          workspace_id: string
+          workspace_name: string
+        }[]
+      }
       increment_embedding_progress: {
         Args: {
           p_chunks_created?: number
@@ -2860,31 +4261,38 @@ export type Database = {
         Args: { p_team_id: string; p_user_id: string }
         Returns: boolean
       }
-      is_bank_admin_or_owner: {
-        Args: { p_bank_id: string; p_user_id: string }
+      is_organization_admin_or_owner: {
+        Args: { p_organization_id: string; p_user_id: string }
         Returns: boolean
       }
-      is_bank_member: {
-        Args: { p_bank_id: string; p_user_id: string }
-        Returns: boolean
-      }
-      is_manager_of: {
-        Args: { p_manager_user_id: string; p_report_user_id: string }
+      is_organization_member: {
+        Args: { p_organization_id: string; p_user_id: string }
         Returns: boolean
       }
       is_team_admin: {
         Args: { p_team_id: string; p_user_id: string }
         Returns: boolean
       }
-      is_vault_admin_or_owner: {
-        Args: { p_user_id: string; p_vault_id: string }
+      is_workspace_admin_or_owner: {
+        Args: { p_user_id: string; p_workspace_id: string }
         Returns: boolean
       }
-      is_vault_member: {
-        Args: { p_user_id: string; p_vault_id: string }
+      is_workspace_member: {
+        Args: { p_user_id: string; p_workspace_id: string }
         Returns: boolean
       }
       manual_google_poll_sync: { Args: never; Returns: string }
+      migrate_batch_fathom_calls: {
+        Args: { p_batch_size?: number }
+        Returns: {
+          error_count: number
+          migrated_count: number
+        }[]
+      }
+      migrate_fathom_call_to_recording: {
+        Args: { p_recording_id: number; p_user_id: string }
+        Returns: string
+      }
       parse_transcript_to_segments: {
         Args: { p_full_transcript: string; p_recording_id: number }
         Returns: number
@@ -2894,9 +4302,9 @@ export type Database = {
         Returns: boolean
       }
       trigger_google_poll_sync: { Args: never; Returns: undefined }
-      would_create_circular_hierarchy: {
-        Args: { p_membership_id: string; p_new_manager_membership_id: string }
-        Returns: boolean
+      update_routing_rule_priorities: {
+        Args: { p_organization_id: string; p_rule_ids: string[] }
+        Returns: undefined
       }
     }
     Enums: {
@@ -3026,12 +4434,10 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       app_role: ["FREE", "PRO", "TEAM", "ADMIN"],
     },
   },
 } as const
+


### PR DESCRIPTION
## Summary

- Regenerate Supabase TypeScript types from linked project — brings in all tables/RPCs added since last generation (organizations, workspaces, workspace_entries, workspace_memberships, workspace_invitations, recordings, user_profiles, folders with is_archived/archived_at/parent_id, etc.)
- Remove ~35 unnecessary `as any` casts across 15 files now that generated types cover these tables and RPCs
- Remove stale `const db = supabase as any` aliases in useWorkspaceMutations, useOrganizationMutations, and WorkspaceManagement
- Fix duplicate type export in workspaces.service.ts

**Remaining `as any` casts** (intentional — tables/RPCs not exposed via PostgREST):
- `personal_folders`, `personal_tags`, `personal_folder_recordings`, `personal_tag_recordings`
- `organization_invitations`, `get_organization_invite_details`, `accept_organization_invite`
- `copy_recordings_to_organization` RPC

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run lint` passes with zero errors (276 warnings, all pre-existing)
- [ ] Verify workspace CRUD operations work in dev
- [ ] Verify invitation flow works (create, accept, revoke)
- [ ] Verify folder operations (create, archive, restore, assign calls)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)