### PR TITLE
design(92): unified button system + fix collapsed sidebar icons

### DIFF
--- a/src/components/ui/__tests__/sidebar-nav.test.tsx
+++ b/src/components/ui/__tests__/sidebar-nav.test.tsx
@@ -404,20 +404,12 @@ describe('SidebarNav', () => {
       expect(mutedIcons.length).toBeGreaterThanOrEqual(3);
     });
 
-    it('should have orange ring on active NavIcon in collapsed mode', () => {
+    it('should have orange tint on active item in collapsed mode', () => {
       const { container } = renderWithRouter({ isCollapsed: true }, ['/']);
 
-      // Active NavIcon should have ring-vibe-orange class (via ring-2 ring-vibe-orange/50)
-      const activeNavIconWrapper = container.querySelector('.ring-vibe-orange\\/50');
-      expect(activeNavIconWrapper).toBeInTheDocument();
-    });
-
-    it('should not have orange ring on inactive NavIcon in collapsed mode', () => {
-      const { container } = renderWithRouter({ isCollapsed: true }, ['/']);
-
-      // Count elements with ring styling - only active item should have it
-      const ringElements = container.querySelectorAll('.ring-vibe-orange\\/50');
-      expect(ringElements.length).toBe(1);
+      // Active collapsed item should have bg-vibe-orange/10 tint
+      const activeItem = container.querySelector('.bg-vibe-orange\\/10');
+      expect(activeItem).toBeInTheDocument();
     });
 
     it('should apply gray background on active item in expanded mode', () => {
@@ -436,12 +428,12 @@ describe('SidebarNav', () => {
       expect(homeButton).not.toHaveClass('bg-gray-100');
     });
 
-    it('should render glossy 3D icon wrapper in collapsed mode', () => {
+    it('should render clean icons without glossy wrapper in collapsed mode', () => {
       const { container } = renderWithRouter({ isCollapsed: true });
 
-      // NavIcon should have gradient background for glossy effect
+      // NavIcon glossy wrapper should NOT be present — icons render clean
       const glossyWrapper = container.querySelector('.bg-gradient-to-br.from-white.to-gray-200');
-      expect(glossyWrapper).toBeInTheDocument();
+      expect(glossyWrapper).not.toBeInTheDocument();
     });
 
     it('should show active text color on label when active in expanded mode', () => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,38 +17,42 @@ const buttonVariants = cva(
     variants: {
       variant: {
         /**
-         * 1. PRIMARY / DEFAULT — Glossy slate gradient for main actions.
-         *    Same appearance in light and dark mode (no change needed).
+         * 1. PRIMARY / DEFAULT — Slate gradient, subtle depth.
+         *    Apple-inspired: suggests dimension without heavy 3D.
+         *    Same appearance in light and dark mode.
          */
         default: [
           "bg-gradient-to-b from-[#627285] to-[#394655]",
           "border border-[rgba(57,70,85,0.8)]",
-          "text-white [text-shadow:0_1px_2px_rgba(0,0,0,0.25)]",
-          "shadow-[inset_0_4px_6px_rgba(255,255,255,0.25),inset_0_-4px_6px_rgba(0,0,0,0.35),0_10px_20px_rgba(61,74,91,0.2)]",
+          "text-white [text-shadow:0_1px_1px_rgba(0,0,0,0.2)]",
+          "shadow-[inset_0_1px_0_rgba(255,255,255,0.15),0_1px_3px_rgba(0,0,0,0.12),0_2px_8px_rgba(61,74,91,0.1)]",
           "active:translate-y-px active:scale-[0.98]",
           "rounded-xl",
         ],
 
         /**
-         * 2. HOLLOW / PLAIN — Simple border for secondary actions.
+         * 2. HOLLOW — Bordered secondary action with subtle gradient.
+         *    Shares the same design language as default (lighter treatment).
          *    Adapts between light and dark mode.
          */
         hollow: [
-          "bg-background border border-border text-foreground",
-          "hover:bg-muted hover:border-border/80",
-          "dark:bg-card dark:hover:bg-secondary",
+          "bg-gradient-to-b from-white to-gray-50 border border-border text-foreground",
+          "shadow-[inset_0_1px_0_rgba(255,255,255,0.6),0_1px_2px_rgba(0,0,0,0.06)]",
+          "hover:bg-gradient-to-b hover:from-gray-50 hover:to-gray-100 hover:border-border/80",
+          "dark:from-card dark:to-secondary dark:hover:from-secondary dark:hover:to-secondary/80",
+          "dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_2px_rgba(0,0,0,0.2)]",
           "rounded-xl",
         ],
 
         /**
-         * 3. DESTRUCTIVE — Red gradient for dangerous actions.
+         * 3. DESTRUCTIVE — Red gradient with same subtle depth as default.
          *    Same appearance in light and dark mode.
          */
         destructive: [
           "bg-gradient-to-b from-[#E54D4D] to-[#C93A3A]",
           "border border-[rgba(190,50,50,0.8)]",
-          "text-white [text-shadow:0_1px_2px_rgba(0,0,0,0.25)]",
-          "shadow-[inset_0_4px_6px_rgba(255,255,255,0.25),inset_0_-4px_6px_rgba(0,0,0,0.3),0_10px_20px_rgba(0,0,0,0.15)]",
+          "text-white [text-shadow:0_1px_1px_rgba(0,0,0,0.2)]",
+          "shadow-[inset_0_1px_0_rgba(255,255,255,0.15),0_1px_3px_rgba(0,0,0,0.12),0_2px_8px_rgba(0,0,0,0.08)]",
           "active:translate-y-px active:scale-[0.98]",
           "rounded-xl",
         ],
@@ -76,12 +80,15 @@ const buttonVariants = cva(
 
         /**
          * 6. OUTLINE — Subtle bordered for toggleable/selectable items.
+         *    Light gradient hint ties it to the same family as default/hollow.
          */
         outline: [
-          "bg-transparent border border-border/40 text-muted-foreground",
-          "hover:bg-muted/50 hover:text-foreground hover:border-border",
-          "dark:border-border dark:text-muted-foreground",
-          "dark:hover:bg-secondary/50 dark:hover:text-white dark:hover:border-border/80",
+          "bg-gradient-to-b from-white/80 to-transparent border border-border/40 text-muted-foreground",
+          "shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
+          "hover:bg-gradient-to-b hover:from-gray-50 hover:to-transparent hover:text-foreground hover:border-border",
+          "dark:from-transparent dark:border-border dark:text-muted-foreground",
+          "dark:hover:from-secondary/30 dark:hover:text-white dark:hover:border-border/80",
+          "dark:shadow-[0_1px_2px_rgba(0,0,0,0.1)]",
           "rounded-lg",
         ],
       },

--- a/src/components/ui/sidebar-nav.tsx
+++ b/src/components/ui/sidebar-nav.tsx
@@ -2,24 +2,23 @@
  * Sidebar Navigation
  *
  * Navigation icons that sit at the top of the sidebar.
- * Loop-inspired design with clean, modern aesthetics.
+ * Clean, modern aesthetics — same icon style in both expanded and collapsed modes.
  * Uses Remix Icons with line/fill variants for active states.
  *
  * ## Design Specification
  *
  * - **Position**: Top of sidebar, above folder list
  * - **Layout**: Vertical column with icons and labels
- * - **Size**: 44x44px icon buttons (collapsed) or full-width items (expanded)
+ * - **Size**: Consistent icon size in both modes, centered when collapsed
  * - **Styling**:
- *   - Clean, modern appearance
- *   - Glossy 3D icons in collapsed mode
+ *   - Clean, cohesive appearance in both modes
  *   - Active state: left border indicator (vibe orange) + fill icon
  *   - Inactive state: line icon
  *   - Hover: subtle background highlight
  * - **Separator**: Thin gray line between sections
  *
  * @pattern sidebar-nav
- * @brand-version v4.1
+ * @brand-version v4.2
  */
 
 import * as React from 'react';
@@ -28,12 +27,7 @@ import {
   RiLayoutColumnLine,
   RiAddLine,
   RiHome4Line,
-  RiSparklingLine,
-  RiArticleLine,
-  RiPriceTag3Line,
-  RiSafeLine,
   RiSettings3Line,
-  RiPieChart2Line,
   RiUpload2Line,
 } from '@remixicon/react';
 import type { RemixiconComponentType } from '@remixicon/react';
@@ -66,69 +60,6 @@ interface SidebarNavProps {
   /** Optional callback when Analytics nav item is clicked (to open category pane) */
   onAnalyticsClick?: () => void;
 }
-
-/**
- * NavIcon Props - supports both Remix Icon components and React nodes
- */
-interface NavIconProps {
-  /** Remix Icon component type for line variant (inactive state) */
-  icon?: RemixiconComponentType;
-  /** Whether the icon is in active state */
-  isActive?: boolean;
-  /** Optional children (for backward compatibility with pre-rendered icons) */
-  children?: React.ReactNode;
-}
-
-/**
- * Glossy 3D icon wrapper with dark mode support.
- * Light mode: White to light gray gradient
- * Dark mode: Dark gray gradient with adjusted shadows
- *
- * Supports two usage patterns:
- * 1. Pass Remix Icon components directly via icon props
- * 2. Pass pre-rendered React nodes as children (backward compatible)
- */
-const NavIcon = React.memo(({ icon: IconLine, isActive, children }: NavIconProps) => {
-  // Determine which icon to render based on props and active state
-  const renderIcon = () => {
-    // If icon components are provided, render the appropriate one
-    if (IconLine) {
-      const IconComponent = IconLine;
-      if (IconComponent) {
-        return (
-          <IconComponent
-            className={cn(
-              iconClass,
-              isActive && "text-vibe-orange"
-            )}
-          />
-        );
-      }
-    }
-    // Fall back to children for backward compatibility
-    return children;
-  };
-
-  return (
-    <div
-      className={cn(
-        'w-full h-full flex items-center justify-center rounded-xl transition-all duration-150',
-        // Light mode styles
-        'bg-gradient-to-br from-white to-gray-200',
-        'border border-border',
-        'shadow-[inset_0_4px_6px_rgba(255,255,255,0.5),inset_0_-4px_6px_rgba(0,0,0,0.08),0_10px_20px_rgba(0,0,0,0.08)]',
-        // Dark mode styles
-        'dark:from-gray-700 dark:to-gray-800',
-        'dark:border-border',
-        'dark:shadow-[inset_0_4px_6px_rgba(255,255,255,0.1),inset_0_-4px_6px_rgba(0,0,0,0.2),0_10px_20px_rgba(0,0,0,0.3)]',
-        // Active state
-        isActive && 'ring-2 ring-vibe-orange/50'
-      )}
-    >
-      {renderIcon()}
-    </div>
-  );
-});
 
 // Icon class for consistent styling - muted gray for inactive state
 const iconClass = 'w-5 h-5 text-muted-foreground';
@@ -310,9 +241,10 @@ export function SidebarNav({ isCollapsed, className, onSyncClick, onLibraryToggl
                 onKeyDown={(e) => handleKeyDown(e, item.id)}
                 className={cn(
                   'relative flex items-center',
-                  isCollapsed ? 'justify-center w-11 h-11 px-0' : 'justify-start w-full px-3 h-10 gap-3',
+                  isCollapsed ? 'justify-center w-10 h-10 px-0' : 'justify-start w-full px-3 h-10 gap-3',
                   'rounded-lg border border-transparent transition-all duration-500 ease-in-out',
                   'hover:bg-hover/70',
+                  isCollapsed && active && 'bg-vibe-orange/10',
                   active && !isCollapsed && [
                     'bg-hover border-border pl-4',
                     "before:content-[''] before:absolute before:left-1 before:top-1/2 before:-translate-y-1/2 before:w-1 before:h-[65%] before:rounded-full before:bg-vibe-orange"
@@ -321,24 +253,15 @@ export function SidebarNav({ isCollapsed, className, onSyncClick, onLibraryToggl
                 )}
                 title={item.name}
               >
-                  {/* Icon Container */}
+                  {/* Icon — same clean rendering in both modes */}
                   <div className={cn(
                       "flex-shrink-0 flex items-center justify-center",
-                       isCollapsed ? "w-11 h-11" : "w-5 h-5"
+                       isCollapsed ? "w-10 h-10" : "w-5 h-5"
                   )}>
-                     {isCollapsed ? (
-                       // Collapsed mode: Use NavIcon with icon props for glossy 3D effect
-                        <NavIcon
-                          icon={item.iconLine}
-                          isActive={active}
-                        />
-                     ) : (
-                       // Expanded mode: Render icon directly
-                       (() => {
-                          const IconComponent = item.iconLine;
-                         return <IconComponent className={cn(iconClass, active && "text-vibe-orange")} />;
-                       })()
-                     )}
+                     {(() => {
+                        const IconComponent = item.iconLine;
+                        return <IconComponent className={cn(iconClass, active && "text-vibe-orange")} />;
+                     })()}
                   </div>
 
                   {/* Label - Visible only when expanded */}
@@ -373,13 +296,9 @@ export function SidebarNav({ isCollapsed, className, onSyncClick, onLibraryToggl
             >
                <div className={cn(
                       "flex-shrink-0 flex items-center justify-center",
-                       isCollapsed ? "w-11 h-11" : "w-5 h-5 text-muted-foreground"
+                       isCollapsed ? "w-10 h-10" : "w-5 h-5 text-muted-foreground"
                   )}>
-                  {isCollapsed ? (
-                      <NavIcon icon={RiLayoutColumnLine} />
-                  ) : (
-                    <RiLayoutColumnLine className="w-5 h-5" />
-                  )}
+                  <RiLayoutColumnLine className={iconClass} />
               </div>
               {!isCollapsed && <span className="text-sm text-muted-foreground truncate">Hub Panel</span>}
             </button>


### PR DESCRIPTION
## Summary

- **Button variants unified**: Replaced heavy glossy shadows (`inset_0_4px_6px` + `0_10px_20px`) with subtle Apple-inspired depth (`inset_0_1px_0` + `0_1px_3px` + `0_2px_8px`). Hollow and outline variants now share gradient design language with default/destructive — cohesive button family.
- **Collapsed sidebar icons fixed**: Removed the NavIcon glossy 3D wrapper (44x44px gradient boxes with heavy inset shadows). Collapsed mode now renders the same clean icon as expanded mode, just centered. Active state uses `bg-vibe-orange/10` tint.
- **Dead code removed**: ~80 lines of NavIcon component, unused interfaces, and 5 unused icon imports cleaned up.

Closes #92

## Test plan

- [ ] Verify button variants render with subtle depth, not heavy 3D shadows
- [ ] Verify collapsed sidebar shows clean icons matching expanded mode style
- [ ] Verify active state in collapsed mode shows orange tint background
- [ ] Verify hollow and outline buttons feel like siblings of the default variant
- [ ] Verify dark mode still works for adaptive variants (hollow, outline, ghost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)