### PR TITLE
feat(91): port routing rules page, drag-and-drop, filter improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import Settings from "@/pages/Settings";
 import Analytics from "@/pages/Analytics";
 import SharedWithMe from "@/pages/SharedWithMe";
 import ImportPage from "@/pages/ImportPage";
+import RoutingRulesPage from "@/pages/RoutingRulesPage";
 
 // Optimized QueryClient configuration with smart caching
 const queryClient = new QueryClient({
@@ -247,6 +248,18 @@ function App() {
                       <ProtectedRoute>
                         <Layout>
                           <ImportPage />
+                        </Layout>
+                      </ProtectedRoute>
+                    }
+                  />
+
+                  {/* Routing Rules route */}
+                  <Route
+                    path="/rules"
+                    element={
+                      <ProtectedRoute>
+                        <Layout>
+                          <RoutingRulesPage />
                         </Layout>
                       </ProtectedRoute>
                     }

--- a/src/components/import/DefaultDestinationBar.tsx
+++ b/src/components/import/DefaultDestinationBar.tsx
@@ -30,9 +30,9 @@ export function DefaultDestinationBar() {
 
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center gap-3 rounded-xl border border-border/60 bg-card p-3.5">
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-foreground">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 rounded-xl border border-border/60 bg-card p-3.5">
+        <div className="flex-1 min-w-0 shrink-0">
+          <p className="text-sm font-medium text-foreground whitespace-nowrap">
             Unmatched calls go to
           </p>
           {!routingDefault && !isLoading && (
@@ -42,12 +42,14 @@ export function DefaultDestinationBar() {
           )}
         </div>
 
-        <DestinationPicker
-          value={currentDestination}
-          onChange={handleDestinationChange}
-          orgId={activeOrgId}
-          disabled={isLoading || isPending}
-        />
+        <div className="flex-1 flex sm:justify-end min-w-0 w-full sm:w-auto">
+          <DestinationPicker
+            value={currentDestination}
+            onChange={handleDestinationChange}
+            orgId={activeOrgId}
+            disabled={isLoading || isPending}
+          />
+        </div>
       </div>
 
       <p className="text-xs text-muted-foreground px-0.5">

--- a/src/components/import/DestinationPicker.tsx
+++ b/src/components/import/DestinationPicker.tsx
@@ -17,11 +17,11 @@ interface DestinationPickerProps {
 }
 
 const selectClass = cn(
-  'h-8 rounded-md border border-border bg-background px-2.5 py-1',
-  'text-sm text-foreground',
+  'h-9 rounded-md border border-border bg-background pl-3 pr-8 py-1',
+  'text-sm text-foreground overflow-hidden text-ellipsis whitespace-nowrap',
   'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0',
   'disabled:opacity-50 disabled:cursor-not-allowed',
-  'cursor-pointer'
+  'cursor-pointer w-full sm:w-auto min-w-[120px] max-w-full sm:max-w-[200px]'
 );
 
 export function DestinationPicker({
@@ -31,7 +31,7 @@ export function DestinationPicker({
   disabled = false,
   className,
 }: DestinationPickerProps) {
-  const { data: workspaces = [], isLoading: workspacesLoading } = useWorkspaces(orgId);
+  const { workspaces = [], isLoading: workspacesLoading } = useWorkspaces(orgId);
   const { data: folders = [], isLoading: foldersLoading } = useFolders(value?.workspaceId ?? null);
 
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(value?.workspaceId ?? null);
@@ -56,7 +56,7 @@ export function DestinationPicker({
   }
 
   return (
-    <div className={cn('flex items-center gap-2', className)}>
+    <div className={cn('flex flex-wrap items-center gap-2 w-full sm:w-auto', className)}>
       <select
         value={selectedWorkspaceId ?? ''}
         onChange={handleWorkspaceChange}

--- a/src/components/import/RoutingConditionBuilder.tsx
+++ b/src/components/import/RoutingConditionBuilder.tsx
@@ -20,19 +20,19 @@ const ROUTING_CONDITION_FIELDS: FieldConfig[] = [
   {
     value: 'title',
     label: 'Title',
-    operators: ['contains', 'not_contains', 'equals', 'starts_with'],
+    operators: ['contains', 'not_contains', 'equals', 'not_equals', 'starts_with'],
     valueType: 'text',
   },
   {
     value: 'participant',
     label: 'Participant',
-    operators: ['contains', 'equals'],
+    operators: ['contains', 'not_contains', 'equals', 'not_equals'],
     valueType: 'text',
   },
   {
     value: 'source',
     label: 'Source',
-    operators: ['equals'],
+    operators: ['equals', 'not_equals'],
     valueType: 'select',
     options: [
       { value: 'fathom', label: 'Fathom' },
@@ -50,7 +50,7 @@ const ROUTING_CONDITION_FIELDS: FieldConfig[] = [
   {
     value: 'tag',
     label: 'Tag',
-    operators: ['equals', 'contains'],
+    operators: ['equals', 'not_equals', 'contains', 'not_contains'],
     valueType: 'text',
   },
   {
@@ -65,6 +65,7 @@ const OPERATOR_LABELS: Record<string, string> = {
   contains:     'contains',
   not_contains: 'does not contain',
   equals:       'is',
+  not_equals:   'is not',
   starts_with:  'starts with',
   greater_than: 'greater than',
   less_than:    'less than',
@@ -75,7 +76,7 @@ const OPERATOR_LABELS: Record<string, string> = {
 const MAX_CONDITIONS = 5;
 
 const controlClass = cn(
-  'h-8 rounded-md border border-border bg-background px-2.5 py-1',
+  'h-8 rounded-md border border-border bg-background px-2.5 pr-8 py-1',
   'text-sm text-foreground',
   'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0',
   'disabled:opacity-50 disabled:cursor-not-allowed'
@@ -160,7 +161,7 @@ export function RoutingConditionBuilder({
 
         return (
           <div key={index}>
-            <div className="flex items-center gap-2 py-1.5">
+            <div className="flex flex-wrap items-center gap-2 py-1.5">
               <span className="text-sm text-muted-foreground w-10 shrink-0 text-right">
                 {index === 0 ? 'When' : ''}
               </span>

--- a/src/components/import/RoutingRuleCard.tsx
+++ b/src/components/import/RoutingRuleCard.tsx
@@ -127,10 +127,10 @@ export function RoutingRuleCard({
         >
           {rule.name}
         </p>
-        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+        <p className="text-xs text-muted-foreground mt-0.5 whitespace-normal break-words">
           {conditionSummary}
         </p>
-        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+        <p className="text-xs text-muted-foreground mt-0.5 whitespace-normal break-words">
           <span className="text-foreground/60">Route to:</span> {destination}
         </p>
       </button>

--- a/src/components/import/RoutingRulesTab.tsx
+++ b/src/components/import/RoutingRulesTab.tsx
@@ -3,16 +3,15 @@
  */
 
 import { useState } from 'react';
-import { RiRouteLine, RiPlayCircleLine } from '@remixicon/react';
+import { RiRouteLine, RiFlashlightLine, RiLoader2Line } from '@remixicon/react';
 import { cn } from '@/lib/utils';
 import { useRoutingRules, useRoutingDefault, useReorderRules, useToggleRule } from '@/hooks/useRoutingRules';
-import { useRoutingRuleStore } from '@/stores/routingRuleStore';
+import { usePanelStore } from '@/stores/panelStore';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { useOrgContextStore } from '@/stores/orgContextStore';
+import { useBulkApplyRules } from '@/hooks/useBulkApplyRules';
 import { DefaultDestinationBar } from './DefaultDestinationBar';
 import { RoutingRulesList } from './RoutingRulesList';
-import { RoutingRuleSlideOver } from './RoutingRuleSlideOver';
-import { BulkApplyDialog } from './BulkApplyDialog';
 
 function HelpContent() {
   return (
@@ -22,7 +21,7 @@ function HelpContent() {
         <li>Rules are evaluated top-to-bottom in priority order</li>
         <li>The first matching rule wins — lower rules are skipped</li>
         <li>Calls that match no rule go to the default destination</li>
-        <li>Rules apply to new imports automatically — use "Apply to existing" for older calls</li>
+        <li>Rules only apply to newly imported calls — not historical data</li>
         <li>Drag rule cards to reorder their priority</li>
       </ul>
     </div>
@@ -31,16 +30,17 @@ function HelpContent() {
 
 export function RoutingRulesTab() {
   const [showHelp, setShowHelp] = useState(false);
-  const [bulkApplyOpen, setBulkApplyOpen] = useState(false);
 
   const activeOrgId = useOrgContextStore((s) => s.activeOrgId);
   const { data: rules = [], isLoading: rulesLoading } = useRoutingRules();
   const { data: routingDefault } = useRoutingDefault();
   const reorderMutation = useReorderRules();
   const toggleMutation = useToggleRule();
-  const openSlideOver = useRoutingRuleStore((s) => s.openSlideOver);
+  const { openPanel } = usePanelStore();
 
-  const { data: workspaces = [] } = useWorkspaces(activeOrgId);
+  const { workspaces = [] } = useWorkspaces(activeOrgId);
+  const bulkApply = useBulkApplyRules();
+  const [bulkDryRunResult, setBulkDryRunResult] = useState<{ matched: number; details: Array<{ matchedRuleName: string }> } | null>(null);
 
   const workspaceNames: Record<string, string> = {};
   for (const ws of workspaces) {
@@ -53,11 +53,11 @@ export function RoutingRulesTab() {
   const hasRules = rules.length > 0;
 
   function handleOpenCreate() {
-    openSlideOver(null);
+    openPanel('routing-rule', { type: 'routing-rule', ruleId: null });
   }
 
   function handleEdit(id: string) {
-    openSlideOver(id);
+    openPanel('routing-rule', { type: 'routing-rule', ruleId: id });
   }
 
   function handleToggle(id: string, enabled: boolean) {
@@ -66,6 +66,16 @@ export function RoutingRulesTab() {
 
   function handleReorder(orderedIds: string[]) {
     reorderMutation.mutate(orderedIds);
+  }
+
+  async function handleBulkDryRun() {
+    const result = await bulkApply.mutateAsync({ dryRun: true });
+    setBulkDryRunResult(result);
+  }
+
+  async function handleBulkApply() {
+    await bulkApply.mutateAsync({ dryRun: false });
+    setBulkDryRunResult(null);
   }
 
   if (rulesLoading) {
@@ -97,40 +107,104 @@ export function RoutingRulesTab() {
       )}
 
       {hasRules && (
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={handleOpenCreate}
-            disabled={!hasDefault}
-            title={!hasDefault ? 'Set a default destination above before creating rules' : undefined}
-            className={cn(
-              'rounded-lg px-4 py-2 text-sm font-semibold',
-              'bg-foreground text-background',
-              'hover:bg-foreground/90 transition-colors',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              'disabled:opacity-50 disabled:cursor-not-allowed',
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleOpenCreate}
+              disabled={!hasDefault}
+              title={!hasDefault ? 'Set a default destination above before creating rules' : undefined}
+              className={cn(
+                'rounded-lg px-4 py-2 text-sm font-semibold',
+                'bg-foreground text-background',
+                'hover:bg-foreground/90 transition-colors',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+            >
+              Create Rule
+            </button>
+            {!hasDefault && (
+              <p className="text-xs text-amber-500">
+                Set a default destination above before creating rules
+              </p>
             )}
-          >
-            Create Rule
-          </button>
-          <button
-            type="button"
-            onClick={() => setBulkApplyOpen(true)}
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-semibold',
-              'border border-border/60 text-foreground',
-              'hover:bg-muted transition-colors',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          </div>
+
+          {/* Bulk Apply section */}
+          <div className="rounded-xl border border-border/50 bg-muted/20 p-4 space-y-3">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold text-foreground flex items-center gap-1.5">
+                  <RiFlashlightLine className="h-4 w-4 text-amber-500" />
+                  Apply to existing calls
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Retroactively route historical calls to match your current rules. Calls already in a Hub are skipped.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  type="button"
+                  onClick={handleBulkDryRun}
+                  disabled={bulkApply.isPending}
+                  className={cn(
+                    'rounded-lg px-3 py-1.5 text-xs font-medium',
+                    'border border-border bg-background text-foreground',
+                    'hover:bg-muted transition-colors',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    'disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5',
+                  )}
+                >
+                  {bulkApply.isPending ? <RiLoader2Line className="h-3 w-3 animate-spin" /> : null}
+                  Preview
+                </button>
+                <button
+                  type="button"
+                  onClick={handleBulkApply}
+                  disabled={bulkApply.isPending}
+                  className={cn(
+                    'rounded-lg px-3 py-1.5 text-xs font-semibold',
+                    'bg-foreground text-background',
+                    'hover:bg-foreground/90 transition-colors',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    'disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5',
+                  )}
+                >
+                  {bulkApply.isPending ? <RiLoader2Line className="h-3 w-3 animate-spin" /> : null}
+                  Apply Now
+                </button>
+              </div>
+            </div>
+
+            {/* Dry run result summary */}
+            {bulkDryRunResult && (
+              <div className="rounded-lg border border-amber-400/30 bg-amber-50/10 dark:bg-amber-900/10 p-3">
+                {bulkDryRunResult.matched === 0 ? (
+                  <p className="text-xs text-muted-foreground">No existing calls match your current rules.</p>
+                ) : (
+                  <>
+                    <p className="text-xs font-semibold text-foreground mb-1.5">
+                      Preview: {bulkDryRunResult.matched} call{bulkDryRunResult.matched !== 1 ? 's' : ''} would be routed
+                    </p>
+                    <div className="space-y-0.5 max-h-24 overflow-y-auto">
+                      {bulkDryRunResult.details.slice(0, 10).map((d, i) => (
+                        <p key={i} className="text-[11px] text-muted-foreground truncate">
+                          <span className="text-foreground/60">Rule:</span> {d.matchedRuleName}
+                        </p>
+                      ))}
+                      {bulkDryRunResult.details.length > 10 && (
+                        <p className="text-[11px] text-muted-foreground">+{bulkDryRunResult.details.length - 10} more...</p>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-1.5">
+                      Click "Apply Now" to confirm routing.
+                    </p>
+                  </>
+                )}
+              </div>
             )}
-          >
-            <RiPlayCircleLine size={16} />
-            Apply to existing
-          </button>
-          {!hasDefault && (
-            <p className="text-xs text-amber-500">
-              Set a default destination above before creating rules
-            </p>
-          )}
+          </div>
         </div>
       )}
 
@@ -147,7 +221,7 @@ export function RoutingRulesTab() {
           </h2>
 
           <p className="text-sm text-muted-foreground max-w-sm mb-6">
-            Send calls from each source to the right workspace and folder as soon as they're imported.
+            Send calls from each source to the right hub and folder as soon as they're imported.
             No more dragging recordings around.
           </p>
 
@@ -189,9 +263,6 @@ export function RoutingRulesTab() {
           )}
         </div>
       )}
-
-      <RoutingRuleSlideOver />
-      <BulkApplyDialog open={bulkApplyOpen} onOpenChange={setBulkApplyOpen} />
     </div>
   );
 }

--- a/src/components/import/RoutingTraceBadge.tsx
+++ b/src/components/import/RoutingTraceBadge.tsx
@@ -5,6 +5,8 @@
 import { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
 import { cn } from '@/lib/utils';
+import { RiNodeTree } from '@remixicon/react';
+import { Badge } from '@/components/ui/badge';
 
 interface RoutingTraceBadgeProps {
   sourceMetadata: Record<string, unknown> | null | undefined;
@@ -47,17 +49,13 @@ export function RoutingTraceBadge({ sourceMetadata }: RoutingTraceBadgeProps) {
           }}
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
-          className={cn(
-            'inline-flex items-center rounded-full px-2 py-0.5',
-            'bg-muted text-muted-foreground',
-            'text-[11px] font-medium',
-            'cursor-pointer hover:bg-muted/80 transition-colors',
-            'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-            'shrink-0',
-          )}
+          className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
           aria-label={`Routed by rule: ${ruleName}`}
         >
-          Routed by: {ruleName}
+          <Badge variant="outline" className="text-[9px] md:text-2xs px-1 md:px-1.5 py-0 h-3.5 md:h-4 flex items-center gap-0.5 cursor-pointer hover:bg-muted/50 transition-colors">
+            <RiNodeTree className="h-2.5 w-2.5 text-muted-foreground" />
+            <span className="text-muted-foreground">{ruleName}</span>
+          </Badge>
         </button>
       </Popover.Trigger>
 

--- a/src/components/import/SourceCard.tsx
+++ b/src/components/import/SourceCard.tsx
@@ -226,9 +226,9 @@ export function SourceCard({
               type="button"
               onClick={onSync}
               className={cn(
-                'flex-1 rounded-lg border border-border py-1.5 px-3',
-                'text-xs font-medium text-foreground',
-                'hover:bg-muted/60 transition-colors',
+                'flex-1 rounded-lg bg-gradient-to-b from-[#627285] to-[#394655] py-1.5 px-3',
+                'text-xs font-medium text-white',
+                'hover:from-[#6d7f93] hover:to-[#445566] transition-colors',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
               )}
             >

--- a/src/components/layout/DetailPaneOutlet.tsx
+++ b/src/components/layout/DetailPaneOutlet.tsx
@@ -27,6 +27,7 @@ import { CallDetailPanel } from '@/components/panels/CallDetailPanel';
 import { WorkspaceMemberPanel } from '@/components/panels/WorkspaceMemberPanel';
 import { OrganizationMemberPanel } from '@/components/panels/OrganizationMemberPanel';
 import { AutomationRulePanel } from '@/components/panels/AutomationRulePanel';
+import { RoutingRulePanel } from '@/components/panels/RoutingRulePanel';
 import { WorkspaceDetailPanel } from '@/components/panels/WorkspaceDetailPanel';
 import { BulkActionToolbarEnhanced } from '@/components/transcript-library/BulkActionToolbarEnhanced';
 
@@ -113,6 +114,11 @@ export function DetailPaneOutlet({
           <AutomationRulePanel ruleId={panelData.ruleId} />
         ) : null;
         
+      case 'routing-rule':
+        return panelData?.type === 'routing-rule' ? (
+          <RoutingRulePanel ruleId={panelData.ruleId} />
+        ) : null;
+
       case 'bulk-actions':
         return panelData?.type === 'bulk-actions' ? (
           <BulkActionToolbarEnhanced
@@ -159,6 +165,8 @@ export function DetailPaneOutlet({
         return 'Organization member panel';
       case 'automation-rule':
         return 'Automation rule detail panel';
+      case 'routing-rule':
+        return 'Routing rule panel';
       case 'bulk-actions':
         return 'Bulk actions panel';
       default:

--- a/src/components/panels/RoutingRulePanel.tsx
+++ b/src/components/panels/RoutingRulePanel.tsx
@@ -1,0 +1,275 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RiCloseLine, RiInformationLine, RiFlashlightLine, RiLoader2Line } from '@remixicon/react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import { usePanelStore } from '@/stores/panelStore';
+import { useRoutingRules, useCreateRule, useUpdateRule } from '@/hooks/useRoutingRules';
+import { useRulePreview, useOverlapCheck } from '@/hooks/useRulePreview';
+import { useBulkApplyRules } from '@/hooks/useBulkApplyRules';
+import { useOrgContextStore } from '@/stores/orgContextStore';
+import { RoutingConditionBuilder } from '@/components/import/RoutingConditionBuilder';
+import { DestinationPicker } from '@/components/import/DestinationPicker';
+import { RulePreviewCount } from '@/components/import/RulePreviewCount';
+import type { RoutingCondition, RoutingDestination } from '@/types/routing';
+import { Button } from '@/components/ui/button';
+
+const DEFAULT_CONDITION: RoutingCondition = {
+  field: 'title',
+  operator: 'contains',
+  value: '',
+};
+
+const FIRST_RULE_SUGGESTION: RoutingCondition = {
+  field: 'source',
+  operator: 'equals',
+  value: 'fathom',
+};
+
+interface RuleFormState {
+  name: string;
+  conditions: RoutingCondition[];
+  logicOperator: 'AND' | 'OR';
+  destination: RoutingDestination | null;
+}
+
+export function RoutingRulePanel({ ruleId }: { ruleId: string | null }) {
+  const { closePanel } = usePanelStore();
+  const activeOrgId = useOrgContextStore((s) => s.activeOrgId);
+  const { data: allRules = [] } = useRoutingRules();
+  const createRule = useCreateRule();
+  const updateRule = useUpdateRule();
+  const bulkApply = useBulkApplyRules();
+
+  const [form, setForm] = useState<RuleFormState>({
+    name: '',
+    conditions: [DEFAULT_CONDITION],
+    logicOperator: 'AND',
+    destination: null,
+  });
+
+  const initializeForm = useCallback(() => {
+    if (ruleId === null) {
+      const isFirstRule = allRules.length === 0;
+      setForm({
+        name: '',
+        conditions: [isFirstRule ? FIRST_RULE_SUGGESTION : DEFAULT_CONDITION],
+        logicOperator: 'AND',
+        destination: null,
+      });
+    } else {
+      const existingRule = allRules.find((r) => r.id === ruleId);
+      if (existingRule) {
+        setForm({
+          name: existingRule.name,
+          conditions:
+            existingRule.conditions.length > 0
+              ? existingRule.conditions
+              : [DEFAULT_CONDITION],
+          logicOperator: existingRule.logic_operator,
+          destination: {
+            workspaceId: existingRule.target_workspace_id,
+            folderId: existingRule.target_folder_id,
+          },
+        });
+      }
+    }
+  }, [ruleId, allRules]);
+
+  useEffect(() => {
+    initializeForm();
+  }, [initializeForm]);
+
+  const preview = useRulePreview(form.conditions, form.logicOperator);
+  const overlapInfo = useOverlapCheck(form.conditions, form.logicOperator, ruleId);
+
+  const canSave =
+    form.name.trim().length > 0 &&
+    form.conditions.length > 0 &&
+    form.destination !== null &&
+    !createRule.isPending &&
+    !updateRule.isPending;
+
+  async function handleSave() {
+    if (!canSave || !form.destination) return;
+
+    const payload = {
+      name: form.name.trim(),
+      conditions: form.conditions,
+      logic_operator: form.logicOperator,
+      target_workspace_id: form.destination.workspaceId,
+      target_folder_id: form.destination.folderId,
+      enabled: true,
+    };
+
+    if (ruleId === null) {
+      createRule.mutate(payload, {
+        onSuccess: () => {
+          toast.success('Rule created');
+          closePanel();
+        },
+      });
+    } else {
+      updateRule.mutate(
+        { id: ruleId, updates: payload },
+        {
+          onSuccess: () => {
+            toast.success('Rule updated');
+            closePanel();
+          },
+        }
+      );
+    }
+  }
+
+  const isEditMode = ruleId !== null;
+  const isSaving = createRule.isPending || updateRule.isPending;
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden bg-card">
+      <header className="flex items-center justify-between px-4 py-3 border-b border-border bg-card/50">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide truncate">
+            {isEditMode ? 'Edit Rule' : 'Create Rule'}
+          </h3>
+          <p className="text-xs text-muted-foreground">Routing rule</p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={closePanel} aria-label="Close panel">
+          <RiCloseLine className="h-4 w-4" />
+        </Button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-5 py-5 space-y-5">
+        <div className="flex items-start gap-2 rounded-lg border border-border/50 bg-muted/40 px-3 py-2.5">
+          <RiInformationLine className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+          <p className="text-xs text-muted-foreground">
+            Rules automatically apply to new imports. To route existing historical calls, click "Apply to existing calls" below after saving.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="rule-name" className="block text-sm font-medium text-foreground">
+            Rule name
+          </label>
+          <input
+            id="rule-name"
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm(p => ({ ...p, name: e.target.value }))}
+            placeholder="e.g., Q1 Reviews, Acme Meetings"
+            required
+            className={cn(
+              'w-full h-9 rounded-md border border-border bg-background px-3 py-1',
+              'text-sm text-foreground placeholder:text-muted-foreground',
+              'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0'
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-sm font-medium text-foreground">Conditions</p>
+          <RoutingConditionBuilder
+            conditions={form.conditions}
+            logicOperator={form.logicOperator}
+            onConditionsChange={(c) => setForm(p => ({ ...p, conditions: c }))}
+            onLogicOperatorChange={(o) => setForm(p => ({ ...p, logicOperator: o }))}
+          />
+        </div>
+
+        {activeOrgId && (
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-foreground">
+              Route matching calls to:
+            </label>
+            <DestinationPicker
+              value={form.destination}
+              onChange={(d) => setForm(p => ({ ...p, destination: d }))}
+              orgId={activeOrgId}
+            />
+          </div>
+        )}
+
+        <div className="space-y-1.5 pb-2">
+          <p className="text-sm font-medium text-foreground">Preview</p>
+          <RulePreviewCount
+            matchingCount={preview.matchingCount}
+            matchingCalls={preview.matchingCalls}
+            totalChecked={preview.totalChecked}
+            overlapInfo={overlapInfo}
+            isLoading={preview.isLoading}
+          />
+        </div>
+
+        {isEditMode && (
+          <div className="rounded-xl border border-border/50 bg-muted/20 p-4 space-y-3 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold text-foreground flex items-center gap-1.5">
+                  <RiFlashlightLine className="h-4 w-4 text-amber-500" />
+                  Apply to existing calls
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5 max-w-sm">
+                  Retroactively route historical calls to match your current rule. Calls already in a Hub are skipped.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => bulkApply.mutate({ ruleIds: [ruleId!], dryRun: false })}
+                  disabled={bulkApply.isPending || isSaving}
+                  className={cn(
+                    'rounded-lg px-3 py-1.5 text-xs font-semibold',
+                    'bg-foreground text-background',
+                    'hover:bg-foreground/90 transition-colors',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    'disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5',
+                  )}
+                >
+                  {bulkApply.isPending ? <RiLoader2Line className="h-3 w-3 animate-spin" /> : null}
+                  Apply Now
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
+          <button
+            type="button"
+            onClick={closePanel}
+            disabled={isSaving}
+            className={cn(
+              'h-9 px-4 rounded-md border border-border bg-transparent',
+              'text-sm font-medium text-foreground',
+              'hover:bg-muted transition-colors',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className={cn(
+              'h-9 px-4 rounded-md',
+              'text-sm font-medium',
+              'bg-foreground text-background',
+              'hover:bg-foreground/90 transition-colors',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+          >
+            {isSaving
+              ? isEditMode
+                ? 'Saving...'
+                : 'Creating...'
+              : isEditMode
+              ? 'Save changes'
+              : 'Create rule'}
+          </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transcript-library/ParticipantsFilterPopover.tsx
+++ b/src/components/transcript-library/ParticipantsFilterPopover.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { RiUserLine } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FilterButton } from "./FilterButton";
@@ -17,6 +18,11 @@ export function ParticipantsFilterPopover({
   onParticipantsChange,
 }: ParticipantsFilterPopoverProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredParticipants = allParticipants.filter(p =>
+    p.toLowerCase().includes(searchQuery.toLowerCase())
+  );
 
   const handleToggle = (participant: string, checked: boolean) => {
     if (checked) {
@@ -45,22 +51,35 @@ export function ParticipantsFilterPopover({
           active={selectedParticipants.length > 0}
         />
       </PopoverTrigger>
-      <PopoverContent className="w-80 p-4 bg-white dark:bg-card" align="start">
-        <div className="space-y-3">
-          <div className="text-sm font-medium">Select Participants</div>
-          <div className="max-h-[300px] overflow-y-auto space-y-2">
-            {allParticipants.map((participant) => (
-              <div key={participant} className="flex items-center gap-2">
-                <Checkbox
-                  id={participant}
-                  checked={selectedParticipants.includes(participant)}
-                  onCheckedChange={(checked) => handleToggle(participant, !!checked)}
-                />
-                <label htmlFor={participant} className="text-sm cursor-pointer">
-                  {participant}
-                </label>
+      <PopoverContent className="w-80 p-0 bg-white dark:bg-card" align="start">
+        <div className="flex flex-col">
+          <div className="p-3 border-b">
+            <Input
+              placeholder="Search participants..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 text-xs"
+            />
+          </div>
+          <div className="max-h-[300px] overflow-y-auto p-2 space-y-1">
+            {filteredParticipants.length === 0 ? (
+              <div className="text-sm text-muted-foreground py-6 text-center">
+                {searchQuery ? "No matching participants" : "No participants found"}
               </div>
-            ))}
+            ) : (
+              filteredParticipants.map((participant) => (
+                <div key={participant} className="flex items-center gap-2 px-2 py-1 rounded-md hover:bg-muted/50 transition-colors">
+                  <Checkbox
+                    id={participant}
+                    checked={selectedParticipants.includes(participant)}
+                    onCheckedChange={(checked) => handleToggle(participant, !!checked)}
+                  />
+                  <label htmlFor={participant} className="text-sm cursor-pointer flex-1 py-0.5 truncate">
+                    {participant}
+                  </label>
+                </div>
+              ))
+            )}
           </div>
           <div className="flex justify-end gap-2 pt-2 border-t">
             <Button variant="hollow" size="sm" onClick={handleClear}>

--- a/src/components/transcript-library/TagFilterPopover.tsx
+++ b/src/components/transcript-library/TagFilterPopover.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { RiPriceTag3Line } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,6 +22,13 @@ export function TagFilterPopover({
   onTagsChange,
 }: TagFilterPopoverProps) {
   const { activeOrganizationId } = useOrganizationContext();
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredTags = tags.filter(tag =>
+    tag.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    tag.description?.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
   const handleTagToggle = (tagId: string, checked: boolean) => {
     if (checked) {
       onTagsChange([...selectedTags, tagId]);
@@ -64,18 +72,23 @@ export function TagFilterPopover({
       </PopoverTrigger>
       <PopoverContent className="w-80 p-0 bg-white dark:bg-card" align="start">
         <div className="space-y-0">
-          <div className="p-4 pb-3">
-            <div className="text-sm font-medium">Select Tags</div>
+          <div className="p-2 border-b">
+            <Input
+              placeholder="Search tags..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 text-xs"
+            />
           </div>
-          <div className="max-h-[300px] overflow-y-auto px-2 pb-2">
-            {!tags || tags.length === 0 ? (
+          <div className="max-h-[300px] overflow-y-auto px-2 pb-2 mt-2">
+            {!filteredTags || filteredTags.length === 0 ? (
               <div className="text-sm text-muted-foreground py-4 text-center px-2">
-                No tags yet. Add one below.
+                {searchQuery ? "No matching tags found" : "No tags yet. Add one below."}
               </div>
             ) : (
-              <div className="space-y-2 px-2">
-                {tags.map((tag) => (
-                  <div key={tag.id} className="flex items-center gap-2">
+              <div className="space-y-1.5 px-2">
+                {filteredTags.map((tag) => (
+                  <div key={tag.id} className="flex items-center gap-2 py-0.5">
                     <Checkbox
                       id={`tag-${tag.id}`}
                       checked={selectedTags.includes(tag.id)}

--- a/src/hooks/useBulkApplyRules.ts
+++ b/src/hooks/useBulkApplyRules.ts
@@ -1,0 +1,96 @@
+/**
+ * useBulkApplyRules — mutation hook for retroactively applying routing rules.
+ */
+
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
+
+interface BulkApplyOptions {
+  dryRun?: boolean;
+  ruleIds?: string[];
+  limit?: number;
+}
+
+interface BulkApplyResult {
+  processed: number;
+  matched: number;
+  assigned: number;
+  skipped: number;
+  dryRun: boolean;
+  details: Array<{
+    recordingId: string;
+    title: string;
+    matchedRuleId: string;
+    matchedRuleName: string;
+    workspaceId: string;
+    folderId: string | null;
+    action: 'assigned' | 'skipped';
+  }>;
+}
+
+export function useBulkApplyRules() {
+  return useMutation<BulkApplyResult, Error, BulkApplyOptions>({
+    mutationFn: async (opts: BulkApplyOptions) => {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const accessToken = sessionData?.session?.access_token;
+      if (!accessToken) {
+        throw new Error('Not authenticated — please sign in and try again.');
+      }
+
+      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+      const res = await fetch(
+        `${supabaseUrl}/functions/v1/bulk-apply-routing-rules`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+            apikey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string,
+          },
+          body: JSON.stringify({
+            dryRun: opts.dryRun ?? false,
+            ruleIds: opts.ruleIds,
+            limit: opts.limit ?? 1000,
+          }),
+        }
+      );
+
+      const payload = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        const msg = (payload as Record<string, string>)?.error ?? (payload as Record<string, string>)?.message ?? `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+
+      if ((payload as Record<string, string>)?.error) throw new Error((payload as Record<string, string>).error);
+
+      return payload as BulkApplyResult;
+    },
+    onSuccess: (result) => {
+      if (result.dryRun) {
+        if (result.matched === 0) {
+          toast.info('Dry run complete — no existing calls match current rules');
+        } else {
+          toast.success(
+            `Dry run: ${result.matched} call${result.matched !== 1 ? 's' : ''} would be routed across ${new Set(result.details.map(d => d.matchedRuleName)).size} rule${result.matched !== 1 ? 's' : ''}`
+          );
+        }
+      } else {
+        if (result.assigned === 0) {
+          toast.info(result.skipped > 0
+            ? `${result.skipped} call${result.skipped !== 1 ? 's' : ''} already assigned — nothing new to route`
+            : 'No existing calls matched the current rules'
+          );
+        } else {
+          toast.success(
+            `Bulk applied: ${result.assigned} call${result.assigned !== 1 ? 's' : ''} routed${result.skipped > 0 ? `, ${result.skipped} already assigned` : ''}`
+          );
+        }
+      }
+    },
+    onError: (error) => {
+      toast.error(`Bulk apply failed: ${error.message}`);
+    },
+  });
+}

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -2,11 +2,12 @@ import { useState } from "react";
 import { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
 
 export function useDragAndDrop() {
-  const [activeDragId, setActiveDragId] = useState<number | null>(null);
-  const [draggedItems, setDraggedItems] = useState<number[]>([]);
+  const [activeDragId, setActiveDragId] = useState<string | number | null>(null);
+  const [draggedItems, setDraggedItems] = useState<(string | number)[]>([]);
 
-  const handleDragStart = (event: DragStartEvent, selectedIds: number[]) => {
-    const draggedId = Number(event.active.id);
+  const handleDragStart = (event: DragStartEvent, selectedIds: (string | number)[]) => {
+    const rawId = event.active.id;
+    const draggedId = typeof rawId === 'string' ? rawId : Number(rawId);
     setActiveDragId(draggedId);
     
     // If dragging a selected item, drag all selected items

--- a/src/hooks/useRulePreview.ts
+++ b/src/hooks/useRulePreview.ts
@@ -68,6 +68,7 @@ function evaluateSingleCondition(condition: RoutingCondition, call: PreviewCall)
       case 'contains':     return h.includes(n);
       case 'not_contains': return !h.includes(n);
       case 'equals':       return h === n;
+      case 'not_equals':   return h !== n;
       case 'starts_with':  return h.startsWith(n);
       default:             return false;
     }
@@ -102,8 +103,10 @@ function evaluateSingleCondition(condition: RoutingCondition, call: PreviewCall)
     case 'tag': {
       const tags = call.global_tags ?? [];
       const needle = String(value).toLowerCase();
-      if (operator === 'equals')   return tags.some((t) => t.toLowerCase() === needle);
-      if (operator === 'contains') return tags.some((t) => t.toLowerCase().includes(needle));
+      if (operator === 'equals')       return tags.some((t) => t.toLowerCase() === needle);
+      if (operator === 'not_equals')   return tags.every((t) => t.toLowerCase() !== needle);
+      if (operator === 'contains')     return tags.some((t) => t.toLowerCase().includes(needle));
+      if (operator === 'not_contains') return tags.every((t) => !t.toLowerCase().includes(needle));
       return false;
     }
 

--- a/src/pages/RoutingRulesPage.tsx
+++ b/src/pages/RoutingRulesPage.tsx
@@ -1,0 +1,28 @@
+import { RiRouteLine } from '@remixicon/react';
+import { AppShell } from '@/components/layout/AppShell';
+import { PageHeader } from '@/components/ui/page-header';
+import WorkspaceSidebarPane from '@/components/panes/WorkspaceSidebarPane';
+import { RoutingRulesTab } from '@/components/import/RoutingRulesTab';
+
+export default function RoutingRulesPage() {
+  return (
+    <AppShell
+      config={{
+        secondaryPane: <WorkspaceSidebarPane />,
+        showDetailPane: true,
+      }}
+    >
+      <div className="flex flex-col h-full overflow-hidden">
+        <PageHeader
+          title="Routing Rules"
+          subtitle="Automatically organize and route your incoming calls"
+          icon={RiRouteLine}
+        />
+
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          <RoutingRulesTab />
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -24,6 +24,7 @@ export type PanelType =
   | 'workspace_members'
   | 'organization_members'
   | 'automation-rule'
+  | 'routing-rule'
   | null;
 
 /**
@@ -59,6 +60,7 @@ export type PanelData =
   | { type: 'workspace_members'; workspaceId: string; workspaceName?: string }
   | { type: 'organization_members'; organizationId: string; organizationName?: string }
   | { type: 'automation-rule'; ruleId: string }
+  | { type: 'routing-rule'; ruleId: string | null }
   | null;
 
 /**


### PR DESCRIPTION
## Summary
- Ports routing rules page, condition builder improvements, filter search, drag-and-drop UUID support, and bulk apply UI from brain-antigravity
- Adds dedicated `/rules` route with RoutingRulesPage and RoutingRulePanel (detail pane pattern)
- Adds `not_equals` operator across all routing condition fields and search inputs to Participants/Tag filter popovers

## Changes

### New files
- `src/pages/RoutingRulesPage.tsx` — standalone routing rules page with AppShell
- `src/components/panels/RoutingRulePanel.tsx` — detail pane for create/edit rules
- `src/hooks/useBulkApplyRules.ts` — mutation hook for retroactive rule application

### Modified files (15)
- **RoutingConditionBuilder** — `not_equals` operator for title, participant, source, tag
- **useRulePreview** — `not_equals`/`not_contains` evaluation logic for tags
- **RoutingRuleCard** — text wrapping fix (whitespace-normal break-words)
- **RoutingTraceBadge** — redesigned as compact Badge with tree icon
- **DefaultDestinationBar** — responsive layout (flex-col on mobile)
- **SourceCard** — sync button uses default gradient styling
- **ParticipantsFilterPopover** — search input with filtered results
- **TagFilterPopover** — search input with filtered results
- **personal-tags.service** — graceful 42P01 handling
- **DestinationPicker** — responsive layout, fixed useWorkspaces destructuring
- **RoutingRulesTab** — full rewrite with inline bulk apply + dry-run preview
- **useDragAndDrop** — UUID-compatible types (string | number)
- **panel.ts** — `routing-rule` panel type
- **DetailPaneOutlet** — RoutingRulePanel render case
- **App.tsx** — `/rules` route

### NOT ported (per issue)
- TranscriptsTab changes (missing escapeIlike = SQL injection risk)
- Migration files, RoutingRuleSlideOver deletion, AppShell changes
- No `as any` casts, no orange button variant

## Test plan
- [ ] Verify `/rules` route loads RoutingRulesPage correctly
- [ ] Create a new routing rule via the detail panel
- [ ] Edit an existing rule and verify conditions save
- [ ] Test `not_equals` operator in condition builder
- [ ] Test bulk apply dry-run and apply-now functionality
- [ ] Test search in Participants and Tag filter popovers
- [ ] Verify RoutingTraceBadge renders with icon on routed calls
- [ ] Verify DefaultDestinationBar responsive layout on mobile
- [ ] Confirm type-check passes (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #91