### PR TITLE
feat: unified skeuomorphic button system applied consistently (#106)

### DIFF
--- a/src/components/dialogs/CopyToOrganizationDialog.tsx
+++ b/src/components/dialogs/CopyToOrganizationDialog.tsx
@@ -146,7 +146,7 @@ export function CopyToOrganizationDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          <Button variant="hollow" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/src/components/dialogs/CreateWorkspaceDialog.tsx
+++ b/src/components/dialogs/CreateWorkspaceDialog.tsx
@@ -282,7 +282,7 @@ export function CreateWorkspaceDialog({
 
         <DialogFooter>
           <Button
-            variant="ghost"
+            variant="hollow"
             onClick={() => onOpenChange(false)}
             disabled={createWorkspace.isPending}
             aria-label="Cancel workspace creation"

--- a/src/components/dialogs/EditWorkspaceDialog.tsx
+++ b/src/components/dialogs/EditWorkspaceDialog.tsx
@@ -171,7 +171,7 @@ export function EditWorkspaceDialog({
 
           <DialogFooter className="flex items-center justify-end">
             <Button
-              variant="ghost"
+              variant="hollow"
               onClick={() => onOpenChange(false)}
               disabled={updateWorkspace.isPending}
               aria-label="Cancel changes"

--- a/src/components/dialogs/MoveToWorkspaceDialog.tsx
+++ b/src/components/dialogs/MoveToWorkspaceDialog.tsx
@@ -147,7 +147,7 @@ export function MoveToWorkspaceDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          <Button variant="hollow" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/src/components/dialogs/OrganizationInviteDialog.tsx
+++ b/src/components/dialogs/OrganizationInviteDialog.tsx
@@ -129,7 +129,7 @@ export function OrganizationInviteDialog({
             <DialogFooter className="pt-2">
               <Button
                 type="button"
-                variant="ghost"
+                variant="hollow"
                 onClick={() => onOpenChange(false)}
               >
                 Cancel

--- a/src/components/import/RoutingRuleSlideOver.tsx
+++ b/src/components/import/RoutingRuleSlideOver.tsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { RiCloseLine, RiInformationLine } from '@remixicon/react';
+import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { useRoutingRuleStore } from '@/stores/routingRuleStore';
@@ -165,18 +166,15 @@ export function RoutingRuleSlideOver() {
               <h2 className="text-base font-semibold text-foreground">
                 {isEditMode ? 'Edit Rule' : 'Create Rule'}
               </h2>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon"
                 onClick={closeSlideOver}
                 aria-label="Close"
-                className={cn(
-                  'flex items-center justify-center w-8 h-8 rounded-md',
-                  'text-muted-foreground hover:text-foreground hover:bg-muted',
-                  'transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                )}
               >
                 <RiCloseLine className="h-5 w-5" />
-              </button>
+              </Button>
             </div>
 
             <div className="flex-1 overflow-y-auto px-5 py-5 space-y-5">
@@ -245,31 +243,20 @@ export function RoutingRuleSlideOver() {
             </div>
 
             <div className="shrink-0 flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
-              <button
+              <Button
                 type="button"
+                variant="hollow"
+                size="sm"
                 onClick={closeSlideOver}
                 disabled={isSaving}
-                className={cn(
-                  'h-9 px-4 rounded-md border border-border bg-transparent',
-                  'text-sm font-medium text-foreground',
-                  'hover:bg-muted transition-colors',
-                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                  'disabled:opacity-50 disabled:cursor-not-allowed'
-                )}
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                size="sm"
                 onClick={handleSave}
                 disabled={!canSave}
-                className={cn(
-                  'h-9 px-4 rounded-md',
-                  'text-sm font-medium text-white',
-                  'bg-brand-500 hover:bg-brand-600 transition-colors',
-                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                  'disabled:opacity-50 disabled:cursor-not-allowed'
-                )}
               >
                 {isSaving
                   ? isEditMode
@@ -278,7 +265,7 @@ export function RoutingRuleSlideOver() {
                   : isEditMode
                   ? 'Save changes'
                   : 'Create rule'}
-              </button>
+              </Button>
             </div>
           </motion.aside>
         </>

--- a/src/components/import/RoutingRulesTab.tsx
+++ b/src/components/import/RoutingRulesTab.tsx
@@ -4,7 +4,7 @@
 
 import { useState } from 'react';
 import { RiRouteLine, RiFlashlightLine, RiLoader2Line } from '@remixicon/react';
-import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 import { useRoutingRules, useRoutingDefault, useReorderRules, useToggleRule } from '@/hooks/useRoutingRules';
 import { usePanelStore } from '@/stores/panelStore';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
@@ -109,21 +109,15 @@ export function RoutingRulesTab() {
       {hasRules && (
         <div className="space-y-3">
           <div className="flex items-center gap-3">
-            <button
+            <Button
               type="button"
+              size="sm"
               onClick={handleOpenCreate}
               disabled={!hasDefault}
               title={!hasDefault ? 'Set a default destination above before creating rules' : undefined}
-              className={cn(
-                'rounded-lg px-4 py-2 text-sm font-semibold',
-                'bg-foreground text-background',
-                'hover:bg-foreground/90 transition-colors',
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                'disabled:opacity-50 disabled:cursor-not-allowed',
-              )}
             >
               Create Rule
-            </button>
+            </Button>
             {!hasDefault && (
               <p className="text-xs text-amber-500">
                 Set a default destination above before creating rules
@@ -144,36 +138,27 @@ export function RoutingRulesTab() {
                 </p>
               </div>
               <div className="flex items-center gap-2 shrink-0">
-                <button
+                <Button
                   type="button"
+                  variant="hollow"
+                  size="sm"
                   onClick={handleBulkDryRun}
                   disabled={bulkApply.isPending}
-                  className={cn(
-                    'rounded-lg px-3 py-1.5 text-xs font-medium',
-                    'border border-border bg-background text-foreground',
-                    'hover:bg-muted transition-colors',
-                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                    'disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5',
-                  )}
+                  className="text-xs"
                 >
                   {bulkApply.isPending ? <RiLoader2Line className="h-3 w-3 animate-spin" /> : null}
                   Preview
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  size="sm"
                   onClick={handleBulkApply}
                   disabled={bulkApply.isPending}
-                  className={cn(
-                    'rounded-lg px-3 py-1.5 text-xs font-semibold',
-                    'bg-foreground text-background',
-                    'hover:bg-foreground/90 transition-colors',
-                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                    'disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5',
-                  )}
+                  className="text-xs"
                 >
                   {bulkApply.isPending ? <RiLoader2Line className="h-3 w-3 animate-spin" /> : null}
                   Apply Now
-                </button>
+                </Button>
               </div>
             </div>
 
@@ -225,22 +210,15 @@ export function RoutingRulesTab() {
             No more dragging recordings around.
           </p>
 
-          <button
+          <Button
             type="button"
             onClick={handleOpenCreate}
             disabled={!hasDefault}
             title={!hasDefault ? 'Set a default destination above to get started' : undefined}
-            className={cn(
-              'rounded-lg px-5 py-2.5 text-sm font-semibold',
-              'bg-foreground text-background',
-              'hover:bg-foreground/90 transition-colors',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              'disabled:opacity-50 disabled:cursor-not-allowed',
-              'mb-2',
-            )}
+            className="mb-2"
           >
             Create your first rule
-          </button>
+          </Button>
 
           {!hasDefault && (
             <p className="text-xs text-amber-500 mb-3">
@@ -248,13 +226,14 @@ export function RoutingRulesTab() {
             </p>
           )}
 
-          <button
+          <Button
             type="button"
+            variant="link"
             onClick={() => setShowHelp((v) => !v)}
-            className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+            className="text-xs"
           >
             Learn how routing works
-          </button>
+          </Button>
 
           {showHelp && (
             <div className="mt-4 rounded-xl border border-border/60 bg-muted/30 p-4 text-left max-w-sm w-full">

--- a/src/components/settings/TeamTab.tsx
+++ b/src/components/settings/TeamTab.tsx
@@ -383,7 +383,7 @@ export default function TeamTab() {
           {(isAdmin || isManager) && (
             <div className="flex gap-2">
               <Button
-                variant="outline"
+                variant="hollow"
                 size="sm"
                 onClick={handleGenerateInviteLink}
                 disabled={isGeneratingInvite}

--- a/src/components/settings/WorkspaceManagement.tsx
+++ b/src/components/settings/WorkspaceManagement.tsx
@@ -241,7 +241,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
               </div>
               <DialogFooter>
                 <Button
-                  variant="outline"
+                  variant="hollow"
                   onClick={() => setCreateDialogOpen(false)}
                   aria-label="Cancel workspace creation"
                 >

--- a/src/components/sync/InlineConnectionWizard.tsx
+++ b/src/components/sync/InlineConnectionWizard.tsx
@@ -342,12 +342,13 @@ export function InlineConnectionWizard({
       </p>
 
       {/* Cancel button - always visible (PRD-020) */}
-      <button
+      <Button
+        variant="link"
         onClick={handleCancel}
-        className="w-full text-xs text-ink-muted hover:text-ink underline"
+        className="w-full text-xs"
       >
         {isConnecting ? "Cancel Connection" : "Cancel"}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/pages/OrganizationJoin.tsx
+++ b/src/pages/OrganizationJoin.tsx
@@ -168,9 +168,9 @@ export default function OrganizationJoin() {
             >
               {isAccepting ? 'Joining...' : 'Accept Invite & Join'}
             </Button>
-            <Button 
-              variant="ghost" 
-              className="w-full text-muted-foreground"
+            <Button
+              variant="hollow"
+              className="w-full"
               onClick={() => navigate('/')}
             >
               Decline

--- a/src/pages/WorkspaceJoin.tsx
+++ b/src/pages/WorkspaceJoin.tsx
@@ -251,9 +251,9 @@ export default function WorkspaceJoin() {
             >
               {isJoining ? 'Joining...' : 'Accept Invite & Join'}
             </Button>
-            <Button 
-              variant="ghost" 
-              className="w-full text-muted-foreground"
+            <Button
+              variant="hollow"
+              className="w-full"
               onClick={() => navigate('/')}
             >
               Decline


### PR DESCRIPTION
## Summary

Closes #106

Audited the entire codebase for button variant inconsistencies and applied the unified skeuomorphic button system consistently:

- **5 dialog cancel buttons**: Changed from `variant="ghost"` → `variant="hollow"` for proper visual hierarchy (CreateWorkspace, EditWorkspace, CopyToOrganization, MoveToWorkspace, OrganizationInvite)
- **Join pages**: Decline button changed from `ghost` → `hollow` on WorkspaceJoin and OrganizationJoin to clearly differentiate from the primary CTA
- **TeamTab**: "Copy Link" secondary action changed from `outline` → `hollow`
- **WorkspaceManagement**: Inline dialog Cancel changed from `outline` → `hollow`
- **RoutingRuleSlideOver**: Replaced all 3 raw `<button>` elements with `<Button>` component (`ghost/icon` close, `hollow` Cancel, `default` Save)
- **RoutingRulesTab**: Replaced all 4 raw `<button>` elements with `<Button>` component (`default` Create Rule, `hollow` Preview, `default` Apply Now, `link` Learn more)
- **InlineConnectionWizard**: Replaced raw `<button>` Cancel with `<Button variant="link">`, removing stale v1 token `text-ink-muted`

## Test plan

- [ ] Verify dialog footers show visual hierarchy: hollow Cancel + slate-gradient primary CTA
- [ ] Verify WorkspaceJoin/OrganizationJoin Decline button has bordered hollow appearance
- [ ] Verify RoutingRuleSlideOver Cancel/Save buttons use system variants
- [ ] Verify RoutingRulesTab Create Rule / Preview / Apply Now buttons render correctly
- [ ] TypeCheck passes: `tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)