### PR TITLE
refactor: rename Hub/Vault/Bank code identifiers to Workspace/Organization

### DIFF
--- a/src/components/import/YouTubeImportForm.tsx
+++ b/src/components/import/YouTubeImportForm.tsx
@@ -191,7 +191,7 @@ export function YouTubeImportForm({ onSuccess, onError, className }: YouTubeImpo
     setUrl('');
     setCurrentStep('idle');
     setError(undefined);
-    // Keep selectedWorkspaceId — user likely wants same vault for next import
+    // Keep selectedWorkspaceId — user likely wants same workspace for next import
   }, []);
 
   const isValid = url.trim().length > 0 && isValidYouTubeInput(url.trim());

--- a/src/components/panels/WorkspaceMemberPanel.tsx
+++ b/src/components/panels/WorkspaceMemberPanel.tsx
@@ -155,7 +155,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
   )
 
   // Handle member removal
-  const handleRemoveHubMember = useCallback(
+  const handleRemoveWorkspaceMember = useCallback(
     (member: WorkspaceMember) => {
       if (!currentUserRole) return
       if (!confirm(`Remove ${member.display_name || member.email || 'this member'} from this workspace?`)) return
@@ -169,7 +169,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
   )
 
   // Handle leave workspace
-  const handleLeaveHub = useCallback(() => {
+  const handleLeaveWorkspace = useCallback(() => {
     if (!currentUserMembership || !currentUserRole) return
     if (!confirm('Are you sure you want to leave this workspace?')) return
     leaveWorkspace.mutate({
@@ -361,7 +361,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
                             <DropdownMenuSeparator />
                               <DropdownMenuItem
                                 className="text-destructive focus:text-destructive"
-                                onClick={() => handleRemoveHubMember(member)}
+                                onClick={() => handleRemoveWorkspaceMember(member)}
                               >
                                 <RiDeleteBinLine className="h-4 w-4 mr-2" />
                                 Remove from Workspace
@@ -372,7 +372,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
                           {isCurrentUser && currentUserRole !== 'workspace_owner' && (
                             <DropdownMenuItem
                               className="text-destructive focus:text-destructive"
-                              onClick={handleLeaveHub}
+                              onClick={handleLeaveWorkspace}
                              >
                               <RiLogoutCircleLine className="h-4 w-4 mr-2" />
                               Leave Workspace

--- a/src/components/settings/WorkspaceManagement.tsx
+++ b/src/components/settings/WorkspaceManagement.tsx
@@ -270,7 +270,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
           </Card>
         ) : (
           workspaces?.map((workspace) => (
-            <HubCard
+            <WorkspaceCard
               key={workspace.id}
               workspace={workspace}
               canManage={canManage}
@@ -282,12 +282,12 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
   )
 }
 
-interface HubCardProps {
+interface WorkspaceCardProps {
   workspace: WorkspaceQueryResult
   canManage: boolean
 }
 
-function HubCard({ workspace, canManage }: HubCardProps) {
+function WorkspaceCard({ workspace, canManage }: WorkspaceCardProps) {
   const { openPanel } = usePanelStore()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const memberCount = workspace.memberships?.length || 0

--- a/src/components/tags/RecurringTitlesTab.tsx
+++ b/src/components/tags/RecurringTitlesTab.tsx
@@ -111,7 +111,7 @@ export function RecurringTitlesTab() {
     },
   });
 
-  // Fetch tags scoped to active bank/workspace
+  // Fetch tags scoped to active organization/workspace
   const { data: tags } = useQuery({
     queryKey: ["call-tags", activeOrganizationId],
     queryFn: async () => {
@@ -130,7 +130,7 @@ export function RecurringTitlesTab() {
     },
   });
 
-  // Fetch folders scoped to active bank/workspace
+  // Fetch folders scoped to active organization/workspace
   const { data: folders } = useQuery({
     queryKey: ["folders", activeOrganizationId],
     queryFn: async () => {

--- a/src/components/tags/RulesTab.tsx
+++ b/src/components/tags/RulesTab.tsx
@@ -148,7 +148,7 @@ export function RulesTab() {
     },
   });
 
-  // Fetch tags scoped to active bank/workspace
+  // Fetch tags scoped to active organization/workspace
   const { data: tags } = useQuery({
     queryKey: ["call-tags", activeOrganizationId],
     queryFn: async () => {
@@ -167,7 +167,7 @@ export function RulesTab() {
     },
   });
 
-  // Fetch folders scoped to active bank/workspace
+  // Fetch folders scoped to active organization/workspace
   const { data: folders } = useQuery({
     queryKey: ["folders", activeOrganizationId],
     queryFn: async () => {

--- a/src/components/tags/__tests__/FoldersTab.integration.test.tsx
+++ b/src/components/tags/__tests__/FoldersTab.integration.test.tsx
@@ -87,10 +87,10 @@ vi.mock('sonner', () => ({
   },
 }));
 
-// Mock useOrganizationContext (used by QuickCreateFolderDialog for bank-scoped folder operations)
+// Mock useOrganizationContext (used by QuickCreateFolderDialog for organization-scoped folder operations)
 vi.mock('@/hooks/useOrganizationContext', () => ({
   useOrganizationContext: vi.fn(() => ({
-    activeOrganizationId: 'test-bank-id',
+    activeOrganizationId: 'test-organization-id',
     activeWorkspaceId: null,
     isLoading: false,
     isInitialized: true,
@@ -120,7 +120,7 @@ import type { Folder } from '@/hooks/useFolders';
 const createMockFolder = (overrides: Partial<Folder> = {}): Folder => ({
   id: 'folder-1',
   user_id: 'user-1',
-  organization_id: 'test-bank-id',
+  organization_id: 'test-organization-id',
   name: 'Test Folder',
   description: null,
   color: '#6B7280',

--- a/src/hooks/useOrganizationContext.ts
+++ b/src/hooks/useOrganizationContext.ts
@@ -33,7 +33,7 @@ export function useOrganizationContext(): {
   isPersonalOrganization: boolean
   isPersonalOrg: boolean
   isBusinessOrganization: boolean
-  bankRole: OrganizationRole | null
+  organizationRole: OrganizationRole | null
   orgRole: OrganizationRole | null
   workspaceRole: WorkspaceRole | null
 } {
@@ -118,7 +118,7 @@ export function useOrganizationContext(): {
     isPersonalOrganization: activeOrganization?.type === 'personal', // Legacy alias
     isPersonalOrg: isPersonalOrg, // Already a boolean from useOrgContext
     isBusinessOrganization: activeOrganization?.type === 'business', // Legacy alias
-    bankRole: activeOrganization?.membership.role || null, // Legacy alias
+    organizationRole: activeOrganization?.membership.role || null, // Legacy alias
     orgRole: activeOrganization?.membership.role || null,
     workspaceRole: activeWorkspaceData?.membership.role || null,
   }

--- a/src/hooks/useRecordingSearch.ts
+++ b/src/hooks/useRecordingSearch.ts
@@ -1,5 +1,5 @@
 /**
- * useRecordingSearch - Client-side search, filter, and sort for vault recordings
+ * useRecordingSearch - Client-side search, filter, and sort for workspace recordings
  *
  * Provides debounced title search (300ms), date range filtering, and
  * multi-field sorting for WorkspaceRecording arrays.
@@ -83,7 +83,7 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 }
 
 /**
- * useRecordingSearch - Search, filter, and sort vault recordings client-side
+ * useRecordingSearch - Search, filter, and sort workspace recordings client-side
  *
  * @param options.recordings - Source recordings array from useWorkspaceRecordings
  * @returns Search/filter state + filtered results

--- a/src/hooks/useRoutingRules.ts
+++ b/src/hooks/useRoutingRules.ts
@@ -1,6 +1,6 @@
 /**
  * useRoutingRules — TanStack Query hooks for import routing rule management.
- * Column names match post-Phase-16 DB rename: bank_id→organization_id, vault_id→workspace_id.
+ * Column names: organization_id (formerly bank_id), workspace_id (formerly vault_id).
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';

--- a/src/hooks/useYouTubeSearch.ts
+++ b/src/hooks/useYouTubeSearch.ts
@@ -1,5 +1,5 @@
 /**
- * useYouTubeSearch - YouTube-specific search, filter, and sort for vault recordings
+ * useYouTubeSearch - YouTube-specific search, filter, and sort for workspace recordings
  *
  * Extends the useRecordingSearch pattern with YouTube-specific sort fields
  * (views, likes) and published-date tie-breaker logic.

--- a/src/services/recordings.service.ts
+++ b/src/services/recordings.service.ts
@@ -40,7 +40,7 @@ export async function getRecordings(): Promise<RecordingListItem[]> {
 }
 
 /**
- * Fetches recordings belonging to a specific workspace (vault).
+ * Fetches recordings belonging to a specific workspace.
  *
  * Two-step query:
  * 1. Get recording_id values from workspace_entries where workspace_id = workspaceId
@@ -57,7 +57,7 @@ export async function getRecordingsByWorkspace(workspaceId: string): Promise<Rec
     .eq('workspace_id', workspaceId)
 
   if (entriesError) {
-    throw new Error(`Failed to fetch vault entries for workspace: ${entriesError.message}`)
+    throw new Error(`Failed to fetch workspace entries: ${entriesError.message}`)
   }
 
   const recordingIds: string[] = (entries ?? []).map((e: { recording_id: string }) => e.recording_id)

--- a/src/types/routing.ts
+++ b/src/types/routing.ts
@@ -2,7 +2,7 @@
  * Routing Rule Types — Phase 18 Import Routing Rules
  *
  * These types mirror the import_routing_rules and import_routing_defaults
- * DB tables (post Phase 16 rename: banks→organizations, vaults→workspaces).
+ * DB tables: organizations (formerly banks) and workspaces (formerly vaults).
  */
 
 export interface RoutingCondition {


### PR DESCRIPTION
## Summary

- `HubCard` → `WorkspaceCard`, `HubCardProps` → `WorkspaceCardProps` (WorkspaceManagement.tsx)
- `handleRemoveHubMember` → `handleRemoveWorkspaceMember`, `handleLeaveHub` → `handleLeaveWorkspace` (WorkspaceMemberPanel.tsx)
- `bankRole` → `organizationRole` (useOrganizationContext.ts)
- Comments updated: `vault` → `workspace`, `bank` → `organization` across hooks, services, tags, tests, and type files
- Legacy rename references in routing.ts and useRoutingRules.ts updated to current naming

No DB table/column names, file names, UI strings, `GitHub` references, Remix Icon names, or `callvault-*` localStorage keys were changed.

Closes #107

## Test plan

- [x] TypeScript compiles with no errors (`npm run type-check`)
- [x] Changed files verified: all 12 target files match the specified renames
- [x] Pre-existing lint warnings and test failures are unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)