### PR TITLE
fix(129): prevent HTTP 400 errors from UUID/BIGINT mismatch on legacy tables

### DIFF
--- a/src/components/transcripts/TranscriptsTab.tsx
+++ b/src/components/transcripts/TranscriptsTab.tsx
@@ -533,16 +533,23 @@ export function TranscriptsTab({
     return filtered;
   }, [calls, selectedFolderId, folderAssignments, folders]);
 
-  // Fetch tag assignments for displayed calls
+  // Fetch tag assignments for displayed calls.
+  // call_tag_assignments.call_recording_id is BIGINT (legacy Fathom numeric ID).
+  // New-pipeline recordings have UUID ids — filter those out to prevent a HTTP 400
+  // type-mismatch error when querying the BIGINT column with a UUID string.
+  const legacyRecordingIds = validCalls
+    .map(c => c.recording_id)
+    .filter((id): id is number => typeof id === 'number');
+
   const { data: tagAssignments = {} } = useQuery({
-    queryKey: ["tag-assignments", validCalls.map(c => c.recording_id)],
+    queryKey: ["tag-assignments", legacyRecordingIds],
     queryFn: async () => {
-      if (validCalls.length === 0) return {};
+      if (legacyRecordingIds.length === 0) return {};
 
       const { data, error } = await supabase
         .from("call_tag_assignments")
         .select("call_recording_id, tag_id")
-        .in("call_recording_id", validCalls.map(c => c.recording_id));
+        .in("call_recording_id", legacyRecordingIds);
 
       if (error) throw error;
 

--- a/src/hooks/useCallDetailQueries.ts
+++ b/src/hooks/useCallDetailQueries.ts
@@ -257,7 +257,9 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
       if (error) throw error;
       return data?.map(d => d.call_tags).filter(Boolean) || [];
     },
-    enabled: open && !!call && !!userId,
+    // call_tag_assignments.call_recording_id is BIGINT — only query for legacy numeric IDs.
+    // New-pipeline recordings (UUID ids) store tags in recordings.global_tags, not here.
+    enabled: open && !!call && !!userId && typeof call?.recording_id === 'number',
   });
 
   // Fetch tags for this call
@@ -281,7 +283,8 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
       if (error) throw error;
       return data?.map(d => d.transcript_tags).filter(Boolean) || [];
     },
-    enabled: open && !!call && !!userId,
+    // transcript_tag_assignments.call_recording_id is BIGINT — only query for legacy numeric IDs.
+    enabled: open && !!call && !!userId && typeof call?.recording_id === 'number',
   });
 
   // Fetch unique speakers from transcripts and enrich with calendar invitee data
@@ -329,7 +332,8 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
 
       return speakers;
     },
-    enabled: open && !!call && !!userId,
+    // fathom_transcripts.recording_id is BIGINT — only query for legacy numeric IDs.
+    enabled: open && !!call && !!userId && typeof call?.recording_id === 'number',
   });
 
   return {


### PR DESCRIPTION
## Summary

- **Root cause**: `call_tag_assignments.call_recording_id` and `fathom_transcripts.recording_id` are BIGINT columns (legacy Fathom numeric IDs). The `recordings` table now stores both old BIGINT-ID calls and new-pipeline UUID calls. When the frontend queries these legacy tables using a UUID value, PostgREST returns HTTP 400 (type mismatch), which surfaces in the browser console as "HTTP 404: Request Failed" (84+ per session due to `retry: 1` × 42 recordings).
- **Fix in `TranscriptsTab.tsx`**: Extract only numeric recording IDs before the batch `call_tag_assignments` query. UUID recording IDs are skipped because new-pipeline recordings store tags in `recordings.global_tags`, not `call_tag_assignments`.
- **Fix in `useCallDetailQueries.ts`**: Add `typeof call.recording_id === 'number'` guard to the `enabled` condition for the `callCategories`, `callTags`, and `callSpeakers` queries — all three target BIGINT columns and are no-ops for UUID recordings.

## Test plan

- [ ] Open v1 frontend (app.callvaultai.com) as a@vibeos.com
- [ ] Switch to Personal org → Transcripts tab — verify no HTTP 400 errors in console
- [ ] Open a new-pipeline recording (UUID id) in the call detail panel — verify no 400 errors for `call_tag_assignments` / `fathom_transcripts`
- [ ] Switch to Business org → verify console is clean (no 400/404 flood)
- [ ] Legacy recording (numeric Fathom ID) detail panel — tags and speakers still load correctly

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)