### PR TITLE
fix(79): complete Hub rename — remaining workspace→hub UI strings

### DIFF
--- a/src/components/DeleteConfirmDialog.tsx
+++ b/src/components/DeleteConfirmDialog.tsx
@@ -28,7 +28,7 @@ const CONTENT: Record<DeleteMode, {
   buttonLabel: string;
 }> = {
   'remove-from-workspace': {
-    title: 'Remove from Workspace',
+    title: 'Remove from Hub',
     destructive: false,
     buttonLabel: 'Remove',
   },
@@ -89,13 +89,13 @@ export default function DeleteConfirmDialog({
                 <>
                   <p className="text-foreground">
                     Remove <strong>{itemCount} item{plural ? 's' : ''}</strong> from{' '}
-                    <strong>{workspaceName || 'this workspace'}</strong>?
-                    {' '}They'll remain in your other workspaces.
+                    <strong>{workspaceName || 'this hub'}</strong>?
+                    {' '}They'll remain in your other hubs.
                   </p>
                   {lastWorkspaceCount != null && lastWorkspaceCount > 0 && (
                     <p className="text-sm text-destructive">
                       {lastWorkspaceCount} of these {lastWorkspaceCount === 1 ? 'is' : 'are'} only
-                      in this workspace and will be permanently deleted.
+                      in this hub and will be permanently deleted.
                     </p>
                   )}
                 </>
@@ -104,7 +104,7 @@ export default function DeleteConfirmDialog({
               {mode === 'permanent-last-workspace' && (
                 <>
                   <p className="text-foreground">
-                    This is the only workspace for{' '}
+                    This is the only hub for{' '}
                     <strong>{itemCount} item{plural ? 's' : ''}</strong>.
                     Removing will permanently delete {plural ? 'them' : 'it'}.
                   </p>
@@ -121,7 +121,7 @@ export default function DeleteConfirmDialog({
                   <p className="text-foreground">
                     Permanently delete{' '}
                     <strong className="text-destructive">{itemCount} item{plural ? 's' : ''}</strong>{' '}
-                    from all workspaces?
+                    from all hubs?
                   </p>
                   {sourceText && (
                     <p className="text-sm text-muted-foreground">

--- a/src/components/QuickCreateFolderDialog.tsx
+++ b/src/components/QuickCreateFolderDialog.tsx
@@ -185,7 +185,7 @@ export default function QuickCreateFolderDialog({
         return;
       }
       if (!targetWorkspaceId) {
-        toast.error("Please select a workspace for this folder");
+        toast.error("Please select a hub for this folder");
         return;
       }
 
@@ -356,13 +356,13 @@ export default function QuickCreateFolderDialog({
           {/* Workspace Selection (Only if no workspace is active/provided) */}
           {(!activeWorkspaceId && !workspaceId) && (
             <div className="space-y-2">
-              <Label htmlFor="workspace-select">Workspace <span className="text-red-500">*</span></Label>
+              <Label htmlFor="workspace-select">Hub <span className="text-red-500">*</span></Label>
               <Select
                 value={selectedWorkspaceId || ""}
                 onValueChange={setSelectedWorkspaceId}
               >
                 <SelectTrigger id="workspace-select">
-                  <SelectValue placeholder="Select a workspace" />
+                  <SelectValue placeholder="Select a hub" />
                 </SelectTrigger>
                 <SelectContent>
                   {workspaces.map((ws) => (

--- a/src/components/QuickCreateTagDialog.tsx
+++ b/src/components/QuickCreateTagDialog.tsx
@@ -49,7 +49,7 @@ export default function QuickCreateTagDialog({
       }
 
       if (!activeOrganizationId) {
-        toast.error("No active workspace selected");
+        toast.error("No active organization selected");
         return;
       }
 

--- a/src/components/dialogs/ChangeRoleDialog.tsx
+++ b/src/components/dialogs/ChangeRoleDialog.tsx
@@ -51,7 +51,7 @@ const WORKSPACE_ROLES: Array<{
   {
     value: 'workspace_owner',
     label: 'Owner',
-    description: 'Full control. Can delete workspace and manage all members.',
+    description: 'Full control. Can delete hub and manage all members.',
     icon: RiVipCrownLine,
     power: 0,
   },
@@ -72,7 +72,7 @@ const WORKSPACE_ROLES: Array<{
   {
     value: 'member',
     label: 'Member',
-    description: 'Can view and interact with workspace recordings.',
+    description: 'Can view and interact with hub recordings.',
     icon: RiUserLine,
     power: 3,
   },

--- a/src/components/dialogs/CreateOrganizationDialog.tsx
+++ b/src/components/dialogs/CreateOrganizationDialog.tsx
@@ -247,16 +247,16 @@ export function CreateOrganizationDialog({
 
           {/* Default Workspace Name (optional) */}
           <div className="space-y-2">
-            <Label htmlFor="default-workspace-name">Default Workspace Name</Label>
+            <Label htmlFor="default-workspace-name">Default Hub Name</Label>
             <Input
               id="default-workspace-name"
               value={defaultWorkspaceName}
               onChange={(e) => setDefaultWorkspaceName(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder={name.trim() ? `${name.trim()}'s Workspace` : "Your first workspace in this organization"}
+              placeholder={name.trim() ? `${name.trim()}'s Hub` : "Your first hub in this organization"}
             />
             <p className="text-xs text-muted-foreground">
-              Your first workspace in this organization. Leave blank for default.
+              Your first hub in this organization. Leave blank for default.
             </p>
           </div>
 

--- a/src/components/dialogs/CreateWorkspaceDialog.tsx
+++ b/src/components/dialogs/CreateWorkspaceDialog.tsx
@@ -285,16 +285,16 @@ export function CreateWorkspaceDialog({
             variant="ghost"
             onClick={() => onOpenChange(false)}
             disabled={createWorkspace.isPending}
-            aria-label="Cancel workspace creation"
+            aria-label="Cancel hub creation"
           >
             Cancel
           </Button>
           <Button
             onClick={handleSubmit}
             disabled={!canSubmit}
-            aria-label="Create workspace"
+            aria-label="Create hub"
           >
-            {createWorkspace.isPending ? 'Creating...' : 'Create Workspace'}
+            {createWorkspace.isPending ? 'Creating...' : 'Create Hub'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/dialogs/MoveToWorkspaceDialog.tsx
+++ b/src/components/dialogs/MoveToWorkspaceDialog.tsx
@@ -93,23 +93,23 @@ export function MoveToWorkspaceDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <RiExpandLeftRightLine className="h-5 w-5 text-vibe-orange" />
-            Move to Workspace
+            Move to Hub
           </DialogTitle>
           <DialogDescription>
-            Move {count} {label} to another workspace within this organization.
+            Move {count} {label} to another hub within this organization.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-4">
           <div className="space-y-2">
-            <Label htmlFor="workspace">Target Workspace</Label>
+            <Label htmlFor="workspace">Target Hub</Label>
             <Select
               value={targetWorkspaceId}
               onValueChange={setTargetWorkspaceId}
               disabled={isLoading}
             >
               <SelectTrigger id="workspace">
-                <SelectValue placeholder={isLoading ? "Loading workspaces..." : "Select a workspace"} />
+                <SelectValue placeholder={isLoading ? "Loading hubs..." : "Select a hub"} />
               </SelectTrigger>
               <SelectContent>
                 {workspaces
@@ -133,14 +133,14 @@ export function MoveToWorkspaceDialog({
               htmlFor="keepInSource"
               className="text-xs font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
             >
-              Also keep in current workspace (copy instead of move)
+              Also keep in current hub (copy instead of move)
             </Label>
           </div>
 
           <div className="p-3 rounded-lg bg-info-bg/10 border border-info-border/20 flex gap-3">
             <RiInformationLine className="h-4 w-4 text-info-text mt-0.5 flex-shrink-0" />
             <p className="text-[11px] text-info-text leading-relaxed">
-              Moving a call to another workspace shares it with that workspace's members.
+              Moving a call to another hub shares it with that hub's members.
               The call stays in the same organization.
             </p>
           </div>

--- a/src/components/layout/DetailPaneOutlet.tsx
+++ b/src/components/layout/DetailPaneOutlet.tsx
@@ -154,7 +154,7 @@ export function DetailPaneOutlet({
       case 'call-detail':
         return 'Call detail panel';
       case 'workspace_members':
-        return 'Workspace member panel';
+        return 'Hub member panel';
       case 'organization_members':
         return 'Organization member panel';
       case 'automation-rule':

--- a/src/components/panels/OrganizationMemberPanel.tsx
+++ b/src/components/panels/OrganizationMemberPanel.tsx
@@ -157,7 +157,7 @@ export function OrganizationMemberPanel({ organizationId, organizationName }: Or
   const handleRemoveMember = useCallback(
     (member: OrganizationMember) => {
       if (member.role === 'organization_owner' && ownerCount <= 1) return
-      if (!confirm(`Remove ${member.display_name || member.email} from this organization? This will also remove them from all workspaces.`)) return
+      if (!confirm(`Remove ${member.display_name || member.email} from this organization? This will also remove them from all hubs.`)) return
       removeMember.mutate({ membershipId: member.id })
     },
     [removeMember, ownerCount]

--- a/src/components/panels/SettingHelpPanel.tsx
+++ b/src/components/panels/SettingHelpPanel.tsx
@@ -54,7 +54,7 @@ const helpContent: Record<SettingHelpTopic, HelpContent> = {
     tips: [
       "Use your full name for easy recognition",
       "This name appears in call transcripts and insights",
-      "Team members will see this name in shared workspaces",
+      "Team members will see this name in shared hubs",
     ],
   },
   preferences: {
@@ -104,7 +104,7 @@ const helpContent: Record<SettingHelpTopic, HelpContent> = {
       "Invite team members by email to collaborate",
       "Assign appropriate roles based on responsibilities",
       "Remove users who no longer need access",
-      "Team members can share workspaces and insights",
+      "Team members can share hubs and insights",
     ],
   },
   billing: {

--- a/src/components/panes/WorkspaceDetailPane.tsx
+++ b/src/components/panes/WorkspaceDetailPane.tsx
@@ -74,7 +74,7 @@ export interface WorkspaceDetailPaneProps {
 /** Loading skeleton for workspace detail */
 function WorkspaceDetailSkeleton() {
   return (
-    <div className="p-6 space-y-6" aria-label="Loading workspace detail">
+    <div className="p-6 space-y-6" aria-label="Loading hub detail">
       <div className="flex items-center gap-3">
         <Skeleton className="h-6 w-48" />
         <Skeleton className="h-5 w-16" />
@@ -219,7 +219,7 @@ export function WorkspaceDetailPane({
             variant="outline"
             size="sm"
             onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.detail(workspaceId) })}
-            aria-label="Retry loading workspace"
+            aria-label="Retry loading hub"
           >
             Try Again
           </Button>
@@ -273,7 +273,7 @@ export function WorkspaceDetailPane({
                 size="icon"
                 onClick={handleOpenSettings}
                 className="h-8 w-8"
-                aria-label="Workspace settings"
+                aria-label="Hub settings"
               >
                 <RiSettings3Line className="h-4 w-4" aria-hidden="true" />
               </Button>

--- a/src/components/panes/WorkspaceListPane.tsx
+++ b/src/components/panes/WorkspaceListPane.tsx
@@ -344,7 +344,7 @@ function WorkspaceListError({ onRetry }: { onRetry: () => void }) {
       <RiErrorWarningLine className="h-12 w-12 text-destructive/40 mb-3" aria-hidden="true" />
       <p className="text-sm font-bold text-foreground">Sync Error</p>
       <p className="text-xs text-muted-foreground mt-1 mb-5 max-w-[200px]">
-        We encountered a problem fetching your workspaces.
+        We encountered a problem fetching your hubs.
       </p>
       <Button variant="outline" size="sm" onClick={onRetry} className="h-8 text-xs">
         Reconnect
@@ -402,7 +402,7 @@ export function WorkspaceListPane({
         className
       )}
       role="navigation"
-      aria-label="Workspace list"
+      aria-label="Hub list"
     >
       {/* Header */}
       <header className="flex-shrink-0 border-b border-border/40 bg-card/60 backdrop-blur-md">

--- a/src/components/settings/WorkspaceManagement.tsx
+++ b/src/components/settings/WorkspaceManagement.tsx
@@ -163,16 +163,16 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
       queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all })
       setCreateDialogOpen(false)
       setNewWorkspaceName('')
-      toast.success('Workspace created successfully')
+      toast.success('Hub created successfully')
     },
     onError: (error) => {
-      toast.error(`Failed to create workspace: ${error.message}`)
+      toast.error(`Failed to create hub: ${error.message}`)
     },
   })
 
   const handleCreateWorkspace = () => {
     if (!newWorkspaceName.trim()) {
-      toast.error('Workspace name is required')
+      toast.error('Hub name is required')
       return
     }
     createWorkspace.mutate({ name: newWorkspaceName.trim(), type: newWorkspaceType })
@@ -243,7 +243,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
                 <Button
                   variant="outline"
                   onClick={() => setCreateDialogOpen(false)}
-                  aria-label="Cancel workspace creation"
+                  aria-label="Cancel hub creation"
                 >
                   Cancel
                 </Button>

--- a/src/components/transcript-library/FolderSidebar.tsx
+++ b/src/components/transcript-library/FolderSidebar.tsx
@@ -701,7 +701,7 @@ export function FolderSidebar({
                     <RiSafeLine className="h-4 w-4 text-muted-foreground shrink-0" />
                   )}
                   <p className="text-sm font-display font-black uppercase tracking-wider text-foreground truncate">
-                    {activeWorkspace?.name || 'Workspace'}
+                    {activeWorkspace?.name || 'Hub'}
                   </p>
                 </div>
               </div>

--- a/src/components/transcript-library/TranscriptTable.tsx
+++ b/src/components/transcript-library/TranscriptTable.tsx
@@ -42,7 +42,7 @@ const workspaceColumnOptions = [
   { id: "participants", label: "Invitees" },
   { id: "tags", label: "Tags" },
   { id: "folders", label: "Folders" },
-  { id: "workspaces", label: "Workspaces" },
+  { id: "workspaces", label: "Hubs" },
   { id: "sharedWith", label: "Shared With" },
 ];
 
@@ -51,7 +51,7 @@ const homeColumnOptions = [
   { id: "duration", label: "Duration" },
   { id: "source", label: "Source" },
   { id: "tags", label: "Tags" },
-  { id: "workspaces", label: "Workspaces" },
+  { id: "workspaces", label: "Hubs" },
   { id: "sharedWith", label: "Shared With" },
 ];
 

--- a/src/components/ui/sidebar-nav.tsx
+++ b/src/components/ui/sidebar-nav.tsx
@@ -369,7 +369,7 @@ export function SidebarNav({ isCollapsed, className, onSyncClick, onLibraryToggl
                 'hover:bg-hover',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-vibe-orange focus-visible:ring-offset-2'
               )}
-              title="Toggle Workspace Panel"
+              title="Toggle Hub Panel"
             >
                <div className={cn(
                       "flex-shrink-0 flex items-center justify-center",
@@ -381,7 +381,7 @@ export function SidebarNav({ isCollapsed, className, onSyncClick, onLibraryToggl
                     <RiLayoutColumnLine className="w-5 h-5" />
                   )}
               </div>
-              {!isCollapsed && <span className="text-sm text-muted-foreground truncate">Workspace Panel</span>}
+              {!isCollapsed && <span className="text-sm text-muted-foreground truncate">Hub Panel</span>}
             </button>
              {isCollapsed && <div className="w-8 h-px bg-cb-border mt-2 mx-auto" />}
           </div>

--- a/src/hooks/useCategorySync.ts
+++ b/src/hooks/useCategorySync.ts
@@ -159,7 +159,7 @@ export function useTagSync() {
   ) => {
     try {
       const user = await requireUser();
-      if (!activeOrgId) throw new Error("No active workspace selected");
+      if (!activeOrgId) throw new Error("No active organization selected");
 
       const { data, error } = await supabase
         .from("call_tags")

--- a/src/hooks/useRoutingRules.ts
+++ b/src/hooks/useRoutingRules.ts
@@ -352,7 +352,7 @@ export function useBulkApplyRules() {
         // Invalidate workspace entries and recordings after actual apply
         queryClient.invalidateQueries({ queryKey: queryKeys.workspaceEntries.all });
         queryClient.invalidateQueries({ queryKey: queryKeys.calls.all });
-        toast.success(`Moved ${data.moved} recording${data.moved !== 1 ? 's' : ''} to matching workspaces`);
+        toast.success(`Moved ${data.moved} recording${data.moved !== 1 ? 's' : ''} to matching hubs`);
       }
     },
     onError: (error: Error) => {

--- a/src/hooks/useWorkspaceAssignment.ts
+++ b/src/hooks/useWorkspaceAssignment.ts
@@ -131,7 +131,7 @@ export function useWorkspaceAssignment(
           context.previous
         )
       }
-      toast.error('Failed to add recording to workspace')
+      toast.error('Failed to add recording to hub')
     },
     onSettled: (_data, _error, { workspaceId }) => {
       queryClient.invalidateQueries({
@@ -144,7 +144,7 @@ export function useWorkspaceAssignment(
     },
     onSuccess: (_data, { workspaceId }) => {
       const workspace = workspaces.find((workspace) => workspace.id === workspaceId)
-      toast.success(`Added to ${workspace?.name || 'workspace'}`)
+      toast.success(`Added to ${workspace?.name || 'hub'}`)
     },
   })
 
@@ -185,7 +185,7 @@ export function useWorkspaceAssignment(
           context.previous
         )
       }
-      toast.error('Failed to remove recording from workspace')
+      toast.error('Failed to remove recording from hub')
     },
     onSettled: (_data, _error, { workspaceId }) => {
       queryClient.invalidateQueries({
@@ -198,7 +198,7 @@ export function useWorkspaceAssignment(
     },
     onSuccess: (_data, { workspaceId }) => {
       const workspace = workspaces.find((workspace) => workspace.id === workspaceId)
-      toast.success(`Removed from ${workspace?.name || 'workspace'}`)
+      toast.success(`Removed from ${workspace?.name || 'hub'}`)
     },
   })
 
@@ -206,7 +206,7 @@ export function useWorkspaceAssignment(
   const toggleWorkspace = (workspaceId: string) => {
     // Don't allow removing from personal workspace
     if (personalWorkspace && workspaceId === personalWorkspace.id) {
-      toast.error('Recordings cannot be removed from your personal workspace')
+      toast.error('Recordings cannot be removed from your personal hub')
       return
     }
 

--- a/src/hooks/useWorkspaceMemberMutations.ts
+++ b/src/hooks/useWorkspaceMemberMutations.ts
@@ -86,7 +86,7 @@ export function useGenerateWorkspaceInvite(workspaceId: string) {
 
       const currentRole = membership?.role as WorkspaceRole | undefined
       if (currentRole !== 'workspace_owner' && currentRole !== 'workspace_admin') {
-        throw new Error('Only workspace owners and admins can generate invite links')
+        throw new Error('Only hub owners and admins can generate invite links')
       }
 
       // Check if workspace already has a valid invite token
@@ -120,10 +120,10 @@ export function useGenerateWorkspaceInvite(workspaceId: string) {
       if (updateError) {
         const message = updateError?.message || ''
         if (message.includes('row-level security')) {
-          throw new Error('You do not have permission to generate invite links for this workspace.')
+          throw new Error('You do not have permission to generate invite links for this hub.')
         }
         if (message.includes('invite_token') || message.includes('invite_expires_at')) {
-          throw new Error('Workspace invite schema is not fully deployed yet. Please run the latest Supabase migrations and try again.')
+          throw new Error('Hub invite schema is not fully deployed yet. Please run the latest Supabase migrations and try again.')
         }
         throw updateError
       }
@@ -169,12 +169,12 @@ export function useChangeRole(workspaceId: string) {
     }) => {
       // Permission check: must be owner or admin
       if (currentUserRole !== 'workspace_owner' && currentUserRole !== 'workspace_admin') {
-        throw new Error('Only workspace owners and admins can change roles')
+        throw new Error('Only hub owners and admins can change roles')
       }
 
       // Cannot change workspace_owner role via this action
       if (targetRole === 'workspace_owner') {
-        throw new Error('Cannot change the workspace owner role')
+        throw new Error('Cannot change the hub owner role')
       }
 
       if (targetRole === 'workspace_admin' && isLastAdmin && newRole !== 'workspace_admin') {
@@ -227,12 +227,12 @@ export function useRemoveMember(workspaceId: string) {
       currentUserRole: WorkspaceRole
     }) => {
       if (currentUserRole !== 'workspace_owner' && currentUserRole !== 'workspace_admin') {
-        throw new Error('Only workspace owners and admins can remove members')
+        throw new Error('Only hub owners and admins can remove members')
       }
 
       // Cannot remove workspace_owner
       if (targetRole === 'workspace_owner') {
-        throw new Error('Cannot remove the workspace owner')
+        throw new Error('Cannot remove the hub owner')
       }
 
       const { error } = await supabase
@@ -269,7 +269,7 @@ export function useLeaveWorkspace(workspaceId: string) {
   return useMutation({
     mutationFn: async ({ membershipId, userRole }: { membershipId: string; userRole: WorkspaceRole }) => {
       if (userRole === 'workspace_owner') {
-        throw new Error('Workspace owners cannot leave. Transfer ownership first.')
+        throw new Error('Hub owners cannot leave. Transfer ownership first.')
       }
 
       if (!user) throw new Error('Not authenticated')
@@ -283,12 +283,12 @@ export function useLeaveWorkspace(workspaceId: string) {
       if (error) throw error
     },
     onSuccess: () => {
-      toast.success('You left the workspace')
+      toast.success('You left the hub')
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.all })
       navigate('/workspaces')
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to leave workspace')
+      toast.error(error.message || 'Failed to leave hub')
     },
   })
 }

--- a/src/hooks/useWorkspaceMutations.ts
+++ b/src/hooks/useWorkspaceMutations.ts
@@ -138,7 +138,7 @@ export function useCreateWorkspace() {
       if (context?.previousList && context.listKey) {
         queryClient.setQueryData(context.listKey, context.previousList)
       }
-      toast.error(`Failed to create workspace: ${error.message}`)
+      toast.error(`Failed to create hub: ${error.message}`)
     },
     onSuccess: (workspace, variables, context) => {
       if (context?.listKey && context.tempId) {
@@ -154,7 +154,7 @@ export function useCreateWorkspace() {
           )
         )
       }
-      toast.success(`Workspace '${variables.name.trim()}' created`)
+      toast.success(`Hub '${variables.name.trim()}' created`)
       queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all })
     },
     onSettled: () => {
@@ -270,7 +270,7 @@ export function useUpdateWorkspace() {
           queryClient.setQueryData(key, data)
         }
       }
-      toast.error('Failed to update workspace')
+      toast.error('Failed to update hub')
     },
     onSettled: (_data, _error, input) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.list() })
@@ -281,7 +281,7 @@ export function useUpdateWorkspace() {
       queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all })
     },
     onSuccess: () => {
-      toast.success('Workspace updated')
+      toast.success('Hub updated')
     },
   })
 }
@@ -351,7 +351,7 @@ export function useDeleteWorkspace() {
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaceEntries.all })
       queryClient.invalidateQueries({ queryKey: ['orgContext'] })
       queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all })
-      toast.success('Workspace deleted')
+      toast.success('Hub deleted')
     },
     onError: (error: Error, input, context) => {
       if (context?.previousDetail) {
@@ -365,7 +365,7 @@ export function useDeleteWorkspace() {
           queryClient.setQueryData(key, data)
         }
       }
-      toast.error(`Failed to delete workspace: ${error.message}`)
+      toast.error(`Failed to delete hub: ${error.message}`)
     },
   })
 }
@@ -418,12 +418,12 @@ export function useSetDefaultWorkspace() {
       return updatedWs
     },
     onSuccess: () => {
-      toast.success('Default workspace updated')
+      toast.success('Default hub updated')
       queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.all })
       queryClient.invalidateQueries({ queryKey: ['orgContext'] }) // Legacy context
     },
     onError: (error: Error) => {
-      toast.error(`Failed to set default workspace: ${error.message}`)
+      toast.error(`Failed to set default hub: ${error.message}`)
     },
   })
 }

--- a/src/lib/folder-icons.ts
+++ b/src/lib/folder-icons.ts
@@ -33,7 +33,7 @@ export const FOLDER_ICON_OPTIONS: FolderIconOption[] = [
   { id: 'building', label: 'Building', icon: RemixIcon.RiBuildingLine, category: 'business' },
   { id: 'building-2', label: 'Building 2', icon: RemixIcon.RiBuilding2Line, category: 'business' },
   { id: 'store', label: 'Store', icon: RemixIcon.RiStoreLine, category: 'business' },
-  { id: 'bank', label: 'Workspace', icon: RemixIcon.RiBankLine, category: 'business' },
+  { id: 'bank', label: 'Hub', icon: RemixIcon.RiBankLine, category: 'business' },
   { id: 'government', label: 'Government', icon: RemixIcon.RiGovernmentLine, category: 'business' },
   { id: 'presentation', label: 'Presentation', icon: RemixIcon.RiSlideshowLine, category: 'business' },
   { id: 'calendar', label: 'Calendar', icon: RemixIcon.RiCalendarLine, category: 'business' },


### PR DESCRIPTION
## Summary
- Renames all remaining user-facing `workspace` strings to `hub` across 22 files
- Covers toast messages, dialog titles/descriptions, table column headers, sidebar labels, aria labels, error messages, and placeholders
- Database/backend/code internals (variable names, file names, DB queries, type names) remain as `workspace`

## Files changed (22)
- **Toast messages (21 strings):** `useWorkspaceMutations.ts`, `useWorkspaceMemberMutations.ts`, `useWorkspaceAssignment.ts`, `WorkspaceManagement.tsx`, `useRoutingRules.ts`
- **Dialog titles/descriptions (12 strings):** `MoveToWorkspaceDialog.tsx`, `CreateWorkspaceDialog.tsx`, `CreateOrganizationDialog.tsx`, `DeleteConfirmDialog.tsx`
- **Table column headers (2):** `TranscriptTable.tsx`
- **Sidebar/nav labels (2):** `sidebar-nav.tsx`, `WorkspaceListPane.tsx`
- **Aria labels (6):** `WorkspaceDetailPane.tsx`, `CreateWorkspaceDialog.tsx`, `WorkspaceManagement.tsx`, `DetailPaneOutlet.tsx`
- **Error messages (10):** `useWorkspaceMemberMutations.ts`, `ChangeRoleDialog.tsx`, `QuickCreateFolderDialog.tsx`, `useCategorySync.ts`, `QuickCreateTagDialog.tsx`
- **Other UI text:** `SettingHelpPanel.tsx`, `FolderSidebar.tsx`, `OrganizationMemberPanel.tsx`, `folder-icons.ts`

## Test plan
- [x] TypeScript type-check passes (0 errors)
- [x] ESLint passes (0 errors, only pre-existing warnings)
- [ ] Visual verification: confirm all user-facing text reads "Hub" not "Workspace"
- [ ] Verify no backend/database references were accidentally changed

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)