### PR TITLE
feat(99): cross-org routing rules

### DIFF
--- a/src/components/import/DestinationPicker.tsx
+++ b/src/components/import/DestinationPicker.tsx
@@ -1,17 +1,23 @@
 /**
- * DestinationPicker — Cascading workspace > folder select for routing destinations.
+ * DestinationPicker — Cascading org > workspace > folder select for routing destinations.
+ *
+ * When the user has multiple org memberships, an org selector appears first.
+ * Selecting a different org shows a workspace picker for that org (cross-org routing).
+ * Selecting the current org shows the existing workspace + folder picker.
  */
 
 import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { useFolders } from '@/hooks/useFolders';
+import { useOrganizations } from '@/hooks/useOrganizations';
 import type { RoutingDestination } from '@/types/routing';
 
 interface DestinationPickerProps {
   value: RoutingDestination | null;
   onChange: (dest: RoutingDestination) => void;
-  orgId: string;
+  /** The organization that owns the routing rule (current active org). */
+  currentOrgId: string;
   disabled?: boolean;
   className?: string;
 }
@@ -27,24 +33,54 @@ const selectClass = cn(
 export function DestinationPicker({
   value,
   onChange,
-  orgId,
+  currentOrgId,
   disabled = false,
   className,
 }: DestinationPickerProps) {
-  const { workspaces = [], isLoading: workspacesLoading } = useWorkspaces(orgId);
-  const { data: folders = [], isLoading: foldersLoading } = useFolders(value?.workspaceId ?? null);
+  // Determine the effective target org (null = same as current org)
+  const targetOrgId = value?.targetOrganizationId ?? null;
+  const effectiveOrgId = targetOrgId ?? currentOrgId;
 
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(value?.workspaceId ?? null);
+  const { data: allOrgs = [], isLoading: orgsLoading } = useOrganizations();
+  const { workspaces = [], isLoading: workspacesLoading } = useWorkspaces(effectiveOrgId);
+  const { data: folders = [], isLoading: foldersLoading } = useFolders(
+    // Only load folders for same-org selection (cross-org rules land in HOME workspace)
+    targetOrgId ? null : (value?.workspaceId ?? null)
+  );
+
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
+    value?.workspaceId ?? null
+  );
 
   useEffect(() => {
     setSelectedWorkspaceId(value?.workspaceId ?? null);
   }, [value?.workspaceId]);
 
+  // Show org selector only when user belongs to more than one org
+  const showOrgSelector = allOrgs.length > 1;
+
+  function handleOrgChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const selectedOrgId = e.target.value || currentOrgId;
+    const isCrossOrg = selectedOrgId !== currentOrgId;
+
+    // Reset workspace/folder selection when org changes
+    setSelectedWorkspaceId(null);
+    onChange({
+      workspaceId: '',
+      folderId: null,
+      targetOrganizationId: isCrossOrg ? selectedOrgId : null,
+    });
+  }
+
   function handleWorkspaceChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const workspaceId = e.target.value || null;
     setSelectedWorkspaceId(workspaceId);
     if (workspaceId) {
-      onChange({ workspaceId, folderId: null });
+      onChange({
+        workspaceId,
+        folderId: null,
+        targetOrganizationId: targetOrgId,
+      });
     }
   }
 
