### PR TITLE
feat: differentiate People tab (your team) vs Admin tab (platform users)

### DIFF
--- a/src/components/panes/SettingsCategoryPane.tsx
+++ b/src/components/panes/SettingsCategoryPane.tsx
@@ -68,8 +68,8 @@ export const SETTINGS_CATEGORIES: CategoryItem[] = [
   },
   {
     id: "users",
-    label: "Users",
-    description: "Manage organization users",
+    label: "People",
+    description: "Your team and workspace members",
     icon: RiTeamLine,
     requiredRoles: ["TEAM", "ADMIN"],
   },

--- a/src/components/panes/SettingsDetailPane.tsx
+++ b/src/components/panes/SettingsDetailPane.tsx
@@ -75,8 +75,8 @@ const CATEGORY_META: Record<
     icon: RiContactsLine,
   },
   users: {
-    label: "Users",
-    description: "Manage organization users",
+    label: "People",
+    description: "Your team and workspace members",
     icon: RiTeamLine,
   },
   billing: {

--- a/src/components/settings/AdminTab.tsx
+++ b/src/components/settings/AdminTab.tsx
@@ -17,9 +17,11 @@ import {
   RiSearchLine,
   RiShieldLine,
   RiPulseLine,
+  RiLockLine,
 } from "@remixicon/react";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
+import { useUserRole } from "@/hooks/useUserRole";
 import { UserTable } from "@/components/settings/UserTable";
 import { supabase } from "@/integrations/supabase/client";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -55,6 +57,7 @@ interface FeatureFlag {
 
 
 export default function AdminTab() {
+  const { isAdmin, loading: roleLoading } = useUserRole();
   const [users, setUsers] = useState<UserProfile[]>([]);
   const [filteredUsers, setFilteredUsers] = useState<UserProfile[]>([]);
   const [stats, setStats] = useState<SystemStats>({
@@ -219,6 +222,26 @@ export default function AdminTab() {
       setUpdatingFlagId(null);
     }
   };
+
+  if (roleLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <RiLoader2Line className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 border border-dashed border-border rounded-xl">
+        <RiLockLine className="h-12 w-12 text-muted-foreground mb-4" />
+        <p className="text-sm font-medium text-foreground mb-1">Admin access required</p>
+        <p className="text-xs text-muted-foreground">
+          This section is restricted to platform administrators.
+        </p>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/src/components/settings/UsersTab.tsx
+++ b/src/components/settings/UsersTab.tsx
@@ -8,7 +8,6 @@ import {
   RiBuilding4Line,
   RiBuildingLine,
   RiMailLine,
-  RiUserAddLine,
   RiCloseLine,
   RiTimeLine,
 } from "@remixicon/react";
@@ -19,9 +18,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import { getOrganizations } from "@/services/organizations.service";
 import {
   getOrganizationMembers,
-  updateOrganizationMemberRole,
   removeOrganizationMember,
 } from "@/services/organizations.service";
+import {
+  getOrganizationInvitations,
+  revokeOrganizationInvitation,
+} from "@/services/organization-invitations.service";
 import type {
   OrganizationMember,
   OrganizationRole,
@@ -207,25 +209,12 @@ export default function UsersTab() {
       // 2. For each org, fetch members and pending invites
       const orgResults = await Promise.all(
         organizations.map(async (orgWithRole) => {
-          const [members, inviteData] = await Promise.all([
+          const [members, orgInvitations] = await Promise.all([
             getOrganizationMembers(orgWithRole.id).catch(() => [] as OrganizationMember[]),
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (supabase as any)
-              .from("organization_invitations")
-              .select("id, email, role, created_at, expires_at")
-              .eq("organization_id", orgWithRole.id)
-              .eq("status", "pending")
-              .order("created_at", { ascending: false })
-              .then(({ data }: { data: unknown[] | null }) => data ?? []),
+            getOrganizationInvitations(orgWithRole.id).catch(() => []),
           ]);
 
-          const pendingInvites: PendingInvite[] = (inviteData as Array<{
-            id: string;
-            email: string;
-            role: string;
-            created_at: string;
-            expires_at: string;
-          }>).map((inv) => ({
+          const pendingInvites: PendingInvite[] = orgInvitations.map((inv) => ({
             id: inv.id,
             email: inv.email,
             role: inv.role,
@@ -263,43 +252,61 @@ export default function UsersTab() {
 
       if (wsError) throw wsError;
 
-      // 4. For each workspace, fetch all members + pending invites
-      const wsResults = await Promise.all(
-        (wsMemberships ?? []).map(async (wm) => {
-          const ws = wm.workspace as { id: string; name: string; organization_id: string } | null;
-          if (!ws) return null;
+      // Collect all workspace member user IDs for a single batch profile fetch
+      const workspaceIds = (wsMemberships ?? [])
+        .map((wm) => (wm.workspace as { id: string } | null)?.id)
+        .filter(Boolean) as string[];
 
-          // Fetch workspace members
-          const { data: memberships, error: memberError } = await supabase
-            .from("workspace_memberships")
-            .select("id, user_id, role, created_at")
-            .eq("workspace_id", ws.id);
+      // Fetch all workspace memberships in one query
+      let allWsMemberships: Array<{ id: string; user_id: string; role: string; created_at: string; workspace_id: string }> = [];
+      if (workspaceIds.length > 0) {
+        const { data: allMemberships, error: allMemberError } = await supabase
+          .from("workspace_memberships")
+          .select("id, user_id, role, created_at, workspace_id")
+          .in("workspace_id", workspaceIds);
 
-          if (memberError) {
-            logger.warn("Failed to fetch workspace members", memberError);
-            return null;
-          }
+        if (allMemberError) throw allMemberError;
+        allWsMemberships = allMemberships ?? [];
+      }
 
-          // Fetch profiles for members
-          const userIds = (memberships ?? []).map((m) => m.user_id);
-          const profileMap = new Map<string, { email: string; display_name: string; avatar_url: string | null }>();
+      // Batch-fetch all user profiles in a single query (user_profiles.user_id = auth.users.id)
+      const allMemberUserIds = [...new Set(allWsMemberships.map((m) => m.user_id))];
+      const profileMap = new Map<string, { email: string; display_name: string; avatar_url: string | null }>();
 
-          if (userIds.length > 0) {
-            const { data: profiles } = await supabase
-              .from("user_profiles")
-              .select("id, email, display_name, avatar_url")
-              .in("id", userIds);
+      if (allMemberUserIds.length > 0) {
+        const { data: profiles } = await supabase
+          .from("user_profiles")
+          .select("user_id, email, display_name, avatar_url")
+          .in("user_id", allMemberUserIds);
 
-            for (const p of profiles ?? []) {
-              profileMap.set(p.id, {
-                email: p.email ?? "",
-                display_name: p.display_name ?? "",
-                avatar_url: p.avatar_url ?? null,
-              });
-            }
-          }
+        for (const p of profiles ?? []) {
+          profileMap.set(p.user_id, {
+            email: p.email ?? "",
+            display_name: p.display_name ?? "",
+            avatar_url: p.avatar_url ?? null,
+          });
+        }
+      }
 
-          const members: WorkspaceMember[] = (memberships ?? []).map((m) => {
+      // Fetch all pending workspace invitations in one query
+      let allWsInvites: Array<{ id: string; workspace_id: string; email: string; role: string; created_at: string; expires_at: string }> = [];
+      if (workspaceIds.length > 0) {
+        const { data: wsInviteData } = await supabase
+          .from("workspace_invitations")
+          .select("id, workspace_id, email, role, created_at, expires_at")
+          .in("workspace_id", workspaceIds)
+          .eq("status", "pending");
+        allWsInvites = wsInviteData ?? [];
+      }
+
+      // 4. Build workspace results using the batch-fetched data
+      const wsResults: WorkspaceWithMembers[] = (wsMemberships ?? []).map((wm) => {
+        const ws = wm.workspace as { id: string; name: string; organization_id: string } | null;
+        if (!ws) return null;
+
+        const wsMembers = allWsMemberships
+          .filter((m) => m.workspace_id === ws.id)
+          .map((m) => {
             const profile = profileMap.get(m.user_id);
             return {
               id: m.id,
@@ -312,14 +319,9 @@ export default function UsersTab() {
             };
           });
 
-          // Fetch pending workspace invitations
-          const { data: wsInvites } = await supabase
-            .from("workspace_invitations")
-            .select("id, email, role, created_at, expires_at")
-            .eq("workspace_id", ws.id)
-            .eq("status", "pending");
-
-          const pendingInvites: PendingInvite[] = (wsInvites ?? []).map((inv) => ({
+        const pendingInvites: PendingInvite[] = allWsInvites
+          .filter((inv) => inv.workspace_id === ws.id)
+          .map((inv) => ({
             id: inv.id,
             email: inv.email,
             role: inv.role,
@@ -330,17 +332,16 @@ export default function UsersTab() {
             contextId: ws.id,
           }));
 
-          return {
-            workspaceId: ws.id,
-            workspaceName: ws.name,
-            orgId: ws.organization_id,
-            members,
-            pendingInvites,
-          } satisfies WorkspaceWithMembers;
-        })
-      );
+        return {
+          workspaceId: ws.id,
+          workspaceName: ws.name,
+          orgId: ws.organization_id,
+          members: wsMembers,
+          pendingInvites,
+        };
+      }).filter(Boolean) as WorkspaceWithMembers[];
 
-      setWorkspacesWithMembers(wsResults.filter(Boolean) as WorkspaceWithMembers[]);
+      setWorkspacesWithMembers(wsResults);
     } catch (error) {
       logger.error("Error loading team data", error);
       toast.error("Failed to load team data");
@@ -353,7 +354,7 @@ export default function UsersTab() {
     loadData();
   }, [loadData]);
 
-  const handleRemoveOrgMember = async (membershipId: string, _orgId: string) => {
+  const handleRemoveOrgMember = async (membershipId: string) => {
     setRemovingId(membershipId);
     try {
       await removeOrganizationMember(membershipId);
@@ -364,17 +365,6 @@ export default function UsersTab() {
       toast.error("Failed to remove member");
     } finally {
       setRemovingId(null);
-    }
-  };
-
-  const handleUpdateOrgMemberRole = async (membershipId: string, newRole: OrganizationRole) => {
-    try {
-      await updateOrganizationMemberRole(membershipId, newRole);
-      toast.success("Role updated");
-      await loadData();
-    } catch (error) {
-      logger.error("Error updating member role", error);
-      toast.error("Failed to update role");
     }
   };
 
@@ -399,12 +389,7 @@ export default function UsersTab() {
   const handleRevokeOrgInvite = async (inviteId: string) => {
     setRevokingId(inviteId);
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase as any)
-        .from("organization_invitations")
-        .update({ status: "revoked" })
-        .eq("id", inviteId);
-      if (error) throw error;
+      await revokeOrganizationInvitation(inviteId);
       toast.success("Invitation revoked");
       await loadData();
     } catch (error) {
@@ -432,12 +417,6 @@ export default function UsersTab() {
       setRevokingId(null);
     }
   };
-
-  // Collect all pending invites across orgs + workspaces
-  const allPendingInvites: PendingInvite[] = [
-    ...orgsWithMembers.flatMap((o) => o.pendingInvites),
-    ...workspacesWithMembers.flatMap((w) => w.pendingInvites),
-  ];
 
   if (loading) {
     return (
@@ -495,7 +474,7 @@ export default function UsersTab() {
                     badge={<OrgRoleBadge role={member.role} />}
                     onRemove={
                       member.role !== "organization_owner"
-                        ? () => handleRemoveOrgMember(member.id, org.id)
+                        ? () => handleRemoveOrgMember(member.id)
                         : undefined
                     }
                     removing={removingId === member.id}
@@ -603,44 +582,6 @@ export default function UsersTab() {
             </div>
           ))}
         </section>
-      )}
-
-      {/* ── All pending invites summary (if any) ─────────────────── */}
-      {allPendingInvites.length > 0 && (
-        <>
-          <Separator />
-          <section className="space-y-4">
-            <div className="flex items-center gap-2">
-              <RiUserAddLine className="h-4 w-4 text-muted-foreground" />
-              <div>
-                <h2 className="font-semibold text-foreground">All Pending Invitations</h2>
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  {allPendingInvites.length} outstanding invitation{allPendingInvites.length !== 1 ? "s" : ""}
-                </p>
-              </div>
-            </div>
-            <div className="border border-dashed border-border rounded-xl overflow-hidden">
-              <div className="divide-y divide-border">
-                {allPendingInvites.map((invite) => (
-                  <div key={invite.id} className="flex items-center justify-between py-3 px-4">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <RiMailLine className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium text-foreground truncate">{invite.email}</p>
-                        <p className="text-xs text-muted-foreground truncate">
-                          {invite.type === "org" ? "Organization" : "Workspace"}: {invite.contextName}
-                        </p>
-                      </div>
-                    </div>
-                    <Badge variant="outline" className="ml-4 flex-shrink-0 text-xs">
-                      {invite.type === "org" ? "Org Invite" : "Workspace Invite"}
-                    </Badge>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </section>
-        </>
       )}
     </div>
   );

--- a/src/components/settings/UsersTab.tsx
+++ b/src/components/settings/UsersTab.tsx
@@ -1,121 +1,443 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { RiLoader2Line, RiGroupLine } from "@remixicon/react";
+import { Separator } from "@/components/ui/separator";
+import {
+  RiLoader2Line,
+  RiGroupLine,
+  RiBuilding4Line,
+  RiBuildingLine,
+  RiMailLine,
+  RiUserAddLine,
+  RiCloseLine,
+  RiTimeLine,
+} from "@remixicon/react";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
-import { useUserRole } from "@/hooks/useUserRole";
-import { UserTable } from "@/components/settings/UserTable";
 import { supabase } from "@/integrations/supabase/client";
-import { getSafeUser } from "@/lib/auth-utils";
-import { usePanelStore } from "@/stores/panelStore";
+import { useAuth } from "@/contexts/AuthContext";
+import { getOrganizations } from "@/services/organizations.service";
+import {
+  getOrganizationMembers,
+  updateOrganizationMemberRole,
+  removeOrganizationMember,
+} from "@/services/organizations.service";
+import type {
+  OrganizationMember,
+  OrganizationRole,
+} from "@/services/organizations.service";
+import type { Organization } from "@/types/workspace";
 
-interface UserProfile {
-  user_id: string;
-  display_name: string | null;
-  email: string;
-  role: "FREE" | "PRO" | "TEAM" | "ADMIN";
-  last_login_at: string | null;
-  onboarding_completed: boolean;
-  created_at: string;
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface OrgWithMembers {
+  org: Organization;
+  members: OrganizationMember[];
+  pendingInvites: PendingInvite[];
 }
 
+interface WorkspaceWithMembers {
+  workspaceId: string;
+  workspaceName: string;
+  orgId: string;
+  members: WorkspaceMember[];
+  pendingInvites: PendingInvite[];
+}
+
+interface WorkspaceMember {
+  id: string;
+  user_id: string;
+  role: string;
+  created_at: string;
+  email: string;
+  display_name: string;
+  avatar_url: string | null;
+}
+
+interface PendingInvite {
+  id: string;
+  email: string;
+  role: string;
+  created_at: string;
+  expires_at: string;
+  type: "org" | "workspace";
+  contextName: string;
+  contextId: string;
+}
+
+// ─── Role badge helpers ───────────────────────────────────────────────────────
+
+function OrgRoleBadge({ role }: { role: OrganizationRole }) {
+  const map: Record<OrganizationRole, { label: string; variant: "default" | "outline" | "destructive" }> = {
+    organization_owner: { label: "Owner", variant: "default" },
+    organization_admin: { label: "Admin", variant: "default" },
+    member: { label: "Member", variant: "outline" },
+  };
+  const config = map[role] ?? { label: role, variant: "outline" as const };
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+}
+
+function WorkspaceRoleBadge({ role }: { role: string }) {
+  const labels: Record<string, string> = {
+    workspace_owner: "Owner",
+    workspace_admin: "Admin",
+    manager: "Manager",
+    member: "Member",
+    guest: "Guest",
+  };
+  return <Badge variant="outline">{labels[role] ?? role}</Badge>;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function MemberRow({
+  name,
+  email,
+  badge,
+  onRemove,
+  removing,
+}: {
+  name: string;
+  email: string;
+  badge: React.ReactNode;
+  onRemove?: () => void;
+  removing?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between py-3 px-4 hover:bg-muted/40 rounded-lg transition-colors">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+          <span className="text-xs font-medium text-muted-foreground uppercase">
+            {(name || email).charAt(0)}
+          </span>
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">{name || email}</p>
+          {name && <p className="text-xs text-muted-foreground truncate">{email}</p>}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0 ml-4">
+        {badge}
+        {onRemove && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRemove}
+            disabled={removing}
+            aria-label="Remove member"
+          >
+            {removing ? (
+              <RiLoader2Line className="h-4 w-4 animate-spin" />
+            ) : (
+              <RiCloseLine className="h-4 w-4" />
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PendingInviteRow({
+  invite,
+  onRevoke,
+  revoking,
+}: {
+  invite: PendingInvite;
+  onRevoke: () => void;
+  revoking: boolean;
+}) {
+  const expiresAt = new Date(invite.expires_at);
+  const isExpired = expiresAt < new Date();
+
+  return (
+    <div className="flex items-center justify-between py-3 px-4 hover:bg-muted/40 rounded-lg transition-colors">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="w-8 h-8 rounded-full bg-muted/60 border border-dashed border-border flex items-center justify-center flex-shrink-0">
+          <RiMailLine className="h-4 w-4 text-muted-foreground" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">{invite.email}</p>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <RiTimeLine className="h-3 w-3" />
+            <span>{isExpired ? "Expired" : `Expires ${expiresAt.toLocaleDateString()}`}</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0 ml-4">
+        <Badge variant="outline" className="text-xs">{invite.role}</Badge>
+        <Badge variant={isExpired ? "destructive" : "outline"} className="text-xs">
+          {isExpired ? "Expired" : "Pending"}
+        </Badge>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRevoke}
+          disabled={revoking}
+          aria-label="Revoke invitation"
+        >
+          {revoking ? (
+            <RiLoader2Line className="h-4 w-4 animate-spin" />
+          ) : (
+            <RiCloseLine className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
 export default function UsersTab() {
-  const { isAdmin } = useUserRole();
-  const { openPanel } = usePanelStore();
-  const [users, setUsers] = useState<UserProfile[]>([]);
+  const { user } = useAuth();
   const [loading, setLoading] = useState(true);
-  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+  const [orgsWithMembers, setOrgsWithMembers] = useState<OrgWithMembers[]>([]);
+  const [workspacesWithMembers, setWorkspacesWithMembers] = useState<WorkspaceWithMembers[]>([]);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadUsers();
-  }, []);
-
-  const loadUsers = async () => {
+  const loadData = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
     try {
-      const { user, error: authError } = await getSafeUser();
-      if (authError || !user) return;
+      // 1. Get all organizations the user belongs to
+      const organizations = await getOrganizations(user.id);
 
-      // For TEAM users: Show only users in same organization (future: add org_id filtering)
-      // For ADMIN users: Show all users in organization
-      // Note: Full system-wide user management is in AdminTab
+      // 2. For each org, fetch members and pending invites
+      const orgResults = await Promise.all(
+        organizations.map(async (orgWithRole) => {
+          const [members, inviteData] = await Promise.all([
+            getOrganizationMembers(orgWithRole.id).catch(() => [] as OrganizationMember[]),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (supabase as any)
+              .from("organization_invitations")
+              .select("id, email, role, created_at, expires_at")
+              .eq("organization_id", orgWithRole.id)
+              .eq("status", "pending")
+              .order("created_at", { ascending: false })
+              .then(({ data }: { data: unknown[] | null }) => data ?? []),
+          ]);
 
-      // Query user_profiles with email and roles
-      const { data: profiles, error: profilesError } = await supabase
-        .from("user_profiles")
+          const pendingInvites: PendingInvite[] = (inviteData as Array<{
+            id: string;
+            email: string;
+            role: string;
+            created_at: string;
+            expires_at: string;
+          }>).map((inv) => ({
+            id: inv.id,
+            email: inv.email,
+            role: inv.role,
+            created_at: inv.created_at,
+            expires_at: inv.expires_at,
+            type: "org" as const,
+            contextName: orgWithRole.name,
+            contextId: orgWithRole.id,
+          }));
+
+          return {
+            org: orgWithRole as Organization,
+            members,
+            pendingInvites,
+          };
+        })
+      );
+
+      setOrgsWithMembers(orgResults);
+
+      // 3. Get all workspaces the user is a member of (across all orgs)
+      const { data: wsMemberships, error: wsError } = await supabase
+        .from("workspace_memberships")
         .select(`
-          user_id,
-          email,
-          display_name,
-          onboarding_completed,
-          created_at
+          id,
+          role,
+          workspace_id,
+          workspace:workspaces (
+            id,
+            name,
+            organization_id
+          )
         `)
-        .order("created_at", { ascending: false });
+        .eq("user_id", user.id);
 
-      if (profilesError) throw profilesError;
+      if (wsError) throw wsError;
 
-      // Get roles for each user
-      const { data: roles } = await supabase
-        .from("user_roles")
-        .select("user_id, role");
+      // 4. For each workspace, fetch all members + pending invites
+      const wsResults = await Promise.all(
+        (wsMemberships ?? []).map(async (wm) => {
+          const ws = wm.workspace as { id: string; name: string; organization_id: string } | null;
+          if (!ws) return null;
 
-      // Create role map
-      const roleMap = new Map(roles?.map((r) => [r.user_id, r.role]) || []);
+          // Fetch workspace members
+          const { data: memberships, error: memberError } = await supabase
+            .from("workspace_memberships")
+            .select("id, user_id, role, created_at")
+            .eq("workspace_id", ws.id);
 
-      // Combine profiles with roles
-      const profilesWithData = (profiles || []).map((profile) => ({
-        user_id: profile.user_id,
-        email: profile.email || "Unknown",
-        display_name: profile.display_name,
-        role: roleMap.get(profile.user_id) || "FREE",
-        last_login_at: null, // TODO: Track in separate table
-        onboarding_completed: profile.onboarding_completed || false,
-        created_at: profile.created_at,
-      }));
+          if (memberError) {
+            logger.warn("Failed to fetch workspace members", memberError);
+            return null;
+          }
 
-      setUsers(profilesWithData as UserProfile[]);
+          // Fetch profiles for members
+          const userIds = (memberships ?? []).map((m) => m.user_id);
+          const profileMap = new Map<string, { email: string; display_name: string; avatar_url: string | null }>();
+
+          if (userIds.length > 0) {
+            const { data: profiles } = await supabase
+              .from("user_profiles")
+              .select("id, email, display_name, avatar_url")
+              .in("id", userIds);
+
+            for (const p of profiles ?? []) {
+              profileMap.set(p.id, {
+                email: p.email ?? "",
+                display_name: p.display_name ?? "",
+                avatar_url: p.avatar_url ?? null,
+              });
+            }
+          }
+
+          const members: WorkspaceMember[] = (memberships ?? []).map((m) => {
+            const profile = profileMap.get(m.user_id);
+            return {
+              id: m.id,
+              user_id: m.user_id,
+              role: m.role,
+              created_at: m.created_at,
+              email: profile?.email ?? "",
+              display_name: profile?.display_name ?? "",
+              avatar_url: profile?.avatar_url ?? null,
+            };
+          });
+
+          // Fetch pending workspace invitations
+          const { data: wsInvites } = await supabase
+            .from("workspace_invitations")
+            .select("id, email, role, created_at, expires_at")
+            .eq("workspace_id", ws.id)
+            .eq("status", "pending");
+
+          const pendingInvites: PendingInvite[] = (wsInvites ?? []).map((inv) => ({
+            id: inv.id,
+            email: inv.email,
+            role: inv.role,
+            created_at: inv.created_at,
+            expires_at: inv.expires_at,
+            type: "workspace" as const,
+            contextName: ws.name,
+            contextId: ws.id,
+          }));
+
+          return {
+            workspaceId: ws.id,
+            workspaceName: ws.name,
+            orgId: ws.organization_id,
+            members,
+            pendingInvites,
+          } satisfies WorkspaceWithMembers;
+        })
+      );
+
+      setWorkspacesWithMembers(wsResults.filter(Boolean) as WorkspaceWithMembers[]);
     } catch (error) {
-      logger.error("Error loading users", error);
-      toast.error("Failed to load users");
+      logger.error("Error loading team data", error);
+      toast.error("Failed to load team data");
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
 
-  const handleRoleChange = async (userId: string, newRole: "FREE" | "PRO" | "TEAM" | "ADMIN") => {
-    if (!isAdmin) {
-      toast.error("Only administrators can change user roles");
-      return;
-    }
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
+  const handleRemoveOrgMember = async (membershipId: string, _orgId: string) => {
+    setRemovingId(membershipId);
     try {
-      setUpdatingUserId(userId);
-
-      // Delete old role
-      await supabase
-        .from("user_roles")
-        .delete()
-        .eq("user_id", userId);
-
-      // Insert new role
-      const { error } = await supabase
-        .from("user_roles")
-        .insert({
-          user_id: userId,
-          role: newRole,
-        });
-
-      if (error) throw error;
-
-      toast.success("User role updated successfully");
-      await loadUsers(); // Refresh the list
+      await removeOrganizationMember(membershipId);
+      toast.success("Member removed");
+      await loadData();
     } catch (error) {
-      logger.error("Error updating user role", error);
-      toast.error("Failed to update user role");
+      logger.error("Error removing org member", error);
+      toast.error("Failed to remove member");
     } finally {
-      setUpdatingUserId(null);
+      setRemovingId(null);
     }
   };
 
+  const handleUpdateOrgMemberRole = async (membershipId: string, newRole: OrganizationRole) => {
+    try {
+      await updateOrganizationMemberRole(membershipId, newRole);
+      toast.success("Role updated");
+      await loadData();
+    } catch (error) {
+      logger.error("Error updating member role", error);
+      toast.error("Failed to update role");
+    }
+  };
+
+  const handleRemoveWorkspaceMember = async (membershipId: string) => {
+    setRemovingId(membershipId);
+    try {
+      const { error } = await supabase
+        .from("workspace_memberships")
+        .delete()
+        .eq("id", membershipId);
+      if (error) throw error;
+      toast.success("Member removed from workspace");
+      await loadData();
+    } catch (error) {
+      logger.error("Error removing workspace member", error);
+      toast.error("Failed to remove workspace member");
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  const handleRevokeOrgInvite = async (inviteId: string) => {
+    setRevokingId(inviteId);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase as any)
+        .from("organization_invitations")
+        .update({ status: "revoked" })
+        .eq("id", inviteId);
+      if (error) throw error;
+      toast.success("Invitation revoked");
+      await loadData();
+    } catch (error) {
+      logger.error("Error revoking org invite", error);
+      toast.error("Failed to revoke invitation");
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  const handleRevokeWorkspaceInvite = async (inviteId: string) => {
+    setRevokingId(inviteId);
+    try {
+      const { error } = await supabase
+        .from("workspace_invitations")
+        .update({ status: "revoked" })
+        .eq("id", inviteId);
+      if (error) throw error;
+      toast.success("Invitation revoked");
+      await loadData();
+    } catch (error) {
+      logger.error("Error revoking workspace invite", error);
+      toast.error("Failed to revoke invitation");
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  // Collect all pending invites across orgs + workspaces
+  const allPendingInvites: PendingInvite[] = [
+    ...orgsWithMembers.flatMap((o) => o.pendingInvites),
+    ...workspacesWithMembers.flatMap((w) => w.pendingInvites),
+  ];
 
   if (loading) {
     return (
@@ -125,77 +447,201 @@ export default function UsersTab() {
     );
   }
 
-  return (
-    <div>
-      {/* Organization Users Section */}
-      <div className="space-y-4">
-        <div>
-          <h2 className="font-semibold text-gray-900 dark:text-gray-50">
-            Organization Users
-          </h2>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            {isAdmin
-              ? "Manage user roles and access within your organization"
-              : "View users in your organization"}
-          </p>
-        </div>
-        <div>
-          {users.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 border border-border dark:border-cb-border-dark">
-              <RiGroupLine className="h-12 w-12 text-muted-foreground mb-4" />
-              <p className="text-sm text-muted-foreground">No users found</p>
-            </div>
-          ) : (
-            <UserTable
-              users={users}
-              isAdmin={isAdmin}
-              updatingUserId={updatingUserId}
-              onRoleChange={handleRoleChange}
-              onManageUser={(userId) => {
-                openPanel('user-detail', { type: 'user-detail', userId, onUserUpdated: loadUsers });
-              }}
-              showActions={isAdmin}
-            />
-          )}
-        </div>
-      </div>
+  const hasNoData =
+    orgsWithMembers.length === 0 && workspacesWithMembers.length === 0;
 
-      {/* Information Section */}
-      <div className="space-y-4 mt-12">
-        <div>
-          <h2 className="font-semibold text-gray-900 dark:text-gray-50">
-            User Management
-          </h2>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            Information about user roles and permissions
-          </p>
-        </div>
-        <div>
-          <div className="space-y-4">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-50">
-              Role Descriptions
-            </h3>
-            <div className="space-y-3 text-sm text-gray-500 dark:text-gray-400">
-              <div className="flex items-start gap-3">
-                <Badge variant="outline" className="shrink-0">FREE</Badge>
-                <p>Individual users with access to core features and personal meetings</p>
-              </div>
-              <div className="flex items-start gap-3">
-                <Badge variant="default" className="shrink-0">PRO</Badge>
-                <p>Premium individual users with access to advanced features and priority support</p>
-              </div>
-              <div className="flex items-start gap-3">
-                <Badge variant="default" className="shrink-0">TEAM</Badge>
-                <p>Team members with shared organization access and collaboration features</p>
-              </div>
-              <div className="flex items-start gap-3">
-                <Badge variant="destructive" className="shrink-0">ADMIN</Badge>
-                <p>Full administrative access including user management and system settings</p>
-              </div>
+  if (hasNoData) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 border border-dashed border-border rounded-xl">
+        <RiGroupLine className="h-12 w-12 text-muted-foreground mb-4" />
+        <p className="text-sm font-medium text-foreground mb-1">No team members yet</p>
+        <p className="text-xs text-muted-foreground">
+          Invite people to your organizations and workspaces to see them here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-12">
+
+      {/* ── Organization Members ─────────────────────────────────── */}
+      {orgsWithMembers.map(({ org, members, pendingInvites }) => (
+        <section key={org.id} className="space-y-4">
+          <div className="flex items-center gap-2">
+            <RiBuilding4Line className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+            <div>
+              <h2 className="font-semibold text-foreground">{org.name}</h2>
+              <p className="text-xs text-muted-foreground">
+                Organization · {members.length} member{members.length !== 1 ? "s" : ""}
+                {pendingInvites.length > 0 && ` · ${pendingInvites.length} pending`}
+              </p>
             </div>
           </div>
-        </div>
-      </div>
+
+          <div className="border border-border rounded-xl overflow-hidden">
+            {members.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+                <RiGroupLine className="h-8 w-8 mb-2" />
+                <p className="text-sm">No members in this organization</p>
+              </div>
+            ) : (
+              <div className="divide-y divide-border">
+                {members.map((member) => (
+                  <MemberRow
+                    key={member.id}
+                    name={member.display_name}
+                    email={member.email}
+                    badge={<OrgRoleBadge role={member.role} />}
+                    onRemove={
+                      member.role !== "organization_owner"
+                        ? () => handleRemoveOrgMember(member.id, org.id)
+                        : undefined
+                    }
+                    removing={removingId === member.id}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Pending org invites for this org */}
+          {pendingInvites.length > 0 && (
+            <div className="border border-dashed border-border rounded-xl overflow-hidden">
+              <div className="px-4 py-2 bg-muted/30">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Pending Invitations
+                </p>
+              </div>
+              <div className="divide-y divide-border">
+                {pendingInvites.map((invite) => (
+                  <PendingInviteRow
+                    key={invite.id}
+                    invite={invite}
+                    onRevoke={() => handleRevokeOrgInvite(invite.id)}
+                    revoking={revokingId === invite.id}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+      ))}
+
+      {workspacesWithMembers.length > 0 && orgsWithMembers.length > 0 && (
+        <Separator />
+      )}
+
+      {/* ── Workspace Members ─────────────────────────────────────── */}
+      {workspacesWithMembers.length > 0 && (
+        <section className="space-y-8">
+          <div>
+            <h2 className="font-semibold text-foreground">Workspaces</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              People who have access to your shared workspaces
+            </p>
+          </div>
+
+          {workspacesWithMembers.map((ws) => (
+            <div key={ws.workspaceId} className="space-y-3">
+              <div className="flex items-center gap-2">
+                <RiBuildingLine className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                <div>
+                  <h3 className="text-sm font-semibold text-foreground">{ws.workspaceName}</h3>
+                  <p className="text-xs text-muted-foreground">
+                    {ws.members.length} member{ws.members.length !== 1 ? "s" : ""}
+                    {ws.pendingInvites.length > 0 && ` · ${ws.pendingInvites.length} pending`}
+                  </p>
+                </div>
+              </div>
+
+              <div className="border border-border rounded-xl overflow-hidden">
+                {ws.members.length === 0 ? (
+                  <div className="flex items-center justify-center py-6 text-muted-foreground">
+                    <p className="text-sm">No members in this workspace</p>
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border">
+                    {ws.members.map((member) => (
+                      <MemberRow
+                        key={member.id}
+                        name={member.display_name}
+                        email={member.email}
+                        badge={<WorkspaceRoleBadge role={member.role} />}
+                        onRemove={
+                          member.role !== "workspace_owner"
+                            ? () => handleRemoveWorkspaceMember(member.id)
+                            : undefined
+                        }
+                        removing={removingId === member.id}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Pending workspace invites */}
+              {ws.pendingInvites.length > 0 && (
+                <div className="border border-dashed border-border rounded-xl overflow-hidden">
+                  <div className="px-4 py-2 bg-muted/30">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Pending Invitations
+                    </p>
+                  </div>
+                  <div className="divide-y divide-border">
+                    {ws.pendingInvites.map((invite) => (
+                      <PendingInviteRow
+                        key={invite.id}
+                        invite={invite}
+                        onRevoke={() => handleRevokeWorkspaceInvite(invite.id)}
+                        revoking={revokingId === invite.id}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </section>
+      )}
+
+      {/* ── All pending invites summary (if any) ─────────────────── */}
+      {allPendingInvites.length > 0 && (
+        <>
+          <Separator />
+          <section className="space-y-4">
+            <div className="flex items-center gap-2">
+              <RiUserAddLine className="h-4 w-4 text-muted-foreground" />
+              <div>
+                <h2 className="font-semibold text-foreground">All Pending Invitations</h2>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {allPendingInvites.length} outstanding invitation{allPendingInvites.length !== 1 ? "s" : ""}
+                </p>
+              </div>
+            </div>
+            <div className="border border-dashed border-border rounded-xl overflow-hidden">
+              <div className="divide-y divide-border">
+                {allPendingInvites.map((invite) => (
+                  <div key={invite.id} className="flex items-center justify-between py-3 px-4">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <RiMailLine className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-foreground truncate">{invite.email}</p>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {invite.type === "org" ? "Organization" : "Workspace"}: {invite.contextName}
+                        </p>
+                      </div>
+                    </div>
+                    <Badge variant="outline" className="ml-4 flex-shrink-0 text-xs">
+                      {invite.type === "org" ? "Org Invite" : "Workspace Invite"}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #121

- **UsersTab rewrite** — Now shows only the current user's org and workspace members (not all platform users). Grouped by organization and workspace with pending invitations (org + workspace level) and revoke capability.
- **AdminTab gate** — Non-admin users now see a "Admin access required" locked state instead of the full platform user list. The existing platform user management and system stats are unchanged for admins.
- **Category rename** — "Users" renamed to "People" in `SettingsCategoryPane` and `SettingsDetailPane` to better reflect the narrowed, team-focused scope.

## Test plan

- [ ] Log in as a non-admin user → Settings → People tab shows your org/workspace members (not all platform users)
- [ ] Log in as a non-admin user → Settings → Admin tab shows locked state
- [ ] Log in as an ADMIN user → Settings → Admin tab shows full platform user management as before
- [ ] Pending invitations appear in People tab and can be revoked
- [ ] Category sidebar shows "People" (not "Users") with updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)