### PR TITLE
fix(108): backfill duration and fix invitees for recordings

### DIFF
--- a/supabase/migrations/20260309200000_backfill_recording_duration.sql
+++ b/supabase/migrations/20260309200000_backfill_recording_duration.sql
@@ -1,0 +1,16 @@
+-- Migration: Backfill missing duration for Fathom recordings
+-- Issue #108: 97% of recordings (1,532/1,581) have NULL duration
+--
+-- Root cause: Original bulk import set duration=NULL. The recordings table
+-- already has recording_start_time and recording_end_time populated, so we
+-- can compute duration directly without joining raw tables.
+--
+-- YouTube recordings (6 rows) also lack duration but their raw tables have
+-- NULL youtube_duration as well — those require a YouTube API re-fetch and
+-- are handled separately via the import pipeline for new imports.
+
+UPDATE recordings
+SET duration = EXTRACT(EPOCH FROM (recording_end_time - recording_start_time))::INTEGER
+WHERE duration IS NULL
+  AND recording_start_time IS NOT NULL
+  AND recording_end_time IS NOT NULL;

--- a/supabase/migrations/20260309200001_fix_fathom_calls_view.sql
+++ b/supabase/migrations/20260309200001_fix_fathom_calls_view.sql
@@ -1,0 +1,14 @@
+-- Migration: Fix fathom_calls view to include canonical_recording_id
+-- Issue #108: Invitees data exists but appears missing in the UI
+--
+-- Bug: The fathom_calls VIEW was created before the canonical_recording_id
+-- column was added to fathom_raw_calls. It uses explicit column names, so
+-- it silently omits canonical_recording_id. Queries in raw-calls.service.ts
+-- filter on canonical_recording_id via this view and return null, hiding
+-- the existing calendar_invitees data.
+--
+-- Fix: Recreate the view using SELECT * so all current and future columns
+-- from fathom_raw_calls are automatically included.
+
+CREATE OR REPLACE VIEW fathom_calls AS
+  SELECT * FROM fathom_raw_calls;

--- a/supabase/migrations/20260309200002_fix_bogus_recording_durations.sql
+++ b/supabase/migrations/20260309200002_fix_bogus_recording_durations.sql
@@ -1,0 +1,8 @@
+-- Migration: Null out implausibly large durations from corrupt timestamp data
+-- Issue #108: Two recordings had start_time in 2021 and end_time years later,
+-- producing durations of 120M+ seconds (~4 years). These indicate bad data in
+-- recording_end_time, not real call lengths. Cap at 12 hours (43200 seconds).
+
+UPDATE recordings
+SET duration = NULL
+WHERE duration > 43200;


### PR DESCRIPTION
## Summary

- **Backfill duration** for 1,526 Fathom recordings: original bulk import stored `NULL` for `duration`, but `recording_start_time` and `recording_end_time` were already populated. Computed `EXTRACT(EPOCH FROM (end - start))` to fill the gap.
- **Fix `fathom_calls` view**: the view was created before `canonical_recording_id` was added to `fathom_raw_calls`, so queries filtering on that column silently returned null — hiding invitees data for 1,547 recordings. Recreated as `SELECT *` to include all columns.
- **Null bogus durations**: two recordings had corrupt timestamps (start 2021, end 2025/2026) producing 120M+ second durations. Nulled out anything over 12 hours.

## What's not changed

- **Speakers**: parsed client-side from `full_transcript` regex — works for 1,568/1,581 recordings, no backend change needed.
- **YouTube duration** (6 recordings): raw tables also have `NULL` for `youtube_duration`, so no backfill possible without re-fetching from YouTube API. The import pipeline already handles duration correctly for new imports via `parseDurationToSeconds`. Existing 6 are tracked separately.

## Test plan

- [ ] Verify recordings in the UI now show duration (previously blank)
- [ ] Verify call detail panel shows invitees (previously blank despite data existing)
- [ ] Spot-check a few recordings to confirm duration values are reasonable

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)