@@ -52,11 +88,38 @@ export function DestinationPicker({
     if (!selectedWorkspaceId) return;
     const rawValue = e.target.value;
     const folderId = rawValue === '' ? null : rawValue;
-    onChange({ workspaceId: selectedWorkspaceId, folderId });
+    onChange({
+      workspaceId: selectedWorkspaceId,
+      folderId,
+      targetOrganizationId: targetOrgId,
+    });
   }
 
   return (
     <div className={cn('flex flex-wrap items-center gap-2 w-full sm:w-auto', className)}>
+      {showOrgSelector && (
+        <>
+          <select
+            value={effectiveOrgId}
+            onChange={handleOrgChange}
+            disabled={disabled || orgsLoading}
+            aria-label="Select organization"
+            className={selectClass}
+          >
+            {orgsLoading ? (
+              <option value="">Loading…</option>
+            ) : (
+              allOrgs.map((org) => (
+                <option key={org.id} value={org.id}>
+                  {org.name}
+                </option>
+              ))
+            )}
+          </select>
+          <span className="text-muted-foreground text-sm">/</span>
+        </>
+      )}
+
       <select
         value={selectedWorkspaceId ?? ''}
         onChange={handleWorkspaceChange}
@@ -74,7 +137,8 @@ export function DestinationPicker({
         ))}
       </select>
 
-      {selectedWorkspaceId && (
+      {/* Folder picker — only for same-org rules; cross-org lands in HOME workspace */}
+      {selectedWorkspaceId && !targetOrgId && (
         <>
           <span className="text-muted-foreground text-sm">/</span>
           <select

--- a/src/components/import/RoutingRuleCard.tsx
+++ b/src/components/import/RoutingRuleCard.tsx
@@ -4,7 +4,7 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { RiDraggable } from '@remixicon/react';
+import { RiDraggable, RiArrowRightUpLine } from '@remixicon/react';
 import { cn } from '@/lib/utils';
 import type { RoutingRule, RoutingCondition } from '@/types/routing';
 
@@ -51,6 +51,7 @@ interface RoutingRuleCardProps {
   rule: RoutingRule;
   workspaceName?: string;
   folderName?: string;
+  targetOrgName?: string;
   onEdit: (id: string) => void;
   onToggle: (id: string, enabled: boolean) => void;
 }
@@ -59,6 +60,7 @@ export function RoutingRuleCard({
   rule,
   workspaceName,
   folderName,
+  targetOrgName,
   onEdit,
   onToggle,
 }: RoutingRuleCardProps) {
@@ -79,11 +81,17 @@ export function RoutingRuleCard({
 
   const conditionSummary = summarizeConditions(rule.conditions, rule.logic_operator);
 
-  const destination = workspaceName
-    ? folderName
-      ? `${workspaceName} / ${folderName}`
-      : workspaceName
-    : rule.target_workspace_id;
+  const isCrossOrg = !!rule.target_organization_id;
+
+  const destination = isCrossOrg
+    ? targetOrgName
+      ? `${targetOrgName} / ${workspaceName ?? rule.target_workspace_id}`
+      : workspaceName ?? rule.target_workspace_id
+    : workspaceName
+      ? folderName
+        ? `${workspaceName} / ${folderName}`
+        : workspaceName
+      : rule.target_workspace_id;
 
   return (
     <div
@@ -119,14 +127,22 @@ export function RoutingRuleCard({
         className="flex-1 min-w-0 text-left focus:outline-none"
         aria-label={`Edit rule: ${rule.name}`}
       >
-        <p
-          className={cn(
-            'text-sm font-semibold text-foreground leading-snug',
-            !rule.enabled && 'line-through'
+        <div className="flex items-center gap-2">
+          <p
+            className={cn(
+              'text-sm font-semibold text-foreground leading-snug',
+              !rule.enabled && 'line-through'
+            )}
+          >
+            {rule.name}
+          </p>
+          {isCrossOrg && (
+            <span className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-brand-400/10 text-brand-500 border border-brand-400/20">
+              <RiArrowRightUpLine className="h-3 w-3" />
+              Cross-org
+            </span>
           )}
-        >
-          {rule.name}
-        </p>
+        </div>
         <p className="text-xs text-muted-foreground mt-0.5 whitespace-normal break-words">
           {conditionSummary}
         </p>

--- a/src/components/import/RoutingRuleSlideOver.tsx
+++ b/src/components/import/RoutingRuleSlideOver.tsx
@@ -35,6 +35,7 @@ interface RuleFormState {
   conditions: RoutingCondition[];
   logicOperator: 'AND' | 'OR';
   destination: RoutingDestination | null;
+  deleteAfterCopy: boolean;
 }
 
 export function RoutingRuleSlideOver() {
@@ -49,6 +50,7 @@ export function RoutingRuleSlideOver() {
     conditions: [DEFAULT_CONDITION],
     logicOperator: 'AND',
     destination: null,
+    deleteAfterCopy: false,
   });
 
   const initializeForm = useCallback(() => {
@@ -61,6 +63,7 @@ export function RoutingRuleSlideOver() {
         conditions: [isFirstRule ? FIRST_RULE_SUGGESTION : DEFAULT_CONDITION],
         logicOperator: 'AND',
         destination: null,
+        deleteAfterCopy: false,
       });
     } else {
       const existingRule = allRules.find((r) => r.id === activeRuleId);
@@ -75,7 +78,9 @@ export function RoutingRuleSlideOver() {
           destination: {
             workspaceId: existingRule.target_workspace_id,
             folderId: existingRule.target_folder_id,
+            targetOrganizationId: existingRule.target_organization_id,
           },
+          deleteAfterCopy: existingRule.delete_after_copy,
         });
       }
     }
@@ -98,12 +103,15 @@ export function RoutingRuleSlideOver() {
   async function handleSave() {
     if (!canSave || !form.destination) return;
 
+    const isCrossOrg = !!form.destination.targetOrganizationId;
     const payload = {
       name: form.name.trim(),
       conditions: form.conditions,
       logic_operator: form.logicOperator,
       target_workspace_id: form.destination.workspaceId,
-      target_folder_id: form.destination.folderId,
+      target_folder_id: isCrossOrg ? null : form.destination.folderId,
+      target_organization_id: form.destination.targetOrganizationId ?? null,
+      delete_after_copy: isCrossOrg ? form.deleteAfterCopy : false,
       enabled: true,
     };
 
@@ -220,15 +228,49 @@ export function RoutingRuleSlideOver() {
               </div>
 
               {activeOrgId && (
-                <div className="space-y-1.5">
-                  <label className="block text-sm font-medium text-foreground">
-                    Route matching calls to:
-                  </label>
-                  <DestinationPicker
-                    value={form.destination}
-                    onChange={(d) => setForm(p => ({ ...p, destination: d }))}
-                    orgId={activeOrgId}
-                  />
+                <div className="space-y-3">
+                  <div className="space-y-1.5">
+                    <label className="block text-sm font-medium text-foreground">
+                      Route matching calls to:
+                    </label>
+                    <DestinationPicker
+                      value={form.destination}
+                      onChange={(d) => setForm(p => ({ ...p, destination: d }))}
+                      currentOrgId={activeOrgId}
+                    />
+                  </div>
+
+                  {form.destination?.targetOrganizationId && (
+                    <div className="flex items-center justify-between rounded-lg border border-border/50 bg-muted/40 px-3 py-2.5">
+                      <div>
+                        <p className="text-xs font-medium text-foreground">Delete original after routing</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                          Off = keep a copy here. On = move (delete from this org).
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={form.deleteAfterCopy}
+                        aria-label="Delete original after routing"
+                        onClick={() => setForm(p => ({ ...p, deleteAfterCopy: !p.deleteAfterCopy }))}
+                        className={cn(
+                          'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent',
+                          'transition-colors duration-200 ease-in-out ml-3',
+                          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                          form.deleteAfterCopy ? 'bg-brand-400' : 'bg-muted'
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm',
+                            'transform transition-transform duration-200 ease-in-out',
+                            form.deleteAfterCopy ? 'translate-x-4' : 'translate-x-0'
+                          )}
+                        />
+                      </button>
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/components/import/RoutingRuleSlideOver.tsx
+++ b/src/components/import/RoutingRuleSlideOver.tsx
@@ -97,6 +97,7 @@ export function RoutingRuleSlideOver() {
     form.name.trim().length > 0 &&
     form.conditions.length > 0 &&
     form.destination !== null &&
+    !!form.destination?.workspaceId &&
     !createRule.isPending &&
     !updateRule.isPending;
 

--- a/src/components/import/RoutingRulesList.tsx
+++ b/src/components/import/RoutingRulesList.tsx
@@ -28,6 +28,7 @@ interface RoutingRulesListProps {
   onToggle: (id: string, enabled: boolean) => void;
   workspaceNames?: Record<string, string>;
   folderNames?: Record<string, string>;
+  orgNames?: Record<string, string>;
 }
 
 export function RoutingRulesList({
@@ -37,6 +38,7 @@ export function RoutingRulesList({
   onToggle,
   workspaceNames,
   folderNames,
+  orgNames,
 }: RoutingRulesListProps) {
   const [items, setItems] = useState<RoutingRule[]>(rules);
 
@@ -87,6 +89,7 @@ export function RoutingRulesList({
               rule={rule}
               workspaceName={workspaceNames?.[rule.target_workspace_id]}
               folderName={rule.target_folder_id ? folderNames?.[rule.target_folder_id] : undefined}
+              targetOrgName={rule.target_organization_id ? orgNames?.[rule.target_organization_id] : undefined}
               onEdit={onEdit}
               onToggle={onToggle}
             />

--- a/src/components/import/RoutingRulesTab.tsx
+++ b/src/components/import/RoutingRulesTab.tsx
@@ -9,6 +9,7 @@ import { useRoutingRules, useRoutingDefault, useReorderRules, useToggleRule } fr
 import { usePanelStore } from '@/stores/panelStore';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { useOrgContextStore } from '@/stores/orgContextStore';
+import { useOrganizations } from '@/hooks/useOrganizations';
 import { useBulkApplyRules } from '@/hooks/useBulkApplyRules';
 import { DefaultDestinationBar } from './DefaultDestinationBar';
 import { RoutingRulesList } from './RoutingRulesList';
@@ -39,12 +40,18 @@ export function RoutingRulesTab() {
   const { openPanel } = usePanelStore();
 
   const { workspaces = [] } = useWorkspaces(activeOrgId);
+  const { data: allOrgs = [] } = useOrganizations();
   const bulkApply = useBulkApplyRules();
   const [bulkDryRunResult, setBulkDryRunResult] = useState<{ matched: number; details: Array<{ matchedRuleName: string }> } | null>(null);
 
   const workspaceNames: Record<string, string> = {};
   for (const ws of workspaces) {
     workspaceNames[ws.id] = ws.name;
+  }
+
+  const orgNames: Record<string, string> = {};
+  for (const org of allOrgs) {
+    orgNames[org.id] = org.name;
   }
 
   const folderNames: Record<string, string> = {};
@@ -103,6 +110,7 @@ export function RoutingRulesTab() {
           onToggle={handleToggle}
           workspaceNames={workspaceNames}
           folderNames={folderNames}
+          orgNames={orgNames}
         />
       )}
 

--- a/src/hooks/useRoutingRules.ts
+++ b/src/hooks/useRoutingRules.ts
@@ -86,6 +86,8 @@ export function useCreateRule() {
       logic_operator: 'AND' | 'OR';
       target_workspace_id: string;
       target_folder_id: string | null;
+      target_organization_id: string | null;
+      delete_after_copy: boolean;
       enabled: boolean;
     }) => {
       if (!activeOrgId) throw new Error('No active organization');
@@ -148,7 +150,7 @@ export function useUpdateRule() {
       updates: Partial<
         Pick<
           RoutingRule,
-          'name' | 'conditions' | 'logic_operator' | 'target_workspace_id' | 'target_folder_id' | 'enabled'
+          'name' | 'conditions' | 'logic_operator' | 'target_workspace_id' | 'target_folder_id' | 'target_organization_id' | 'delete_after_copy' | 'enabled'
         >
       >;
     }) => {

--- a/src/types/routing.ts
+++ b/src/types/routing.ts
@@ -21,6 +21,13 @@ export interface RoutingRule {
   logic_operator: 'AND' | 'OR';
   target_workspace_id: string;
   target_folder_id: string | null;
+  /** Non-null when this rule routes to a different organization (cross-org). */
+  target_organization_id: string | null;
+  /**
+   * Per-rule copy preference for cross-org rules.
+   * false = keep source recording (default), true = delete source after copy.
+   */
+  delete_after_copy: boolean;
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -37,6 +44,8 @@ export interface RoutingDefault {
 export interface RoutingDestination {
   workspaceId: string;
   folderId: string | null;
+  /** Non-null = cross-org rule; the target workspace belongs to this org. */
+  targetOrganizationId?: string | null;
 }
 
 /** Single match result from bulk apply dry run / execution. */

--- a/supabase/functions/_shared/connector-pipeline.ts
+++ b/supabase/functions/_shared/connector-pipeline.ts
@@ -272,6 +272,16 @@ export async function runPipeline(
     // -------------------------------------------------------------------------
     // Routing resolution: only when connector didn't specify an explicit workspace
     // -------------------------------------------------------------------------
+    // Cross-org intent is captured here so the actual insertRecording + RPC call
+    // happens OUTSIDE the routing try-catch. If insertRecording were called inside
+    // the routing catch, a DB error would be swallowed and fall through to the
+    // normal-path insertRecording below, creating a duplicate in the source org.
+    let crossOrgRouting: {
+      targetOrgId: string;
+      deleteAfterCopy: boolean;
+      workspaceId: string | null;
+    } | null = null;
+
     if (!record.workspace_id) {
       try {
         // Resolve organization_id for routing lookup
@@ -341,36 +351,44 @@ export async function runPipeline(
             // Step 3: If no default either, do nothing — insertRecording uses personal workspace (preserved behavior)
           }
 
-          // Capture cross-org routing intent before losing routing reference
+          // Capture cross-org intent — insert + RPC execute OUTSIDE this try-catch (see below)
           if (routing?.targetOrganizationId) {
-            const crossOrgTargetId = routing.targetOrganizationId;
-            const deleteAfterCopy = routing.deleteAfterCopy;
-
-            const { id } = await insertRecording(supabase, userId, record);
-
-            // Perform cross-org copy after successful source insert (non-blocking on failure)
-            try {
-              const { error: crossOrgError } = await supabase.rpc('route_recording_cross_org', {
-                p_recording_id: id,
-                p_target_org_id: crossOrgTargetId,
-                p_user_id: userId,
-                p_delete_source: deleteAfterCopy,
-                p_target_workspace_id: routing.workspaceId || null,
-              });
-              if (crossOrgError) {
-                console.error('[connector-pipeline] Cross-org routing RPC failed (non-blocking):', crossOrgError);
-              }
-            } catch (crossOrgErr) {
-              console.error('[connector-pipeline] Cross-org routing error (non-blocking):', crossOrgErr);
-            }
-
-            return { success: true, recordingId: id };
+            crossOrgRouting = {
+              targetOrgId: routing.targetOrganizationId,
+              deleteAfterCopy: routing.deleteAfterCopy,
+              workspaceId: routing.workspaceId || null,
+            };
           }
         }
       } catch (routingErr) {
         // Non-blocking: routing failure should never prevent an import
         console.error('[connector-pipeline] Routing resolution error (skipping routing):', routingErr);
       }
+    }
+
+    // Cross-org path: executed OUTSIDE the routing try-catch so that insertRecording
+    // failures propagate to the outer catch (pipeline fails cleanly) rather than being
+    // swallowed and falling through to a duplicate insert in the source org.
+    if (crossOrgRouting) {
+      const { id } = await insertRecording(supabase, userId, record);
+
+      // RPC copy is non-blocking — source recording is preserved on failure
+      try {
+        const { error: crossOrgError } = await supabase.rpc('route_recording_cross_org', {
+          p_recording_id: id,
+          p_target_org_id: crossOrgRouting.targetOrgId,
+          p_user_id: userId,
+          p_delete_source: crossOrgRouting.deleteAfterCopy,
+          p_target_workspace_id: crossOrgRouting.workspaceId,
+        });
+        if (crossOrgError) {
+          console.error('[connector-pipeline] Cross-org routing RPC failed (non-blocking):', crossOrgError);
+        }
+      } catch (crossOrgErr) {
+        console.error('[connector-pipeline] Cross-org routing error (non-blocking):', crossOrgErr);
+      }
+
+      return { success: true, recordingId: id };
     }
 
     const { id } = await insertRecording(supabase, userId, record);

--- a/supabase/functions/_shared/connector-pipeline.ts
+++ b/supabase/functions/_shared/connector-pipeline.ts
@@ -297,18 +297,31 @@ export async function runPipeline(
           const routing = await resolveRoutingDestination(supabase, organizationId, record);
 
           if (routing) {
-            // Routing rule matched — set destination and record trace metadata
-            record.workspace_id = routing.workspaceId;
-            if (routing.folderId) {
-              record.folder_id = routing.folderId;
+            if (routing.targetOrganizationId) {
+              // Cross-org rule: recording is inserted into source org first (no workspace override),
+              // then copied to the target org via route_recording_cross_org after insert.
+              // Store routing trace + cross-org marker in source_metadata for audit trail.
+              record.source_metadata = {
+                ...record.source_metadata,
+                routed_by_rule_id: routing.matchedRuleId,
+                routed_by_rule_name: routing.matchedRuleName,
+                routed_at: new Date().toISOString(),
+                cross_org_target_id: routing.targetOrganizationId,
+              };
+              // crossOrgRouting is resolved outside this closure below
+            } else {
+              // Same-org rule: set destination and record trace metadata
+              record.workspace_id = routing.workspaceId;
+              if (routing.folderId) {
+                record.folder_id = routing.folderId;
+              }
+              record.source_metadata = {
+                ...record.source_metadata,
+                routed_by_rule_id: routing.matchedRuleId,
+                routed_by_rule_name: routing.matchedRuleName,
+                routed_at: new Date().toISOString(),
+              };
             }
-            // Merge routing trace into source_metadata for display in UI
-            record.source_metadata = {
-              ...record.source_metadata,
-              routed_by_rule_id: routing.matchedRuleId,
-              routed_by_rule_name: routing.matchedRuleName,
-              routed_at: new Date().toISOString(),
-            };
           } else {
             // Step 2: No rule matched — try org-level default destination
             const { data: defaultDest, error: defaultError } = await supabase
@@ -326,6 +339,31 @@ export async function runPipeline(
               }
             }
             // Step 3: If no default either, do nothing — insertRecording uses personal workspace (preserved behavior)
+          }
+
+          // Capture cross-org routing intent before losing routing reference
+          if (routing?.targetOrganizationId) {
+            const crossOrgTargetId = routing.targetOrganizationId;
+            const deleteAfterCopy = routing.deleteAfterCopy;
+
+            const { id } = await insertRecording(supabase, userId, record);
+
+            // Perform cross-org copy after successful source insert (non-blocking on failure)
+            try {
+              const { error: crossOrgError } = await supabase.rpc('route_recording_cross_org', {
+                p_recording_id: id,
+                p_target_org_id: crossOrgTargetId,
+                p_user_id: userId,
+                p_delete_source: deleteAfterCopy,
+              });
+              if (crossOrgError) {
+                console.error('[connector-pipeline] Cross-org routing RPC failed (non-blocking):', crossOrgError);
+              }
+            } catch (crossOrgErr) {
+              console.error('[connector-pipeline] Cross-org routing error (non-blocking):', crossOrgErr);
+            }
+
+            return { success: true, recordingId: id };
           }
         }
       } catch (routingErr) {

--- a/supabase/functions/_shared/connector-pipeline.ts
+++ b/supabase/functions/_shared/connector-pipeline.ts
@@ -355,6 +355,7 @@ export async function runPipeline(
                 p_target_org_id: crossOrgTargetId,
                 p_user_id: userId,
                 p_delete_source: deleteAfterCopy,
+                p_target_workspace_id: routing.workspaceId || null,
               });
               if (crossOrgError) {
                 console.error('[connector-pipeline] Cross-org routing RPC failed (non-blocking):', crossOrgError);

--- a/supabase/functions/_shared/routing-engine.ts
+++ b/supabase/functions/_shared/routing-engine.ts
@@ -23,6 +23,13 @@ export interface RoutingDestination {
   folderId: string | null;
   matchedRuleId: string;
   matchedRuleName: string;
+  /** Set when the rule routes to a different organization (cross-org). Null = same org. */
+  targetOrganizationId: string | null;
+  /**
+   * Per-rule copy preference for cross-org rules.
+   * false = keep source recording (default), true = delete source after copy.
+   */
+  deleteAfterCopy: boolean;
 }
 
 /**
@@ -37,6 +44,10 @@ export interface RoutingRule {
   logic_operator: 'AND' | 'OR';
   target_workspace_id: string;
   target_folder_id: string | null;
+  /** Non-null when this is a cross-org rule that copies recordings to another org. */
+  target_organization_id: string | null;
+  /** Per-rule copy preference: false = keep source, true = delete source after copy. */
+  delete_after_copy: boolean;
 }
 
 /**
@@ -72,7 +83,7 @@ export async function resolveRoutingDestination(
   // Query active rules for this organization ordered by priority ascending (lowest first)
   const { data: rules, error } = await supabase
     .from('import_routing_rules')
-    .select('id, name, priority, conditions, logic_operator, target_workspace_id, target_folder_id')
+    .select('id, name, priority, conditions, logic_operator, target_workspace_id, target_folder_id, target_organization_id, delete_after_copy')
     .eq('organization_id', organizationId)
     .eq('enabled', true)
     .order('priority', { ascending: true });
@@ -95,6 +106,8 @@ export async function resolveRoutingDestination(
         folderId: rule.target_folder_id,
         matchedRuleId: rule.id,
         matchedRuleName: rule.name,
+        targetOrganizationId: rule.target_organization_id ?? null,
+        deleteAfterCopy: rule.delete_after_copy ?? false,
       };
     }
   }
@@ -116,7 +129,7 @@ export async function loadRoutingRules(
 ): Promise<RoutingRule[]> {
   const { data: rules, error } = await supabase
     .from('import_routing_rules')
-    .select('id, name, priority, conditions, logic_operator, target_workspace_id, target_folder_id')
+    .select('id, name, priority, conditions, logic_operator, target_workspace_id, target_folder_id, target_organization_id, delete_after_copy')
     .eq('organization_id', organizationId)
     .eq('enabled', true)
     .order('priority', { ascending: true });
@@ -150,6 +163,8 @@ export function evaluateRecordAgainstRules(
         folderId: rule.target_folder_id,
         matchedRuleId: rule.id,
         matchedRuleName: rule.name,
+        targetOrganizationId: rule.target_organization_id ?? null,
+        deleteAfterCopy: rule.delete_after_copy ?? false,
       };
     }
   }

--- a/supabase/functions/apply-routing-rules/index.ts
+++ b/supabase/functions/apply-routing-rules/index.ts
@@ -242,6 +242,7 @@ Deno.serve(async (req) => {
               p_target_org_id: match.target_organization_id,
               p_user_id: user.id,
               p_delete_source: match.delete_after_copy,
+              p_target_workspace_id: match.target_workspace_id || null,
             });
 
             if (crossOrgError) {

--- a/supabase/functions/apply-routing-rules/index.ts
+++ b/supabase/functions/apply-routing-rules/index.ts
@@ -46,6 +46,10 @@ interface MatchResult {
   target_workspace_id: string;
   target_workspace_name: string | null;
   target_folder_id: string | null;
+  /** Non-null for cross-org rules — recording is copied to this org instead of moved within same org. */
+  target_organization_id: string | null;
+  /** Per-rule copy preference: true = delete source after cross-org copy. */
+  delete_after_copy: boolean;
 }
 
 Deno.serve(async (req) => {
@@ -195,6 +199,8 @@ Deno.serve(async (req) => {
             target_workspace_id: destination.workspaceId,
             target_workspace_name: workspaceNameMap[destination.workspaceId] ?? null,
             target_folder_id: destination.folderId,
+            target_organization_id: destination.targetOrganizationId,
+            delete_after_copy: destination.deleteAfterCopy,
           });
         }
       }
@@ -225,75 +231,94 @@ Deno.serve(async (req) => {
 
       const results = await Promise.allSettled(
         batch.map(async (match) => {
-          // Insert new workspace_entry FIRST, then delete old ones.
-          // This order prevents orphaning: if insert fails, old entry is preserved.
-          const entryPayload: Record<string, unknown> = {
-            workspace_id: match.target_workspace_id,
-            recording_id: match.recording_id,
-            folder_id: match.target_folder_id ?? null,
-          };
+          if (match.target_organization_id) {
+            // ----------------------------------------------------------------
+            // Cross-org rule: copy recording to target org via RPC.
+            // The route_recording_cross_org function handles membership verification,
+            // transcript_chunks copy, and optional source deletion.
+            // ----------------------------------------------------------------
+            const { error: crossOrgError } = await supabase.rpc('route_recording_cross_org', {
+              p_recording_id: match.recording_id,
+              p_target_org_id: match.target_organization_id,
+              p_user_id: user.id,
+              p_delete_source: match.delete_after_copy,
+            });
 
-          const { error: entryError } = await supabase
-            .from('workspace_entries')
-            .upsert(entryPayload, { onConflict: 'workspace_id,recording_id' });
-
-          if (entryError) {
-            throw new Error(`workspace_entry upsert failed for ${match.recording_id}: ${entryError.message}`);
-          }
-
-          // Now safe to remove old workspace entries (excluding the one we just inserted)
-          const { error: deleteError } = await supabase
-            .from('workspace_entries')
-            .delete()
-            .eq('recording_id', match.recording_id)
-            .neq('workspace_id', match.target_workspace_id);
-
-          if (deleteError) {
-            console.error(
-              `[apply-routing-rules] Failed to remove old workspace_entries for ${match.recording_id}:`,
-              deleteError,
-            );
-            // Non-fatal: recording may appear in both workspaces temporarily
-          }
-
-          // Atomic JSONB merge — avoids read-modify-write race condition.
-          // Uses Supabase's PostgREST JSONB concatenation via the || operator
-          // by reading and updating in a single UPDATE statement.
-          const routingTrace = {
-            routed_by_rule_id: match.rule_id,
-            routed_by_rule_name: match.rule_name,
-            routed_at: now,
-            routed_retroactively: true,
-          };
-
-          const { error: updateError } = await supabase.rpc('jsonb_merge_source_metadata', {
-            p_recording_id: match.recording_id,
-            p_merge_data: routingTrace,
-          });
-
-          // Fallback: if the RPC doesn't exist yet, use direct update
-          if (updateError?.message?.includes('function') && updateError?.message?.includes('does not exist')) {
-            const { data: existingRec } = await supabase
-              .from('recordings')
-              .select('source_metadata')
-              .eq('id', match.recording_id)
-              .single();
-
-            const { error: fallbackError } = await supabase
-              .from('recordings')
-              .update({
-                source_metadata: {
-                  ...(existingRec?.source_metadata ?? {}),
-                  ...routingTrace,
-                },
-              })
-              .eq('id', match.recording_id);
-
-            if (fallbackError) {
-              throw new Error(`routing trace update failed for ${match.recording_id}: ${fallbackError.message}`);
+            if (crossOrgError) {
+              throw new Error(`cross-org copy failed for ${match.recording_id}: ${crossOrgError.message}`);
             }
-          } else if (updateError) {
-            throw new Error(`routing trace update failed for ${match.recording_id}: ${updateError.message}`);
+          } else {
+            // ----------------------------------------------------------------
+            // Same-org rule: move within the organization via workspace entries.
+            // Insert new workspace_entry FIRST, then delete old ones.
+            // This order prevents orphaning: if insert fails, old entry is preserved.
+            // ----------------------------------------------------------------
+            const entryPayload: Record<string, unknown> = {
+              workspace_id: match.target_workspace_id,
+              recording_id: match.recording_id,
+              folder_id: match.target_folder_id ?? null,
+            };
+
+            const { error: entryError } = await supabase
+              .from('workspace_entries')
+              .upsert(entryPayload, { onConflict: 'workspace_id,recording_id' });
+
+            if (entryError) {
+              throw new Error(`workspace_entry upsert failed for ${match.recording_id}: ${entryError.message}`);
+            }
+
+            // Now safe to remove old workspace entries (excluding the one we just inserted)
+            const { error: deleteError } = await supabase
+              .from('workspace_entries')
+              .delete()
+              .eq('recording_id', match.recording_id)
+              .neq('workspace_id', match.target_workspace_id);
+
+            if (deleteError) {
+              console.error(
+                `[apply-routing-rules] Failed to remove old workspace_entries for ${match.recording_id}:`,
+                deleteError,
+              );
+              // Non-fatal: recording may appear in both workspaces temporarily
+            }
+
+            // Stamp routing trace into source_metadata
+            const routingTrace = {
+              routed_by_rule_id: match.rule_id,
+              routed_by_rule_name: match.rule_name,
+              routed_at: now,
+              routed_retroactively: true,
+            };
+
+            const { error: updateError } = await supabase.rpc('jsonb_merge_source_metadata', {
+              p_recording_id: match.recording_id,
+              p_merge_data: routingTrace,
+            });
+
+            // Fallback: if the RPC doesn't exist yet, use direct update
+            if (updateError?.message?.includes('function') && updateError?.message?.includes('does not exist')) {
+              const { data: existingRec } = await supabase
+                .from('recordings')
+                .select('source_metadata')
+                .eq('id', match.recording_id)
+                .single();
+
+              const { error: fallbackError } = await supabase
+                .from('recordings')
+                .update({
+                  source_metadata: {
+                    ...(existingRec?.source_metadata ?? {}),
+                    ...routingTrace,
+                  },
+                })
+                .eq('id', match.recording_id);
+
+              if (fallbackError) {
+                throw new Error(`routing trace update failed for ${match.recording_id}: ${fallbackError.message}`);
+              }
+            } else if (updateError) {
+              throw new Error(`routing trace update failed for ${match.recording_id}: ${updateError.message}`);
+            }
           }
         }),
       );

--- a/supabase/functions/apply-routing-rules/index.ts
+++ b/supabase/functions/apply-routing-rules/index.ts
@@ -247,6 +247,33 @@ Deno.serve(async (req) => {
             if (crossOrgError) {
               throw new Error(`cross-org copy failed for ${match.recording_id}: ${crossOrgError.message}`);
             }
+
+            // Stamp routing trace so this recording is not re-matched on subsequent
+            // bulk-apply runs (same guard mechanism as same-org rules).
+            // Only stamp if delete_after_copy is false — if the source was deleted,
+            // there is nothing left to update.
+            if (!match.delete_after_copy) {
+              const crossOrgTrace = {
+                routed_by_rule_id: match.rule_id,
+                routed_by_rule_name: match.rule_name,
+                routed_at: now,
+                routed_retroactively: true,
+                cross_org_target_id: match.target_organization_id,
+              };
+
+              const { error: traceError } = await supabase.rpc('jsonb_merge_source_metadata', {
+                p_recording_id: match.recording_id,
+                p_merge_data: crossOrgTrace,
+              });
+
+              if (traceError) {
+                // Non-fatal: duplicate copy on next run is annoying but not destructive
+                console.error(
+                  `[apply-routing-rules] Failed to stamp cross-org routing trace for ${match.recording_id}:`,
+                  traceError,
+                );
+              }
+            }
           } else {
             // ----------------------------------------------------------------
             // Same-org rule: move within the organization via workspace entries.

--- a/supabase/migrations/20260309200000_cross_org_routing_rules.sql
+++ b/supabase/migrations/20260309200000_cross_org_routing_rules.sql
@@ -163,8 +163,10 @@ BEGIN
   FROM transcript_chunks tc
   WHERE tc.canonical_recording_id = p_recording_id;
 
-  -- Delete source recording if requested (move semantics)
+  -- Delete source recording if requested (move semantics).
+  -- workspace_entries references recordings via FK, so entries must be removed first.
   IF p_delete_source THEN
+    DELETE FROM workspace_entries WHERE recording_id = p_recording_id;
     DELETE FROM recordings WHERE id = p_recording_id;
   END IF;
 

--- a/supabase/migrations/20260309200000_cross_org_routing_rules.sql
+++ b/supabase/migrations/20260309200000_cross_org_routing_rules.sql
@@ -65,7 +65,11 @@ CREATE POLICY "Org members can update routing rules"
 -- ============================================================================
 -- Called by edge functions running as service role, so we cannot rely on
 -- auth.uid(). Instead, the caller passes p_user_id explicitly.
--- Security: verifies p_user_id is a member of the target org before copying.
+-- Security (defense-in-depth):
+--   a) REVOKE EXECUTE FROM PUBLIC + GRANT only to service_role so direct
+--      PostgREST callers cannot invoke it.
+--   b) Source org membership verified explicitly inside the function body so
+--      that even a misconfigured grant cannot leak recordings across orgs.
 -- After insert the auto_create_default_workspace_entry trigger places the copy
 -- in the target org's HOME workspace automatically.
 
@@ -91,9 +95,15 @@ BEGIN
     RAISE EXCEPTION 'Recording not found: %', p_recording_id;
   END IF;
 
-  -- Guard: user must be member of target org
+  -- Guard (a): user must be member of the SOURCE org.
+  -- This prevents cross-org exfiltration even if execute grants are misconfigured.
+  IF NOT is_organization_member(v_source.organization_id, p_user_id) THEN
+    RAISE EXCEPTION 'Access denied: user % is not a member of source organization %', p_user_id, v_source.organization_id;
+  END IF;
+
+  -- Guard (b): user must also be member of the TARGET org.
   IF NOT is_organization_member(p_target_org_id, p_user_id) THEN
-    RAISE EXCEPTION 'User % is not a member of target organization %', p_user_id, p_target_org_id;
+    RAISE EXCEPTION 'Access denied: user % is not a member of target organization %', p_user_id, p_target_org_id;
   END IF;
 
   -- Guard: cross-org only — same-org routing uses the normal workspace entry path
@@ -165,7 +175,12 @@ $$;
 COMMENT ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN) IS
   'Cross-org routing: copies a recording to a target organization and optionally deletes the source. '
   'Called by edge functions using service role — takes p_user_id explicitly instead of auth.uid(). '
-  'Verifies user membership in target org. Copied recording lands in target org HOME workspace via trigger.';
+  'Verifies user membership in BOTH source and target orgs. Copied recording lands in target HOME workspace via trigger.';
+
+-- Restrict direct invocation: only service_role (used by edge functions) may call this.
+-- Public users cannot call it via PostgREST even if they know a recording UUID.
+REVOKE EXECUTE ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN) TO service_role;
 
 -- ============================================================================
 -- COLUMN COMMENTS

--- a/supabase/migrations/20260309200000_cross_org_routing_rules.sql
+++ b/supabase/migrations/20260309200000_cross_org_routing_rules.sql
@@ -1,0 +1,187 @@
+-- Migration: Cross-org routing rules
+-- Purpose: Extend import_routing_rules with target_organization_id (nullable) to support routing
+--          calls to a different org by copying the recording. Adds delete_after_copy for
+--          per-rule copy/move preference. Updates INSERT/UPDATE RLS to require target org
+--          membership. Adds route_recording_cross_org RPC callable by service-role edge functions.
+-- Author: Claude (issue #99)
+-- Date: 2026-03-09
+
+-- ============================================================================
+-- 1. ADD COLUMNS TO import_routing_rules
+-- ============================================================================
+
+-- target_organization_id: NULL = same-org rule (existing behavior, no change).
+--   Non-null = route matching calls to this org by copying the recording there.
+--   User must be a member of the target org to create or update this rule (enforced by RLS).
+ALTER TABLE import_routing_rules
+  ADD COLUMN target_organization_id UUID REFERENCES organizations(id) ON DELETE RESTRICT;
+
+-- delete_after_copy: per-rule override for copy preference.
+--   false (default) = keep source-org recording after cross-org copy ("keep" semantics).
+--   true  = delete source-org recording after copying ("move" semantics).
+--   Only meaningful when target_organization_id IS NOT NULL.
+ALTER TABLE import_routing_rules
+  ADD COLUMN delete_after_copy BOOLEAN NOT NULL DEFAULT false;
+
+-- ============================================================================
+-- 2. UPDATE RLS POLICIES
+-- ============================================================================
+-- The old INSERT/UPDATE policies use the pre-rename policy name "Bank members …".
+-- Drop and replace with org-aware policies that also require target org membership
+-- for cross-org rules.
+
+-- INSERT: require membership in both source and target orgs
+DROP POLICY IF EXISTS "Bank members can insert routing rules" ON import_routing_rules;
+
+CREATE POLICY "Org members can insert routing rules"
+  ON import_routing_rules FOR INSERT
+  WITH CHECK (
+    auth.uid() = created_by
+    AND is_organization_member(import_routing_rules.organization_id, auth.uid())
+    AND (
+      import_routing_rules.target_organization_id IS NULL
+      OR is_organization_member(import_routing_rules.target_organization_id, auth.uid())
+    )
+  );
+
+-- UPDATE: same dual-membership requirement
+DROP POLICY IF EXISTS "Bank members can update routing rules" ON import_routing_rules;
+
+CREATE POLICY "Org members can update routing rules"
+  ON import_routing_rules FOR UPDATE
+  USING (
+    is_organization_member(import_routing_rules.organization_id, auth.uid())
+  )
+  WITH CHECK (
+    is_organization_member(import_routing_rules.organization_id, auth.uid())
+    AND (
+      import_routing_rules.target_organization_id IS NULL
+      OR is_organization_member(import_routing_rules.target_organization_id, auth.uid())
+    )
+  );
+
+-- ============================================================================
+-- 3. CROSS-ORG ROUTING COPY RPC
+-- ============================================================================
+-- Called by edge functions running as service role, so we cannot rely on
+-- auth.uid(). Instead, the caller passes p_user_id explicitly.
+-- Security: verifies p_user_id is a member of the target org before copying.
+-- After insert the auto_create_default_workspace_entry trigger places the copy
+-- in the target org's HOME workspace automatically.
+
+CREATE OR REPLACE FUNCTION public.route_recording_cross_org(
+  p_recording_id   UUID,
+  p_target_org_id  UUID,
+  p_user_id        UUID,
+  p_delete_source  BOOLEAN DEFAULT false
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_source           RECORD;
+  v_new_recording_id UUID;
+BEGIN
+  -- Fetch source recording (bypasses RLS via SECURITY DEFINER)
+  SELECT * INTO v_source FROM recordings WHERE id = p_recording_id;
+
+  IF v_source IS NULL THEN
+    RAISE EXCEPTION 'Recording not found: %', p_recording_id;
+  END IF;
+
+  -- Guard: user must be member of target org
+  IF NOT is_organization_member(p_target_org_id, p_user_id) THEN
+    RAISE EXCEPTION 'User % is not a member of target organization %', p_user_id, p_target_org_id;
+  END IF;
+
+  -- Guard: cross-org only — same-org routing uses the normal workspace entry path
+  IF v_source.organization_id = p_target_org_id THEN
+    RAISE EXCEPTION 'Source and target organization are the same (use same-org routing instead)';
+  END IF;
+
+  -- Create recording copy in target org.
+  -- source_call_id set to NULL to avoid unique-dedup constraint collision.
+  -- The auto_create_default_workspace_entry trigger will place the copy in the
+  -- target org HOME workspace automatically after INSERT.
+  INSERT INTO recordings (
+    organization_id, owner_user_id, title, audio_url, video_url,
+    full_transcript, summary, global_tags, source_app, source_metadata,
+    duration, recording_start_time, recording_end_time,
+    source_call_id, created_at, synced_at
+  )
+  VALUES (
+    p_target_org_id,
+    p_user_id,
+    v_source.title,
+    v_source.audio_url,
+    v_source.video_url,
+    v_source.full_transcript,
+    v_source.summary,
+    v_source.global_tags,
+    v_source.source_app,
+    COALESCE(v_source.source_metadata, '{}'::jsonb) || jsonb_build_object(
+      'cross_org_routed_from_id',  p_recording_id,
+      'cross_org_routed_from_org', v_source.organization_id,
+      'cross_org_routed_at',       NOW()::TEXT,
+      'cross_org_routed_by',       p_user_id
+    ),
+    v_source.duration,
+    v_source.recording_start_time,
+    v_source.recording_end_time,
+    NULL,   -- avoid dedup collision
+    NOW(),
+    v_source.synced_at
+  )
+  RETURNING id INTO v_new_recording_id;
+
+  -- Copy transcript_chunks linked to the source recording
+  INSERT INTO transcript_chunks (
+    canonical_recording_id, recording_id, user_id, chunk_text, chunk_index,
+    speaker_name, speaker_email, call_date, call_title, call_category, topics,
+    sentiment, intent_signals, user_tags, entities, source_platform, embedding, fts, created_at
+  )
+  SELECT
+    v_new_recording_id,
+    tc.recording_id,
+    p_user_id,
+    tc.chunk_text, tc.chunk_index, tc.speaker_name, tc.speaker_email,
+    tc.call_date, tc.call_title, tc.call_category, tc.topics,
+    tc.sentiment, tc.intent_signals, tc.user_tags, tc.entities,
+    tc.source_platform, tc.embedding, tc.fts, NOW()
+  FROM transcript_chunks tc
+  WHERE tc.canonical_recording_id = p_recording_id;
+
+  -- Delete source recording if requested (move semantics)
+  IF p_delete_source THEN
+    DELETE FROM recordings WHERE id = p_recording_id;
+  END IF;
+
+  RETURN v_new_recording_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN) IS
+  'Cross-org routing: copies a recording to a target organization and optionally deletes the source. '
+  'Called by edge functions using service role — takes p_user_id explicitly instead of auth.uid(). '
+  'Verifies user membership in target org. Copied recording lands in target org HOME workspace via trigger.';
+
+-- ============================================================================
+-- COLUMN COMMENTS
+-- ============================================================================
+
+COMMENT ON COLUMN import_routing_rules.target_organization_id IS
+  'When set, matching calls are copied to this organization (cross-org routing). '
+  'NULL = same-org routing (original behavior). '
+  'Creating or updating a rule with this set requires the user to be a member of the target org (enforced by RLS).';
+
+COMMENT ON COLUMN import_routing_rules.delete_after_copy IS
+  'Per-rule copy preference for cross-org rules. '
+  'false = keep source-org recording after copying (default). '
+  'true = delete source-org recording after copying (move semantics). '
+  'Ignored for same-org rules (target_organization_id IS NULL).';
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================

--- a/supabase/migrations/20260309210000_fix_cross_org_routing_chunks_and_workspace.sql
+++ b/supabase/migrations/20260309210000_fix_cross_org_routing_chunks_and_workspace.sql
@@ -1,0 +1,309 @@
+-- Migration: Fix cross-org routing — chunk unique constraint + target workspace placement
+-- Purpose:
+--   1. Relax transcript_chunks schema so cross-org copies can insert chunks without
+--      hitting the UNIQUE(recording_id, chunk_index) constraint on the legacy BIGINT column.
+--      Copied recordings do not have a fathom_calls entry in the target org, so recording_id
+--      must be nullable for copies. Replace the constraint with UNIQUE(canonical_recording_id,
+--      chunk_index) which correctly reflects the current data model.
+--   2. Update route_recording_cross_org to accept an optional target_workspace_id so that
+--      cross-org rules that specify a workspace (other than HOME) are respected.
+--   3. Update copy_recording_to_organization (same chunk fix) and route copied chunks with
+--      recording_id = NULL for copies.
+-- Author: Claude (issue #99)
+-- Date: 2026-03-09
+
+-- ============================================================================
+-- 1. RELAX transcript_chunks SCHEMA FOR CROSS-ORG COPIES
+-- ============================================================================
+
+-- Make recording_id nullable — cross-org copies have no fathom_calls entry in
+-- the target org. NULL satisfies the FK (FK constraints ignore NULLs in SQL).
+ALTER TABLE transcript_chunks
+  ALTER COLUMN recording_id DROP NOT NULL;
+
+-- Drop the legacy UNIQUE(recording_id, chunk_index) constraint.
+-- The legacy BIGINT is not unique across organizations — copying chunks from org A
+-- to org B would reuse the same recording_id BIGINT, violating the constraint.
+-- The canonical primary key for uniqueness is now canonical_recording_id (UUID).
+ALTER TABLE transcript_chunks
+  DROP CONSTRAINT IF EXISTS transcript_chunks_recording_id_chunk_index_key;
+
+-- Add the correct uniqueness constraint: one chunk per index per canonical recording.
+-- WHERE clause excludes rows without a canonical recording (legacy chunks without backfill).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_transcript_chunks_canonical_chunk
+  ON transcript_chunks (canonical_recording_id, chunk_index)
+  WHERE canonical_recording_id IS NOT NULL;
+
+-- ============================================================================
+-- 2. UPDATE route_recording_cross_org — target workspace + chunk fix
+-- ============================================================================
+-- Changes vs previous version:
+--   a) Added p_target_workspace_id parameter (optional; NULL = HOME workspace).
+--   b) Chunk copy now sets recording_id = NULL (avoids BIGINT uniqueness conflict).
+--   c) After trigger places copy in HOME, relocates to target workspace if specified.
+
+CREATE OR REPLACE FUNCTION public.route_recording_cross_org(
+  p_recording_id        UUID,
+  p_target_org_id       UUID,
+  p_user_id             UUID,
+  p_delete_source       BOOLEAN DEFAULT false,
+  p_target_workspace_id UUID    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_source             RECORD;
+  v_new_recording_id   UUID;
+  v_home_workspace_id  UUID;
+BEGIN
+  -- Fetch source recording (bypasses RLS via SECURITY DEFINER)
+  SELECT * INTO v_source FROM recordings WHERE id = p_recording_id;
+
+  IF v_source IS NULL THEN
+    RAISE EXCEPTION 'Recording not found: %', p_recording_id;
+  END IF;
+
+  -- Guard (a): user must be member of the SOURCE org.
+  IF NOT is_organization_member(v_source.organization_id, p_user_id) THEN
+    RAISE EXCEPTION 'Access denied: user % is not a member of source organization %', p_user_id, v_source.organization_id;
+  END IF;
+
+  -- Guard (b): user must also be member of the TARGET org.
+  IF NOT is_organization_member(p_target_org_id, p_user_id) THEN
+    RAISE EXCEPTION 'Access denied: user % is not a member of target organization %', p_user_id, p_target_org_id;
+  END IF;
+
+  -- Guard: cross-org only — same-org routing uses the normal workspace entry path.
+  IF v_source.organization_id = p_target_org_id THEN
+    RAISE EXCEPTION 'Source and target organization are the same (use same-org routing instead)';
+  END IF;
+
+  -- Create recording copy in target org.
+  -- source_call_id set to NULL to avoid unique-dedup constraint collision.
+  -- The auto_create_default_workspace_entry trigger places the copy in the
+  -- target org HOME workspace automatically after INSERT.
+  INSERT INTO recordings (
+    organization_id, owner_user_id, title, audio_url, video_url,
+    full_transcript, summary, global_tags, source_app, source_metadata,
+    duration, recording_start_time, recording_end_time,
+    source_call_id, created_at, synced_at
+  )
+  VALUES (
+    p_target_org_id,
+    p_user_id,
+    v_source.title,
+    v_source.audio_url,
+    v_source.video_url,
+    v_source.full_transcript,
+    v_source.summary,
+    v_source.global_tags,
+    v_source.source_app,
+    COALESCE(v_source.source_metadata, '{}'::jsonb) || jsonb_build_object(
+      'cross_org_routed_from_id',  p_recording_id,
+      'cross_org_routed_from_org', v_source.organization_id,
+      'cross_org_routed_at',       NOW()::TEXT,
+      'cross_org_routed_by',       p_user_id
+    ),
+    v_source.duration,
+    v_source.recording_start_time,
+    v_source.recording_end_time,
+    NULL,   -- avoid dedup collision
+    NOW(),
+    v_source.synced_at
+  )
+  RETURNING id INTO v_new_recording_id;
+
+  -- Copy transcript_chunks linked to the source recording.
+  -- recording_id is set to NULL: cross-org copies have no fathom_calls entry in
+  -- the target org. canonical_recording_id is the authoritative FK for the copy.
+  INSERT INTO transcript_chunks (
+    canonical_recording_id, recording_id, user_id, chunk_text, chunk_index,
+    speaker_name, speaker_email, call_date, call_title, call_category, topics,
+    sentiment, intent_signals, user_tags, entities, source_platform, embedding, fts, created_at
+  )
+  SELECT
+    v_new_recording_id,
+    NULL,   -- recording_id: NULL for cross-org copies (no fathom_calls entry in target org)
+    p_user_id,
+    tc.chunk_text, tc.chunk_index, tc.speaker_name, tc.speaker_email,
+    tc.call_date, tc.call_title, tc.call_category, tc.topics,
+    tc.sentiment, tc.intent_signals, tc.user_tags, tc.entities,
+    tc.source_platform, tc.embedding, tc.fts, NOW()
+  FROM transcript_chunks tc
+  WHERE tc.canonical_recording_id = p_recording_id;
+
+  -- ---------------------------------------------------------------
+  -- Relocate to target workspace if specified and different from HOME.
+  -- The auto_create_default_workspace_entry trigger already placed the
+  -- recording in HOME workspace. If the rule specifies a different workspace,
+  -- we move it: insert the target entry, then remove the HOME entry.
+  -- ---------------------------------------------------------------
+  IF p_target_workspace_id IS NOT NULL THEN
+    SELECT id INTO v_home_workspace_id
+    FROM workspaces
+    WHERE organization_id = p_target_org_id
+      AND is_home = TRUE
+    LIMIT 1;
+
+    IF v_home_workspace_id IS NULL OR v_home_workspace_id != p_target_workspace_id THEN
+      -- Insert target workspace entry (trigger already inserted HOME; upsert is safe)
+      INSERT INTO workspace_entries (workspace_id, recording_id, created_at)
+      VALUES (p_target_workspace_id, v_new_recording_id, NOW())
+      ON CONFLICT DO NOTHING;
+
+      -- Remove HOME workspace entry (recording should land in target workspace only)
+      IF v_home_workspace_id IS NOT NULL THEN
+        DELETE FROM workspace_entries
+        WHERE recording_id = v_new_recording_id
+          AND workspace_id = v_home_workspace_id;
+      END IF;
+    END IF;
+  END IF;
+
+  -- Delete source recording if requested (move semantics).
+  -- workspace_entries references recordings via FK — entries must be removed first.
+  IF p_delete_source THEN
+    DELETE FROM workspace_entries WHERE recording_id = p_recording_id;
+    DELETE FROM recordings WHERE id = p_recording_id;
+  END IF;
+
+  RETURN v_new_recording_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN, UUID) IS
+  'Cross-org routing: copies a recording to a target organization and optionally deletes the source. '
+  'Called by edge functions using service role — takes p_user_id explicitly instead of auth.uid(). '
+  'Verifies user membership in BOTH source and target orgs. '
+  'p_target_workspace_id: if set, moves the copy to that workspace instead of HOME. '
+  'Copied recording chunks set recording_id = NULL (no fathom_calls entry in target org).';
+
+REVOKE EXECUTE ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN, UUID) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN, UUID) TO service_role;
+
+-- ============================================================================
+-- 3. UPDATE copy_recording_to_organization — same chunk fix
+-- ============================================================================
+-- The same UNIQUE(recording_id, chunk_index) violation affects this RPC.
+-- Set recording_id = NULL for copied chunks (consistent with route_recording_cross_org).
+
+CREATE OR REPLACE FUNCTION public.copy_recording_to_organization(
+  p_recording_id UUID,
+  p_target_org_id UUID
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller_id UUID;
+  v_source RECORD;
+  v_new_recording_id UUID;
+  v_target_home_workspace_id UUID;
+BEGIN
+  v_caller_id := auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT * INTO v_source
+  FROM recordings
+  WHERE id = p_recording_id;
+
+  IF v_source IS NULL THEN
+    RAISE EXCEPTION 'Recording not found: %', p_recording_id;
+  END IF;
+
+  IF NOT is_organization_member(v_source.organization_id, v_caller_id) THEN
+    RAISE EXCEPTION 'Access denied: not a member of source organization';
+  END IF;
+
+  IF NOT is_organization_member(p_target_org_id, v_caller_id) THEN
+    RAISE EXCEPTION 'Access denied: not a member of target organization';
+  END IF;
+
+  IF v_source.organization_id = p_target_org_id THEN
+    RAISE EXCEPTION 'Source and target organization are the same';
+  END IF;
+
+  SELECT id INTO v_target_home_workspace_id
+  FROM workspaces
+  WHERE organization_id = p_target_org_id
+    AND is_home = TRUE
+  LIMIT 1;
+
+  IF v_target_home_workspace_id IS NULL THEN
+    RAISE EXCEPTION 'Target organization has no HOME workspace';
+  END IF;
+
+  INSERT INTO recordings (
+    organization_id, owner_user_id, title, audio_url, video_url,
+    full_transcript, summary, global_tags, source_app, source_metadata,
+    duration, recording_start_time, recording_end_time,
+    source_call_id, created_at, synced_at
+  )
+  VALUES (
+    p_target_org_id,
+    v_caller_id,
+    v_source.title,
+    v_source.audio_url,
+    v_source.video_url,
+    v_source.full_transcript,
+    v_source.summary,
+    v_source.global_tags,
+    v_source.source_app,
+    COALESCE(v_source.source_metadata, '{}'::jsonb) || jsonb_build_object(
+      'copied_from_recording_id', p_recording_id,
+      'copied_from_org_id', v_source.organization_id,
+      'copied_at', NOW()::TEXT,
+      'copied_by', v_caller_id
+    ),
+    v_source.duration,
+    v_source.recording_start_time,
+    v_source.recording_end_time,
+    NULL,
+    NOW(),
+    v_source.synced_at
+  )
+  RETURNING id INTO v_new_recording_id;
+
+  -- Copy transcript_chunks.
+  -- recording_id = NULL: cross-org copies have no fathom_calls entry in the target org.
+  INSERT INTO transcript_chunks (
+    canonical_recording_id, recording_id, user_id, chunk_text, chunk_index,
+    speaker_name, speaker_email, call_date, call_title, call_category, topics,
+    sentiment, intent_signals, user_tags, entities, source_platform, embedding, fts, created_at
+  )
+  SELECT
+    v_new_recording_id,
+    NULL,   -- recording_id: NULL for cross-org copies (no fathom_calls entry in target org)
+    v_caller_id,
+    tc.chunk_text, tc.chunk_index, tc.speaker_name, tc.speaker_email,
+    tc.call_date, tc.call_title, tc.call_category, tc.topics,
+    tc.sentiment, tc.intent_signals, tc.user_tags, tc.entities,
+    tc.source_platform, tc.embedding, tc.fts, NOW()
+  FROM transcript_chunks tc
+  WHERE tc.canonical_recording_id = p_recording_id;
+
+  INSERT INTO workspace_entries (workspace_id, recording_id, created_at)
+  VALUES (v_target_home_workspace_id, v_new_recording_id, NOW())
+  ON CONFLICT DO NOTHING;
+
+  RETURN v_new_recording_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.copy_recording_to_organization(UUID, UUID) IS
+  'Copies a recording (and transcript_chunks) to a target organization. '
+  'Caller must be a member of BOTH source and target orgs. '
+  'New recording is placed in the target org HOME workspace. '
+  'Copied chunks set recording_id = NULL (no fathom_calls entry in target org).';
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================

--- a/supabase/migrations/20260309210000_fix_cross_org_routing_chunks_and_workspace.sql
+++ b/supabase/migrations/20260309210000_fix_cross_org_routing_chunks_and_workspace.sql
@@ -41,6 +41,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_transcript_chunks_canonical_chunk
 --   a) Added p_target_workspace_id parameter (optional; NULL = HOME workspace).
 --   b) Chunk copy now sets recording_id = NULL (avoids BIGINT uniqueness conflict).
 --   c) After trigger places copy in HOME, relocates to target workspace if specified.
+--   d) Move semantics: explicitly delete transcript_chunks before recordings
+--      (canonical_recording_id FK is ON DELETE SET NULL, not CASCADE).
+--
+-- Drop the old 4-parameter overload created in 20260309200000: CREATE OR REPLACE
+-- with a new parameter list creates a new overload rather than replacing the old one.
+-- The old overload is dead (never called) and should be cleaned up.
+DROP FUNCTION IF EXISTS public.route_recording_cross_org(UUID, UUID, UUID, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION public.route_recording_cross_org(
   p_recording_id        UUID,
@@ -164,8 +171,12 @@ BEGIN
   END IF;
 
   -- Delete source recording if requested (move semantics).
-  -- workspace_entries references recordings via FK — entries must be removed first.
+  -- Order matters for FK constraints:
+  --   1. transcript_chunks.canonical_recording_id is ON DELETE SET NULL (not CASCADE),
+  --      so chunks would be orphaned rather than removed. Delete explicitly.
+  --   2. workspace_entries.recording_id is a FK — entries must be removed before recording.
   IF p_delete_source THEN
+    DELETE FROM transcript_chunks WHERE canonical_recording_id = p_recording_id;
     DELETE FROM workspace_entries WHERE recording_id = p_recording_id;
     DELETE FROM recordings WHERE id = p_recording_id;
   END IF;


### PR DESCRIPTION
## Summary

- Extends `import_routing_rules` to support routing calls to a different organization by copying the recording (with optional delete of source)
- Adds `target_organization_id` (nullable FK) and `delete_after_copy` (boolean) columns with RLS requiring target org membership
- New `route_recording_cross_org()` SECURITY DEFINER RPC handles secure cross-org copying without needing user JWT
- Routing engine, connector pipeline, and bulk-apply all handle cross-org rules
- UI: org selector in DestinationPicker (when user is in multiple orgs), cross-org badge in rule cards, copy/move toggle in slide-over

## Changes

**Backend:**
- `supabase/migrations/20260309200000_cross_org_routing_rules.sql` — schema + RLS + RPC
- `supabase/functions/_shared/routing-engine.ts` — types + SELECT updated
- `supabase/functions/_shared/connector-pipeline.ts` — cross-org branch in runPipeline
- `supabase/functions/apply-routing-rules/index.ts` — cross-org branch in bulk apply

**Frontend:**
- `src/types/routing.ts` — RoutingRule and RoutingDestination extended
- `src/components/import/DestinationPicker.tsx` — two-step org→workspace picker
- `src/components/import/RoutingRuleCard.tsx` — cross-org badge
- `src/components/import/RoutingRuleSlideOver.tsx` — deleteAfterCopy toggle
- `src/components/import/RoutingRulesList.tsx` — orgNames prop passthrough
- `src/components/import/RoutingRulesTab.tsx` — orgNames data fetching
- `src/hooks/useRoutingRules.ts` — mutation types include new fields

## Test plan
- [ ] Create a same-org routing rule — existing behavior unchanged
- [ ] Create a cross-org routing rule (requires user in 2+ orgs) — org selector appears in destination picker
- [ ] Cross-org rule card shows "Cross-org" badge
- [ ] Import a call that matches a cross-org rule — copy appears in target org HOME workspace
- [ ] `delete_after_copy = false` (default) — original stays in source org
- [ ] `delete_after_copy = true` — original deleted from source org after copy
- [ ] RLS: attempting to save a cross-org rule targeting an org user is NOT a member of — blocked
- [ ] Bulk apply with cross-org rules — uses `route_recording_cross_org` RPC

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)