### PR TITLE
fix: empty org dropdown in copy dialog + stale Hub identifiers (#117)

### DIFF
--- a/src/components/dialogs/CopyToOrganizationDialog.tsx
+++ b/src/components/dialogs/CopyToOrganizationDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -27,9 +28,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { RiBuildingLine, RiErrorWarningLine } from '@remixicon/react'
+import { RiBuildingLine, RiErrorWarningLine, RiAddLine } from '@remixicon/react'
 import { useCopyToOrganization } from '@/hooks/useDataMovement'
-import { useOrganizations } from '@/hooks/useOrganizations'
+import { useOrganizations, useCreateOrganization } from '@/hooks/useOrganizations'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import { Checkbox } from '@/components/ui/checkbox'
 
@@ -50,16 +51,47 @@ export function CopyToOrganizationDialog({
   const { data: organizations, isLoading } = useOrganizations()
   const [targetOrgId, setTargetOrgId] = useState<string>('')
   const [removeSource, setRemoveSource] = useState(false)
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [newOrgName, setNewOrgName] = useState('')
 
   const copyToOrg = useCopyToOrganization()
+  const createOrg = useCreateOrganization()
+
+  const otherOrgs = organizations?.filter(org => org.id !== activeOrgId) ?? []
 
   // Reset form state when dialog opens/closes
   useEffect(() => {
     if (!open) {
       setTargetOrgId('')
       setRemoveSource(false)
+      setShowCreateForm(false)
+      setNewOrgName('')
     }
   }, [open])
+
+  const handleOrgValueChange = (value: string) => {
+    if (value === '__create_new__') {
+      setShowCreateForm(true)
+      setTargetOrgId('')
+    } else {
+      setShowCreateForm(false)
+      setTargetOrgId(value)
+    }
+  }
+
+  const handleCreateOrg = () => {
+    if (!newOrgName.trim() || newOrgName.trim().length < 3) return
+    createOrg.mutate(
+      { name: newOrgName.trim() },
+      {
+        onSuccess: (org) => {
+          setTargetOrgId(org.id)
+          setShowCreateForm(false)
+          setNewOrgName('')
+        },
+      }
+    )
+  }
 
   const handleCopy = () => {
     if (!targetOrgId) return
@@ -99,24 +131,74 @@ export function CopyToOrganizationDialog({
         <div className="space-y-4 py-4">
           <div className="space-y-2">
             <Label htmlFor="org">Target Organization</Label>
-            <Select
-              value={targetOrgId}
-              onValueChange={setTargetOrgId}
-              disabled={isLoading}
-            >
-              <SelectTrigger id="org">
-                <SelectValue placeholder={isLoading ? "Loading organizations..." : "Select an organization"} />
-              </SelectTrigger>
-              <SelectContent>
-                {organizations
-                  ?.filter(org => org.id !== activeOrgId)
-                  .map(org => (
+            {showCreateForm ? (
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  <Input
+                    autoFocus
+                    placeholder="Organization name (min 3 chars)"
+                    value={newOrgName}
+                    onChange={(e) => setNewOrgName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleCreateOrg()
+                      if (e.key === 'Escape') {
+                        setShowCreateForm(false)
+                        setNewOrgName('')
+                      }
+                    }}
+                    disabled={createOrg.isPending}
+                  />
+                  <Button
+                    size="sm"
+                    onClick={handleCreateOrg}
+                    disabled={newOrgName.trim().length < 3 || createOrg.isPending}
+                    className="shrink-0"
+                  >
+                    {createOrg.isPending ? 'Creating...' : 'Create'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => { setShowCreateForm(false); setNewOrgName('') }}
+                    disabled={createOrg.isPending}
+                    className="shrink-0"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                {newOrgName.trim().length > 0 && newOrgName.trim().length < 3 && (
+                  <p className="text-xs text-destructive">Name must be at least 3 characters</p>
+                )}
+              </div>
+            ) : (
+              <Select
+                value={targetOrgId}
+                onValueChange={handleOrgValueChange}
+                disabled={isLoading}
+              >
+                <SelectTrigger id="org">
+                  <SelectValue placeholder={isLoading ? "Loading organizations..." : "Select an organization"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {otherOrgs.map(org => (
                     <SelectItem key={org.id} value={org.id}>
                       {org.name}
                     </SelectItem>
                   ))}
-              </SelectContent>
-            </Select>
+                  <SelectItem value="__create_new__">
+                    <span className="flex items-center gap-2 text-muted-foreground">
+                      <RiAddLine className="h-3.5 w-3.5" />
+                      Create new organization…
+                    </span>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+            {!isLoading && !showCreateForm && otherOrgs.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                You only have one organization. Select "Create new organization…" above to add another.
+              </p>
+            )}
           </div>
 
           <div className="flex items-center space-x-2 pt-2">
@@ -151,7 +233,7 @@ export function CopyToOrganizationDialog({
           </Button>
           <Button
             onClick={handleCopy}
-            disabled={!targetOrgId || copyToOrg.isPending}
+            disabled={!targetOrgId || copyToOrg.isPending || showCreateForm}
             className="bg-vibe-orange hover:bg-vibe-orange/90"
           >
             {copyToOrg.isPending ? 'Copying...' : `Copy ${label}`}

--- a/src/components/panels/WorkspaceMemberPanel.tsx
+++ b/src/components/panels/WorkspaceMemberPanel.tsx
@@ -155,7 +155,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
   )
 
   // Handle member removal
-  const handleRemoveHubMember = useCallback(
+  const handleRemoveWorkspaceMember = useCallback(
     (member: WorkspaceMember) => {
       if (!currentUserRole) return
       if (!confirm(`Remove ${member.display_name || member.email || 'this member'} from this workspace?`)) return
@@ -169,7 +169,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
   )
 
   // Handle leave workspace
-  const handleLeaveHub = useCallback(() => {
+  const handleLeaveWorkspace = useCallback(() => {
     if (!currentUserMembership || !currentUserRole) return
     if (!confirm('Are you sure you want to leave this workspace?')) return
     leaveWorkspace.mutate({
@@ -361,7 +361,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
                             <DropdownMenuSeparator />
                               <DropdownMenuItem
                                 className="text-destructive focus:text-destructive"
-                                onClick={() => handleRemoveHubMember(member)}
+                                onClick={() => handleRemoveWorkspaceMember(member)}
                               >
                                 <RiDeleteBinLine className="h-4 w-4 mr-2" />
                                 Remove from Workspace
@@ -372,7 +372,7 @@ export function WorkspaceMemberPanel({ workspaceId, workspaceName }: WorkspaceMe
                           {isCurrentUser && currentUserRole !== 'workspace_owner' && (
                             <DropdownMenuItem
                               className="text-destructive focus:text-destructive"
-                              onClick={handleLeaveHub}
+                              onClick={handleLeaveWorkspace}
                              >
                               <RiLogoutCircleLine className="h-4 w-4 mr-2" />
                               Leave Workspace

--- a/src/components/settings/WorkspaceManagement.tsx
+++ b/src/components/settings/WorkspaceManagement.tsx
@@ -270,7 +270,7 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
           </Card>
         ) : (
           workspaces?.map((workspace) => (
-            <HubCard
+            <WorkspaceCard
               key={workspace.id}
               workspace={workspace}
               canManage={canManage}
@@ -282,12 +282,12 @@ export function WorkspaceManagement({ orgId, canManage }: WorkspaceManagementPro
   )
 }
 
-interface HubCardProps {
+interface WorkspaceCardProps {
   workspace: WorkspaceQueryResult
   canManage: boolean
 }
 
-function HubCard({ workspace, canManage }: HubCardProps) {
+function WorkspaceCard({ workspace, canManage }: WorkspaceCardProps) {
   const { openPanel } = usePanelStore()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const memberCount = workspace.memberships?.length || 0

--- a/src/services/organizations.service.ts
+++ b/src/services/organizations.service.ts
@@ -43,12 +43,15 @@ export async function getOrganizations(userId: string): Promise<OrganizationWith
   }
 
   // Transform membership rows to OrganizationWithRole[]
+  // Filter out rows where the org join returned null (e.g. stale FK or RLS blocking)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (data ?? []).map((row: any) => ({
-    ...row.org,
-    membershipRole: row.role as string,
-    membershipId: row.id as string,
-  })) as OrganizationWithRole[]
+  return (data ?? [])
+    .filter((row: any) => row.org != null)
+    .map((row: any) => ({
+      ...row.org,
+      membershipRole: row.role as string,
+      membershipId: row.id as string,
+    })) as OrganizationWithRole[]
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes three issues from #117:

- **Empty organization dropdown** in `CopyToOrganizationDialog`: service now filters out null `org` join rows (caused by failed embedded FK join returning null), preventing spread of undefined `id`/`name` into org objects that silently broke the Select items
- **Create new organization inline**: added `__create_new__` SelectItem at the bottom of the org dropdown; selecting it reveals an inline name input that uses `useCreateOrganization` (no navigation side-effects) and auto-selects the new org on success; shows helper text when the filtered list is empty
- **Stale Hub identifiers renamed** to Workspace for internal consistency: `handleRemoveHubMember` → `handleRemoveWorkspaceMember`, `handleLeaveHub` → `handleLeaveWorkspace`, `HubCard`/`HubCardProps` → `WorkspaceCard`/`WorkspaceCardProps`

## Files changed

- `src/services/organizations.service.ts` — filter null org rows from getOrganizations
- `src/components/dialogs/CopyToOrganizationDialog.tsx` — inline create form, improved empty state
- `src/components/panels/WorkspaceMemberPanel.tsx` — rename Hub→Workspace function names
- `src/components/settings/WorkspaceManagement.tsx` — rename Hub→Workspace component name

## Test plan

- [ ] Open "Copy to Organization" dialog with a single org account → should see empty list + helper text + "Create new organization…" option
- [ ] Open dialog with multiple org account → should see all orgs except the active one
- [ ] Select "Create new organization…" → inline form appears; enter name < 3 chars → button disabled; enter valid name → org created, auto-selected in dropdown
- [ ] Submit copy with newly created org as target → copy proceeds normally
- [ ] TypeScript: `npm run type-check` passes ✅

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)