### PR TITLE
feat(95): workspace_entries home-guard RLS migration

### DIFF
--- a/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
+++ b/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
@@ -50,6 +50,39 @@ CREATE POLICY "Members can delete own entries from non-home workspaces"
   );
 
 -- =============================================================================
+-- 2. Block UPDATE of workspace_id / recording_id for home-workspace entries
+--    A client could bypass the DELETE guard by changing the key columns
+--    (e.g. UPDATE workspace_entries SET workspace_id = <other> ...) rather
+--    than deleting the row. A BEFORE UPDATE trigger closes that loophole.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION workspace_entries_immutable_home_keys()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- Only block changes to the relationship keys; other columns (future ones) are fine
+  IF (NEW.workspace_id <> OLD.workspace_id OR NEW.recording_id <> OLD.recording_id) THEN
+    IF EXISTS (
+      SELECT 1 FROM workspaces WHERE id = OLD.workspace_id AND is_home = true
+    ) THEN
+      RAISE EXCEPTION
+        'workspace_entries: key columns are immutable for home workspace entries (workspace_id=%, recording_id=%)',
+        OLD.workspace_id, OLD.recording_id
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_workspace_entries_immutable_home_keys ON workspace_entries;
+CREATE TRIGGER trg_workspace_entries_immutable_home_keys
+  BEFORE UPDATE ON workspace_entries
+  FOR EACH ROW EXECUTE FUNCTION workspace_entries_immutable_home_keys();
+
+-- =============================================================================
 -- END OF MIGRATION
 -- =============================================================================
 

--- a/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
+++ b/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
@@ -1,0 +1,56 @@
+-- Migration: Workspace entries home-workspace guard
+-- Purpose:   Issue #95 — Add/remove call from workspace
+--            1. Tighten DELETE RLS on workspace_entries so regular users
+--               cannot remove recordings from the home workspace via RLS.
+--               (SECURITY DEFINER functions such as delete_recording bypass RLS
+--               and are therefore unaffected by this change.)
+--            2. Verify INSERT RLS already allows workspace members to add calls.
+--               (No change needed — "Workspace members can create entries" exists.)
+--            3. The recording FK (workspace_entries.recording_id -> recordings.id
+--               ON DELETE CASCADE) means deleting a workspace_entry row never
+--               deletes the underlying recording — this is correct by design.
+-- Closes:    #95 (backend requirements)
+-- Date:      2026-03-10
+
+BEGIN;
+
+-- =============================================================================
+-- 1. Tighten workspace_entries DELETE to block home-workspace removals
+--    via RLS (protects against accidental client-side misuse).
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Workspace admins can delete entries" ON workspace_entries;
+CREATE POLICY "Workspace admins can delete entries from non-home workspaces"
+  ON workspace_entries FOR DELETE
+  USING (
+    is_workspace_admin_or_owner(workspace_id, auth.uid())
+    AND NOT EXISTS (
+      SELECT 1 FROM workspaces WHERE id = workspace_id AND is_home = true
+    )
+  );
+
+DROP POLICY IF EXISTS "Members can delete own entries" ON workspace_entries;
+CREATE POLICY "Members can delete own entries from non-home workspaces"
+  ON workspace_entries FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM workspace_memberships
+      WHERE workspace_memberships.workspace_id = workspace_entries.workspace_id
+        AND workspace_memberships.user_id = auth.uid()
+        AND workspace_memberships.role IN ('member', 'manager')
+    )
+    AND EXISTS (
+      SELECT 1 FROM recordings
+      WHERE recordings.id = workspace_entries.recording_id
+        AND recordings.owner_user_id = auth.uid()
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM workspaces WHERE id = workspace_id AND is_home = true
+    )
+  );
+
+-- =============================================================================
+-- END OF MIGRATION
+-- =============================================================================
+
+COMMIT;

--- a/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
+++ b/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
@@ -25,7 +25,7 @@ CREATE POLICY "Workspace admins can delete entries from non-home workspaces"
   USING (
     is_workspace_admin_or_owner(workspace_id, auth.uid())
     AND NOT EXISTS (
-      SELECT 1 FROM workspaces WHERE id = workspace_id AND is_home = true
+      SELECT 1 FROM workspaces WHERE id = workspace_entries.workspace_id AND is_home = true
     )
   );
 
@@ -45,7 +45,7 @@ CREATE POLICY "Members can delete own entries from non-home workspaces"
         AND recordings.owner_user_id = auth.uid()
     )
     AND NOT EXISTS (
-      SELECT 1 FROM workspaces WHERE id = workspace_id AND is_home = true
+      SELECT 1 FROM workspaces WHERE id = workspace_entries.workspace_id AND is_home = true
     )
   );
 

--- a/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
+++ b/supabase/migrations/20260310000001_workspace_entries_home_guard.sql
@@ -60,6 +60,7 @@ CREATE OR REPLACE FUNCTION workspace_entries_immutable_home_keys()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public
 AS $$
 BEGIN
   -- Only block changes to the relationship keys; other columns (future ones) are fine


### PR DESCRIPTION
## Summary
- Adds RLS migration (`20260310000001_workspace_entries_home_guard.sql`) to protect home workspace entries from deletion
- Home workspace entries (`is_home = true`) cannot be removed via RLS DELETE policy
- Applies to both personal home workspaces (`workspace_type='personal', is_home=true`) and team home workspaces (`workspace_type='team', is_home=true`)

## Why
Issue #95 introduces "Remove from Workspace" UI. Without this guard, a user could accidentally remove a call from their home workspace, making it disappear from the default view entirely.

## Test plan
- [ ] Attempt to delete a workspace_entries row where the workspace has `is_home = true` — should be blocked by RLS with permission error
- [ ] Deleting a workspace_entries row for a non-home workspace should succeed normally

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)