### PR TITLE
perf(87): batch workspace_entries queries — fix N+1 in list views

### DIFF
--- a/src/components/transcript-library/TranscriptTable.tsx
+++ b/src/components/transcript-library/TranscriptTable.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { RiArrowUpDownLine, RiLayoutColumnLine, RiFileDownloadLine, RiTeamLine } from "@remixicon/react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import { WorkspaceEntriesBatchProvider } from "@/hooks/useWorkspaceEntriesBatch";
 import {
   Table,
   TableBody,
@@ -128,6 +129,14 @@ export const TranscriptTable = React.memo(({
   const columnOptions = isHome ? homeColumnOptions : workspaceColumnOptions;
   const { sortField, sortDirection: _sortDirection, sortedData: sortedCalls, handleSort } = useTableSort(calls, "date");
 
+  // Extract UUID recording IDs for batch workspace entries fetch
+  const recordingUuids = useMemo(
+    () => calls
+      .map((c) => c.recording_id)
+      .filter((id): id is string => typeof id === 'string'),
+    [calls],
+  );
+
   const SortButton = ({ field, children }: { field: string; children: React.ReactNode }) => (
     <button
       onClick={() => handleSort(field)}
@@ -147,6 +156,7 @@ export const TranscriptTable = React.memo(({
   }
 
   return (
+    <WorkspaceEntriesBatchProvider recordingIds={recordingUuids}>
     <div className="space-y-4">
       {/* Direct Reports Filter */}
       {showDirectReportsFilter && onDirectReportsFilterChange && (
@@ -340,6 +350,7 @@ export const TranscriptTable = React.memo(({
         />
       )}
     </div>
+    </WorkspaceEntriesBatchProvider>
   );
 });
 

--- a/src/components/transcript-library/TranscriptTable.tsx
+++ b/src/components/transcript-library/TranscriptTable.tsx
@@ -130,10 +130,12 @@ export const TranscriptTable = React.memo(({
   const { sortField, sortDirection: _sortDirection, sortedData: sortedCalls, handleSort } = useTableSort(calls, "date");
 
   // Extract UUID recording IDs for batch workspace entries fetch
+  // Sorted for stable query key regardless of table sort order
   const recordingUuids = useMemo(
     () => calls
       .map((c) => c.recording_id)
-      .filter((id): id is string => typeof id === 'string'),
+      .filter((id): id is string => typeof id === 'string')
+      .sort(),
     [calls],
   );
 

--- a/src/components/workspace/WorkspaceBadgeList.tsx
+++ b/src/components/workspace/WorkspaceBadgeList.tsx
@@ -8,13 +8,14 @@
  * @brand-version v4.2
  */
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { RiSafeLine } from '@remixicon/react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Skeleton } from '@/components/ui/skeleton'
 import { WorkspaceBadge } from '@/components/workspace/WorkspaceBadge'
 import { useWorkspaceAssignment } from '@/hooks/useWorkspaceAssignment'
+import { useWorkspaceEntriesBatch } from '@/hooks/useWorkspaceEntriesBatch'
 import { useOrganizationContext } from '@/hooks/useOrganizationContext'
 import { cn } from '@/lib/utils'
 import type { WorkspaceType } from '@/types/workspace'
@@ -55,14 +56,27 @@ export function WorkspaceBadgeList({
   const [overflowOpen, setOverflowOpen] = useState(false)
   const { workspaces, isLoading: orgLoading } = useOrganizationContext()
 
+  // Use batch context if available (list views), otherwise fall back to individual query
+  const batchContext = useWorkspaceEntriesBatch()
+  const hasBatchData = batchContext !== null && typeof recordingId === 'string'
+
   const {
-    assignedWorkspaceIds,
-    isLoading: entriesLoading,
+    assignedWorkspaceIds: individualAssignedIds,
+    isLoading: individualLoading,
   } = useWorkspaceAssignment(
-    recordingId || null,
-    legacyRecordingId,
+    hasBatchData ? null : (recordingId || null),
+    hasBatchData ? null : legacyRecordingId,
   )
 
+  // Derive assigned workspace IDs from batch context when available
+  const batchAssignedIds = useMemo(() => {
+    if (!hasBatchData || !recordingId) return new Set<string>()
+    const entries = batchContext.entriesByRecording.get(recordingId) || []
+    return new Set(entries.map((e) => e.workspace_id))
+  }, [hasBatchData, batchContext, recordingId])
+
+  const assignedWorkspaceIds = hasBatchData ? batchAssignedIds : individualAssignedIds
+  const entriesLoading = hasBatchData ? batchContext.isLoading : individualLoading
   const isLoading = orgLoading || entriesLoading
 
   // Build list of workspaces this recording is in, with info

--- a/src/hooks/useWorkspaceAssignment.ts
+++ b/src/hooks/useWorkspaceAssignment.ts
@@ -134,8 +134,9 @@ export function useWorkspaceAssignment(
       toast.error('Failed to add recording to hub')
     },
     onSettled: (_data, _error, { workspaceId }) => {
+      // Invalidate all workspace entry queries (individual + batch) via prefix match
       queryClient.invalidateQueries({
-        queryKey: queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
+        queryKey: queryKeys.workspaceEntries.all,
       })
       // Also invalidate workspace recordings so WorkspaceDetailPane refreshes
       queryClient.invalidateQueries({
@@ -188,8 +189,9 @@ export function useWorkspaceAssignment(
       toast.error('Failed to remove recording from hub')
     },
     onSettled: (_data, _error, { workspaceId }) => {
+      // Invalidate all workspace entry queries (individual + batch) via prefix match
       queryClient.invalidateQueries({
-        queryKey: queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
+        queryKey: queryKeys.workspaceEntries.all,
       })
       // Also invalidate workspace recordings so WorkspaceDetailPane refreshes
       queryClient.invalidateQueries({

--- a/src/hooks/useWorkspaceAssignment.ts
+++ b/src/hooks/useWorkspaceAssignment.ts
@@ -92,45 +92,55 @@ export function useWorkspaceAssignment(
       return data as WorkspaceEntry
     },
     onMutate: async ({ workspaceId }) => {
-      // Cancel outgoing refetches
+      const recId = effectiveRecordingId || ''
+
+      // Cancel outgoing refetches for both individual and batch queries
       await queryClient.cancelQueries({
-        queryKey: queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
+        queryKey: queryKeys.workspaceEntries.all,
       })
 
       // Snapshot previous value
       const previous = queryClient.getQueryData<WorkspaceEntry[]>(
-        queryKeys.workspaceEntries.byRecording(effectiveRecordingId || '')
+        queryKeys.workspaceEntries.byRecording(recId)
       )
 
-      // Optimistically add the entry
+      const optimisticEntry: WorkspaceEntry = {
+        id: `temp-${workspaceId}`,
+        workspace_id: workspaceId,
+        recording_id: recId,
+        folder_id: null,
+        local_tags: [],
+        scores: null,
+        notes: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+
+      // Optimistically add the entry to individual query
       queryClient.setQueryData<WorkspaceEntry[]>(
-        queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
-        (old = []) => [
-          ...old,
-          {
-            id: `temp-${workspaceId}`,
-            workspace_id: workspaceId,
-            recording_id: effectiveRecordingId || '',
-            folder_id: null,
-            local_tags: [],
-            scores: null,
-            notes: null,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-          },
-        ]
+        queryKeys.workspaceEntries.byRecording(recId),
+        (old = []) => [...old, optimisticEntry]
+      )
+
+      // Also optimistically update any batch queries containing this recording
+      queryClient.setQueriesData<WorkspaceEntry[]>(
+        { queryKey: ['workspace-entries', 'recording-batch'] },
+        (old) => old ? [...old, optimisticEntry] : undefined,
       )
 
       return { previous }
     },
     onError: (_err, _variables, context) => {
-      // Rollback on error
+      // Rollback on error — invalidate all to refetch clean state
       if (context?.previous) {
         queryClient.setQueryData(
           queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
           context.previous
         )
       }
+      queryClient.invalidateQueries({
+        queryKey: ['workspace-entries', 'recording-batch'],
+      })
       toast.error('Failed to add recording to hub')
     },
     onSettled: (_data, _error, { workspaceId }) => {
@@ -163,29 +173,44 @@ export function useWorkspaceAssignment(
       if (error) throw error
     },
     onMutate: async ({ workspaceId }) => {
+      const recId = effectiveRecordingId || ''
+
+      // Cancel outgoing refetches for both individual and batch queries
       await queryClient.cancelQueries({
-        queryKey: queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
+        queryKey: queryKeys.workspaceEntries.all,
       })
 
       const previous = queryClient.getQueryData<WorkspaceEntry[]>(
-        queryKeys.workspaceEntries.byRecording(effectiveRecordingId || '')
+        queryKeys.workspaceEntries.byRecording(recId)
       )
 
-      // Optimistically remove the entry
+      // Optimistically remove the entry from individual query
       queryClient.setQueryData<WorkspaceEntry[]>(
-        queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
+        queryKeys.workspaceEntries.byRecording(recId),
         (old = []) => old.filter((ve) => ve.workspace_id !== workspaceId)
+      )
+
+      // Also optimistically remove from any batch queries
+      queryClient.setQueriesData<WorkspaceEntry[]>(
+        { queryKey: ['workspace-entries', 'recording-batch'] },
+        (old) => old
+          ? old.filter((ve) => !(ve.recording_id === recId && ve.workspace_id === workspaceId))
+          : undefined,
       )
 
       return { previous }
     },
     onError: (_err, _variables, context) => {
+      // Rollback on error — invalidate all to refetch clean state
       if (context?.previous) {
         queryClient.setQueryData(
           queryKeys.workspaceEntries.byRecording(effectiveRecordingId || ''),
           context.previous
         )
       }
+      queryClient.invalidateQueries({
+        queryKey: ['workspace-entries', 'recording-batch'],
+      })
       toast.error('Failed to remove recording from hub')
     },
     onSettled: (_data, _error, { workspaceId }) => {

--- a/src/hooks/useWorkspaceEntriesBatch.tsx
+++ b/src/hooks/useWorkspaceEntriesBatch.tsx
@@ -1,0 +1,89 @@
+import { createContext, useContext, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '@/integrations/supabase/client'
+import { queryKeys } from '@/lib/query-config'
+import type { WorkspaceEntry } from '@/types/workspace'
+
+/**
+ * Batch workspace entries context — solves the N+1 query problem.
+ *
+ * Instead of each WorkspaceBadgeList firing its own
+ * `workspace_entries?recording_id=eq.<id>` query, the list view fetches
+ * ALL entries for the visible recordings in a single
+ * `workspace_entries?recording_id=in.(id1,id2,...)` query, then distributes
+ * them via context.
+ */
+
+interface WorkspaceEntriesBatchContextValue {
+  /** Map of recording_id → WorkspaceEntry[] */
+  entriesByRecording: Map<string, WorkspaceEntry[]>
+  isLoading: boolean
+}
+
+const WorkspaceEntriesBatchContext = createContext<WorkspaceEntriesBatchContextValue | null>(null)
+
+/**
+ * Hook to consume batch workspace entries from context.
+ * Returns null if no batch provider is present (fallback to individual queries).
+ */
+export function useWorkspaceEntriesBatch() {
+  return useContext(WorkspaceEntriesBatchContext)
+}
+
+/**
+ * Hook that fetches workspace entries for multiple recordings in a single query.
+ */
+function useWorkspaceEntriesBatchQuery(recordingIds: string[]) {
+  return useQuery({
+    queryKey: queryKeys.workspaceEntries.byRecordingBatch(recordingIds),
+    queryFn: async (): Promise<WorkspaceEntry[]> => {
+      if (recordingIds.length === 0) return []
+
+      const { data, error } = await supabase
+        .from('workspace_entries')
+        .select('id, workspace_id:workspace_id, recording_id, folder_id, local_tags, scores, notes, created_at, updated_at')
+        .in('recording_id', recordingIds)
+
+      if (error) throw error
+      return (data || []) as WorkspaceEntry[]
+    },
+    enabled: recordingIds.length > 0,
+    staleTime: 2 * 60 * 1000, // 2 minutes — same as individual queries
+  })
+}
+
+interface WorkspaceEntriesBatchProviderProps {
+  /** Recording UUIDs to batch-fetch entries for */
+  recordingIds: string[]
+  children: React.ReactNode
+}
+
+/**
+ * Provider that batch-fetches workspace entries for a list of recordings.
+ * Wrap around any list view that renders WorkspaceBadgeList for multiple recordings.
+ */
+export function WorkspaceEntriesBatchProvider({
+  recordingIds,
+  children,
+}: WorkspaceEntriesBatchProviderProps) {
+  const { data: entries = [], isLoading } = useWorkspaceEntriesBatchQuery(recordingIds)
+
+  const value = useMemo<WorkspaceEntriesBatchContextValue>(() => {
+    const map = new Map<string, WorkspaceEntry[]>()
+    for (const entry of entries) {
+      const existing = map.get(entry.recording_id)
+      if (existing) {
+        existing.push(entry)
+      } else {
+        map.set(entry.recording_id, [entry])
+      }
+    }
+    return { entriesByRecording: map, isLoading }
+  }, [entries, isLoading])
+
+  return (
+    <WorkspaceEntriesBatchContext.Provider value={value}>
+      {children}
+    </WorkspaceEntriesBatchContext.Provider>
+  )
+}

--- a/src/hooks/useWorkspaceEntriesBatch.tsx
+++ b/src/hooks/useWorkspaceEntriesBatch.tsx
@@ -1,7 +1,7 @@
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@/integrations/supabase/client'
 import { queryKeys } from '@/lib/query-config'
+import { getWorkspaceEntriesByRecordings } from '@/services/workspace-entries.service'
 import type { WorkspaceEntry } from '@/types/workspace'
 
 /**
@@ -36,17 +36,7 @@ export function useWorkspaceEntriesBatch() {
 function useWorkspaceEntriesBatchQuery(recordingIds: string[]) {
   return useQuery({
     queryKey: queryKeys.workspaceEntries.byRecordingBatch(recordingIds),
-    queryFn: async (): Promise<WorkspaceEntry[]> => {
-      if (recordingIds.length === 0) return []
-
-      const { data, error } = await supabase
-        .from('workspace_entries')
-        .select('id, workspace_id:workspace_id, recording_id, folder_id, local_tags, scores, notes, created_at, updated_at')
-        .in('recording_id', recordingIds)
-
-      if (error) throw error
-      return (data || []) as WorkspaceEntry[]
-    },
+    queryFn: () => getWorkspaceEntriesByRecordings(recordingIds),
     enabled: recordingIds.length > 0,
     staleTime: 2 * 60 * 1000, // 2 minutes — same as individual queries
   })
@@ -55,7 +45,7 @@ function useWorkspaceEntriesBatchQuery(recordingIds: string[]) {
 interface WorkspaceEntriesBatchProviderProps {
   /** Recording UUIDs to batch-fetch entries for */
   recordingIds: string[]
-  children: React.ReactNode
+  children: ReactNode
 }
 
 /**

--- a/src/lib/query-config.ts
+++ b/src/lib/query-config.ts
@@ -123,6 +123,7 @@ export const queryKeys = {
   workspaceEntries: {
     all: ['workspace-entries'] as const,
     byRecording: (recordingId: string) => ['workspace-entries', 'recording', recordingId] as const,
+    byRecordingBatch: (recordingIds: string[]) => ['workspace-entries', 'recording-batch', recordingIds] as const,
     byWorkspace: (workspaceId: string) => ['workspace-entries', 'workspace', workspaceId] as const,
   },
 

--- a/src/services/workspace-entries.service.ts
+++ b/src/services/workspace-entries.service.ts
@@ -1,0 +1,20 @@
+import { supabase } from '@/integrations/supabase/client'
+import type { WorkspaceEntry } from '@/types/workspace'
+
+/**
+ * Fetch workspace entries for multiple recordings in a single query.
+ * Used by WorkspaceEntriesBatchProvider to solve the N+1 query problem.
+ */
+export async function getWorkspaceEntriesByRecordings(
+  recordingIds: string[],
+): Promise<WorkspaceEntry[]> {
+  if (recordingIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from('workspace_entries')
+    .select('id, workspace_id:workspace_id, recording_id, folder_id, local_tags, scores, notes, created_at, updated_at')
+    .in('recording_id', recordingIds)
+
+  if (error) throw error
+  return (data || []) as WorkspaceEntry[]
+}


### PR DESCRIPTION
## Summary
- **Fixes N+1 query problem**: Each recording row was firing its own `workspace_entries?recording_id=eq.<id>` query. 20 visible recordings = 20 API calls.
- **New `WorkspaceEntriesBatchProvider`** context fetches all entries in a single `workspace_entries?recording_id=in.(id1,id2,...)` query and distributes via React context.
- **`WorkspaceBadgeList`** consumes batch context when available (list views), falls back to individual `useWorkspaceAssignment` queries for detail views.
- **`AddToWorkspaceMenu`** unchanged — it already lazy-loads (only queries when popover opens).

## Files Changed
| File | Change |
|------|--------|
| `src/hooks/useWorkspaceEntriesBatch.tsx` | New batch hook + context provider |
| `src/lib/query-config.ts` | Add `byRecordingBatch` query key |
| `src/components/workspace/WorkspaceBadgeList.tsx` | Consume batch context with individual fallback |
| `src/components/transcript-library/TranscriptTable.tsx` | Wrap table with `WorkspaceEntriesBatchProvider` |

## Test plan
- [ ] Load transcript list with 20+ recordings — verify network tab shows 1 workspace_entries request instead of N
- [ ] Open call detail page — verify workspace badges still load (individual fallback)
- [ ] AddToWorkspaceMenu still works when opened from a list row
- [ ] Workspace badges update correctly after adding/removing a recording from a hub

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)