### PR TITLE
fix(88): guard personal_folders queries until migration is deployed

### DIFF
--- a/src/components/AssignFolderDialog.tsx
+++ b/src/components/AssignFolderDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
+import { isTableMissing } from "@/lib/supabase-errors";
 import { RiArrowRightSLine, RiArrowDownSLine, RiFolderLine, RiCheckLine } from "@remixicon/react";
 import { cn } from "@/lib/utils";
 import { getIconComponent } from "@/lib/folder-icons";
@@ -82,7 +83,7 @@ export default function AssignFolderDialog({
         .select('recording_id, folder_id')
         .in('recording_id', uuidRecordingIds);
 
-      if (personalError && !personalError.message?.includes('does not exist') && personalError.code !== '42P01') throw personalError;
+      if (personalError && !isTableMissing(personalError)) throw personalError;
 
       const combined = [
         ...(legacyData || []).map(a => a.folder_id),
@@ -132,7 +133,7 @@ export default function AssignFolderDialog({
         .eq('organization_id', activeOrganizationId)
         .order('name');
 
-      if (personalError && !personalError.message?.includes('does not exist') && personalError.code !== '42P01') throw personalError;
+      if (personalError && !isTableMissing(personalError)) throw personalError;
 
       const all = [
         ...(legacyData || []).map(f => ({ ...f, is_personal: false })),
@@ -293,30 +294,32 @@ export default function AssignFolderDialog({
       });
       if (legacyToAdd.length > 0) await supabase.from("folder_assignments").insert(legacyToAdd);
 
-      // 2. Handle Personal Folders
+      // 2. Handle Personal Folders — skip entirely when table doesn't exist yet
       const personalSelected = new Set(Array.from(selectedFolders).filter(id => allFolders.find(f => f.id === id && (f as any).is_personal)));
-      
-      const { data: existingPersonal } = await (supabase as any)
+
+      const { data: existingPersonal, error: existingPersonalError } = await (supabase as any)
         .from('personal_folder_recordings')
         .select('recording_id, folder_id')
         .in('recording_id', uuidRecordingIds);
 
-      // Deletions
-      const personalToDelete = (existingPersonal || []).filter((a: any) => !personalSelected.has(a.folder_id));
-      for (const a of personalToDelete) {
-        await (supabase as any).from('personal_folder_recordings').delete()
-          .eq('recording_id', a.recording_id).eq('folder_id', a.folder_id).eq('user_id', userId);
-      }
-      // Insertions
-      const personalToAdd: any[] = [];
-      uuidRecordingIds.forEach(rid => {
-        personalSelected.forEach(fid => {
-          if (!(existingPersonal || []).some((a: any) => a.recording_id === rid && a.folder_id === fid)) {
-            personalToAdd.push({ recording_id: rid, folder_id: fid, user_id: userId });
-          }
+      if (!isTableMissing(existingPersonalError)) {
+        // Deletions
+        const personalToDelete = (existingPersonal || []).filter((a: any) => !personalSelected.has(a.folder_id));
+        for (const a of personalToDelete) {
+          await (supabase as any).from('personal_folder_recordings').delete()
+            .eq('recording_id', a.recording_id).eq('folder_id', a.folder_id).eq('user_id', userId);
+        }
+        // Insertions
+        const personalToAdd: any[] = [];
+        uuidRecordingIds.forEach(rid => {
+          personalSelected.forEach(fid => {
+            if (!(existingPersonal || []).some((a: any) => a.recording_id === rid && a.folder_id === fid)) {
+              personalToAdd.push({ recording_id: rid, folder_id: fid, user_id: userId });
+            }
+          });
         });
-      });
-      if (personalToAdd.length > 0) await (supabase as any).from('personal_folder_recordings').insert(personalToAdd);
+        if (personalToAdd.length > 0) await (supabase as any).from('personal_folder_recordings').insert(personalToAdd);
+      }
 
       const count = targetRecordingIds.length;
       const folderCount = selectedFolders.size;

--- a/src/components/AssignFolderDialog.tsx
+++ b/src/components/AssignFolderDialog.tsx
@@ -302,7 +302,9 @@ export default function AssignFolderDialog({
         .select('recording_id, folder_id')
         .in('recording_id', uuidRecordingIds);
 
-      if (!isTableMissing(existingPersonalError)) {
+      if (existingPersonalError && !isTableMissing(existingPersonalError)) throw existingPersonalError;
+
+      if (!existingPersonalError) {
         // Deletions
         const personalToDelete = (existingPersonal || []).filter((a: any) => !personalSelected.has(a.folder_id));
         for (const a of personalToDelete) {

--- a/src/components/AssignFolderDialog.tsx
+++ b/src/components/AssignFolderDialog.tsx
@@ -76,13 +76,13 @@ export default function AssignFolderDialog({
 
       if (legacyError) throw legacyError;
 
-      // Personal assignments
+      // Personal assignments — table may not exist yet (migration pending)
       const { data: personalData, error: personalError } = await (supabase as any)
         .from('personal_folder_recordings')
         .select('recording_id, folder_id')
         .in('recording_id', uuidRecordingIds);
 
-      if (personalError) throw personalError;
+      if (personalError && !personalError.message?.includes('does not exist') && personalError.code !== '42P01') throw personalError;
 
       const combined = [
         ...(legacyData || []).map(a => a.folder_id),
@@ -125,14 +125,14 @@ export default function AssignFolderDialog({
       const { data: legacyData, error: legacyError } = await legacyQuery;
       if (legacyError) throw legacyError;
 
-      // 2. Fetch Personal Folders
+      // 2. Fetch Personal Folders — table may not exist yet (migration pending)
       const { data: personalData, error: personalError } = await (supabase as any)
         .from('personal_folders')
         .select('*')
         .eq('organization_id', activeOrganizationId)
         .order('name');
-      
-      if (personalError) throw personalError;
+
+      if (personalError && !personalError.message?.includes('does not exist') && personalError.code !== '42P01') throw personalError;
 
       const all = [
         ...(legacyData || []).map(f => ({ ...f, is_personal: false })),

--- a/src/lib/supabase-errors.ts
+++ b/src/lib/supabase-errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true when a Supabase/PostgREST error indicates the queried
+ * relation (table/view) does not exist — typically HTTP 404 with
+ * PostgreSQL code 42P01.
+ *
+ * Used to gracefully degrade when a migration has not yet been deployed
+ * to the hosted Supabase instance (e.g. migration 20260306).
+ */
+export function isTableMissing(error: { code?: string; message?: string; details?: string } | null): boolean {
+  if (!error) return false
+  if (error.code === '42P01') return true
+  if (error.message?.includes('does not exist')) return true
+  if (error.details?.includes('does not exist')) return true
+  return false
+}

--- a/src/services/personal-folders.service.ts
+++ b/src/services/personal-folders.service.ts
@@ -1,5 +1,19 @@
 import { supabase } from '@/integrations/supabase/client'
 
+/**
+ * Returns true when a Supabase error indicates the table does not exist
+ * (HTTP 404 / PGRST code 42P01).  This happens when migration 20260306
+ * has not yet been deployed to the hosted instance.
+ */
+function isTableMissing(error: { code?: string; message?: string; details?: string } | null): boolean {
+  if (!error) return false
+  if (error.code === '42P01') return true
+  // PostgREST returns a message like "relation … does not exist"
+  if (error.message?.includes('does not exist')) return true
+  if (error.details?.includes('does not exist')) return true
+  return false
+}
+
 export interface PersonalFolder {
   id: string
   user_id: string
@@ -22,8 +36,11 @@ export async function getPersonalFolders(organizationId: string): Promise<Person
     .eq('organization_id', organizationId)
     .order('created_at', { ascending: false })
 
-  if (error) throw new Error(`Failed to fetch personal folders: ${error.message}`)
-  
+  if (error) {
+    if (isTableMissing(error)) return []
+    throw new Error(`Failed to fetch personal folders: ${error.message}`)
+  }
+
   return data as PersonalFolder[]
 }
 
@@ -43,7 +60,10 @@ export async function createPersonalFolder(organizationId: string, name: string)
     .select()
     .single()
 
-  if (error) throw new Error(`Failed to create personal folder: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal folders are not available yet — migration pending')
+    throw new Error(`Failed to create personal folder: ${error.message}`)
+  }
 
   return data as PersonalFolder
 }
@@ -54,7 +74,10 @@ export async function updatePersonalFolder(folderId: string, name: string): Prom
     .update({ name })
     .eq('id', folderId)
 
-  if (error) throw new Error(`Failed to update personal folder: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal folders are not available yet — migration pending')
+    throw new Error(`Failed to update personal folder: ${error.message}`)
+  }
 }
 
 export async function deletePersonalFolder(folderId: string): Promise<void> {
@@ -63,7 +86,10 @@ export async function deletePersonalFolder(folderId: string): Promise<void> {
     .delete()
     .eq('id', folderId)
 
-  if (error) throw new Error(`Failed to delete personal folder: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal folders are not available yet — migration pending')
+    throw new Error(`Failed to delete personal folder: ${error.message}`)
+  }
 }
 
 export async function getPersonalFolderAssignments(organizationId: string): Promise<Record<string, string[]>> {
@@ -73,7 +99,10 @@ export async function getPersonalFolderAssignments(organizationId: string): Prom
     .select('id')
     .eq('organization_id', organizationId)
 
-  if (foldersError) throw new Error(`Failed to fetch folders for assignments: ${foldersError.message}`)
+  if (foldersError) {
+    if (isTableMissing(foldersError)) return {}
+    throw new Error(`Failed to fetch folders for assignments: ${foldersError.message}`)
+  }
   
   const folderIds = (folders ?? []).map((f) => f.id)
   
@@ -85,7 +114,10 @@ export async function getPersonalFolderAssignments(organizationId: string): Prom
     .select('recording_id, folder_id')
     .in('folder_id', folderIds)
 
-  if (error) throw new Error(`Failed to fetch personal folder assignments: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) return {}
+    throw new Error(`Failed to fetch personal folder assignments: ${error.message}`)
+  }
 
   const assignments: Record<string, string[]> = {}
   ;(data ?? []).forEach((row) => {
@@ -113,7 +145,10 @@ export async function assignCallToPersonalFolder(recordingId: string, folderId: 
       user_id: userId,
     }, { onConflict: 'folder_id,recording_id' })
 
-  if (error) throw new Error(`Failed to assign call to personal folder: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal folders are not available yet — migration pending')
+    throw new Error(`Failed to assign call to personal folder: ${error.message}`)
+  }
 }
 
 export async function removeCallFromPersonalFolder(recordingId: string, folderId: string): Promise<void> {
@@ -123,7 +158,10 @@ export async function removeCallFromPersonalFolder(recordingId: string, folderId
     .eq('recording_id', recordingId)
     .eq('folder_id', folderId)
 
-  if (error) throw new Error(`Failed to remove call from personal folder: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal folders are not available yet — migration pending')
+    throw new Error(`Failed to remove call from personal folder: ${error.message}`)
+  }
 }
 
 export async function moveCallToPersonalFolder(recordingId: string, fromFolderId: string, toFolderId: string): Promise<void> {

--- a/src/services/personal-folders.service.ts
+++ b/src/services/personal-folders.service.ts
@@ -1,18 +1,5 @@
 import { supabase } from '@/integrations/supabase/client'
-
-/**
- * Returns true when a Supabase error indicates the table does not exist
- * (HTTP 404 / PGRST code 42P01).  This happens when migration 20260306
- * has not yet been deployed to the hosted instance.
- */
-function isTableMissing(error: { code?: string; message?: string; details?: string } | null): boolean {
-  if (!error) return false
-  if (error.code === '42P01') return true
-  // PostgREST returns a message like "relation … does not exist"
-  if (error.message?.includes('does not exist')) return true
-  if (error.details?.includes('does not exist')) return true
-  return false
-}
+import { isTableMissing } from '@/lib/supabase-errors'
 
 export interface PersonalFolder {
   id: string

--- a/src/services/personal-tags.service.ts
+++ b/src/services/personal-tags.service.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client'
+import { isTableMissing } from '@/lib/supabase-errors'
 
 export interface PersonalTag {
   id: string
@@ -17,8 +18,11 @@ export async function getPersonalTags(organizationId: string): Promise<PersonalT
     .eq('organization_id', organizationId)
     .order('name', { ascending: true })
 
-  if (error) throw new Error(`Failed to fetch personal tags: ${error.message}`)
-  
+  if (error) {
+    if (isTableMissing(error)) return []
+    throw new Error(`Failed to fetch personal tags: ${error.message}`)
+  }
+
   return data as PersonalTag[]
 }
 
@@ -39,7 +43,10 @@ export async function createPersonalTag(organizationId: string, name: string, co
     .select()
     .single()
 
-  if (error) throw new Error(`Failed to create personal tag: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal tags are not available yet — migration pending')
+    throw new Error(`Failed to create personal tag: ${error.message}`)
+  }
 
   return data as PersonalTag
 }
@@ -50,7 +57,10 @@ export async function updatePersonalTag(tagId: string, updates: Partial<{ name: 
     .update(updates)
     .eq('id', tagId)
 
-  if (error) throw new Error(`Failed to update personal tag: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal tags are not available yet — migration pending')
+    throw new Error(`Failed to update personal tag: ${error.message}`)
+  }
 }
 
 export async function deletePersonalTag(tagId: string): Promise<void> {
@@ -59,7 +69,10 @@ export async function deletePersonalTag(tagId: string): Promise<void> {
     .delete()
     .eq('id', tagId)
 
-  if (error) throw new Error(`Failed to delete personal tag: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal tags are not available yet — migration pending')
+    throw new Error(`Failed to delete personal tag: ${error.message}`)
+  }
 }
 
 export async function getPersonalTagAssignments(organizationId: string): Promise<Record<string, string[]>> {
@@ -68,7 +81,10 @@ export async function getPersonalTagAssignments(organizationId: string): Promise
     .select('id')
     .eq('organization_id', organizationId)
 
-  if (tagsError) throw new Error(`Failed to fetch tags for assignments: ${tagsError.message}`)
+  if (tagsError) {
+    if (isTableMissing(tagsError)) return {}
+    throw new Error(`Failed to fetch tags for assignments: ${tagsError.message}`)
+  }
   
   const tagIds = (tags ?? []).map((t) => t.id)
   
@@ -79,7 +95,10 @@ export async function getPersonalTagAssignments(organizationId: string): Promise
     .select('recording_id, tag_id')
     .in('tag_id', tagIds)
 
-  if (error) throw new Error(`Failed to fetch personal tag assignments: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) return {}
+    throw new Error(`Failed to fetch personal tag assignments: ${error.message}`)
+  }
 
   const assignments: Record<string, string[]> = {}
   ;(data ?? []).forEach((row) => {
@@ -107,7 +126,10 @@ export async function assignTagToRecording(recordingId: string, tagId: string): 
       user_id: userId,
     }, { onConflict: 'tag_id,recording_id' })
 
-  if (error) throw new Error(`Failed to assign tag to recording: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal tags are not available yet — migration pending')
+    throw new Error(`Failed to assign tag to recording: ${error.message}`)
+  }
 }
 
 export async function removeTagFromRecording(recordingId: string, tagId: string): Promise<void> {
@@ -117,5 +139,8 @@ export async function removeTagFromRecording(recordingId: string, tagId: string)
     .eq('recording_id', recordingId)
     .eq('tag_id', tagId)
 
-  if (error) throw new Error(`Failed to remove tag from recording: ${error.message}`)
+  if (error) {
+    if (isTableMissing(error)) throw new Error('Personal tags are not available yet — migration pending')
+    throw new Error(`Failed to remove tag from recording: ${error.message}`)
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `isTableMissing()` helper to detect when `personal_folders` / `personal_folder_recordings` tables don't exist yet (migration 20260306 not deployed)
- Read queries (`getPersonalFolders`, `getPersonalFolderAssignments`) gracefully return empty results instead of throwing 404
- Write queries (create/update/delete/assign/remove) throw a clear "migration pending" message
- Guards direct Supabase queries in `AssignFolderDialog.tsx` the same way

## Test plan
- [ ] Verify app loads without 404 errors in console for personal_folders
- [ ] Verify legacy folders still work normally in AssignFolderDialog
- [ ] After migration is deployed, verify personal folders feature works end-to-end

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)