### PR TITLE
fix: Remove personal_folders queries (table does not exist)

### DIFF
--- a/src/components/AssignFolderDialog.tsx
+++ b/src/components/AssignFolderDialog.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
-import { isTableMissing } from "@/lib/supabase-errors";
 import { RiArrowRightSLine, RiArrowDownSLine, RiFolderLine, RiCheckLine } from "@remixicon/react";
 import { cn } from "@/lib/utils";
 import { getIconComponent } from "@/lib/folder-icons";
@@ -67,7 +66,6 @@ export default function AssignFolderDialog({
     setLoading(true);
     try {
       const numericRecordingIds = targetRecordingIds.map(id => parseInt(id));
-      const uuidRecordingIds = targetRecordingIds;
 
       // Legacy assignments
       const { data: legacyData, error: legacyError } = await supabase
@@ -77,24 +75,13 @@ export default function AssignFolderDialog({
 
       if (legacyError) throw legacyError;
 
-      // Personal assignments — table may not exist yet (migration pending)
-      const { data: personalData, error: personalError } = await (supabase as any)
-        .from('personal_folder_recordings')
-        .select('recording_id, folder_id')
-        .in('recording_id', uuidRecordingIds);
-
-      if (personalError && !isTableMissing(personalError)) throw personalError;
-
-      const combined = [
-        ...(legacyData || []).map(a => a.folder_id),
-        ...(personalData || []).map(a => a.folder_id)
-      ];
+      // personal_folder_recordings table is pending migration — skip for now
+      const combined = (legacyData || []).map(a => a.folder_id);
 
       if (isBulkMode) {
         // Simple intersection for bulk mode
         const counts = new Map<string, number>();
         legacyData?.forEach(a => counts.set(a.folder_id, (counts.get(a.folder_id) || 0) + 1));
-        personalData?.forEach(a => counts.set(a.folder_id, (counts.get(a.folder_id) || 0) + 1));
 
         const common = new Set<string>();
         counts.forEach((count, id) => {
@@ -126,19 +113,8 @@ export default function AssignFolderDialog({
       const { data: legacyData, error: legacyError } = await legacyQuery;
       if (legacyError) throw legacyError;
 
-      // 2. Fetch Personal Folders — table may not exist yet (migration pending)
-      const { data: personalData, error: personalError } = await (supabase as any)
-        .from('personal_folders')
-        .select('*')
-        .eq('organization_id', activeOrganizationId)
-        .order('name');
-
-      if (personalError && !isTableMissing(personalError)) throw personalError;
-
-      const all = [
-        ...(legacyData || []).map(f => ({ ...f, is_personal: false })),
-        ...(personalData || []).map(f => ({ ...f, is_personal: true, parent_id: null }))
-      ];
+      // personal_folders table is pending migration — only legacy folders for now
+      const all = (legacyData || []).map(f => ({ ...f, is_personal: false }));
 
       setAllFolders(all as any);
 
@@ -264,7 +240,6 @@ export default function AssignFolderDialog({
     setSaving(true);
     try {
       const numericRecordingIds = targetRecordingIds.map(id => parseInt(id)).filter(id => !isNaN(id));
-      const uuidRecordingIds = targetRecordingIds;
 
       const { user } = await getSafeUser();
       const userId = user?.id || null;
@@ -294,34 +269,7 @@ export default function AssignFolderDialog({
       });
       if (legacyToAdd.length > 0) await supabase.from("folder_assignments").insert(legacyToAdd);
 
-      // 2. Handle Personal Folders — skip entirely when table doesn't exist yet
-      const personalSelected = new Set(Array.from(selectedFolders).filter(id => allFolders.find(f => f.id === id && (f as any).is_personal)));
-
-      const { data: existingPersonal, error: existingPersonalError } = await (supabase as any)
-        .from('personal_folder_recordings')
-        .select('recording_id, folder_id')
-        .in('recording_id', uuidRecordingIds);
-
-      if (existingPersonalError && !isTableMissing(existingPersonalError)) throw existingPersonalError;
-
-      if (!existingPersonalError) {
-        // Deletions
-        const personalToDelete = (existingPersonal || []).filter((a: any) => !personalSelected.has(a.folder_id));
-        for (const a of personalToDelete) {
-          await (supabase as any).from('personal_folder_recordings').delete()
-            .eq('recording_id', a.recording_id).eq('folder_id', a.folder_id).eq('user_id', userId);
-        }
-        // Insertions
-        const personalToAdd: any[] = [];
-        uuidRecordingIds.forEach(rid => {
-          personalSelected.forEach(fid => {
-            if (!(existingPersonal || []).some((a: any) => a.recording_id === rid && a.folder_id === fid)) {
-              personalToAdd.push({ recording_id: rid, folder_id: fid, user_id: userId });
-            }
-          });
-        });
-        if (personalToAdd.length > 0) await (supabase as any).from('personal_folder_recordings').insert(personalToAdd);
-      }
+      // personal_folder_recordings table is pending migration — skip personal folder writes
 
       const count = targetRecordingIds.length;
       const folderCount = selectedFolders.size;

--- a/src/services/personal-folders.service.ts
+++ b/src/services/personal-folders.service.ts
@@ -16,19 +16,9 @@ export interface PersonalFolderRecording {
   created_at: string
 }
 
-export async function getPersonalFolders(organizationId: string): Promise<PersonalFolder[]> {
-  const { data, error } = await (supabase as any)
-    .from('personal_folders')
-    .select('*')
-    .eq('organization_id', organizationId)
-    .order('created_at', { ascending: false })
-
-  if (error) {
-    if (isTableMissing(error)) return []
-    throw new Error(`Failed to fetch personal folders: ${error.message}`)
-  }
-
-  return data as PersonalFolder[]
+// TODO: personal_folders table migration is pending — remove this stub when table exists
+export async function getPersonalFolders(_organizationId: string): Promise<PersonalFolder[]> {
+  return []
 }
 
 export async function createPersonalFolder(organizationId: string, name: string): Promise<PersonalFolder> {
@@ -79,43 +69,9 @@ export async function deletePersonalFolder(folderId: string): Promise<void> {
   }
 }
 
-export async function getPersonalFolderAssignments(organizationId: string): Promise<Record<string, string[]>> {
-  // Fetch folder IDs for this org
-  const { data: folders, error: foldersError } = await (supabase as any)
-    .from('personal_folders')
-    .select('id')
-    .eq('organization_id', organizationId)
-
-  if (foldersError) {
-    if (isTableMissing(foldersError)) return {}
-    throw new Error(`Failed to fetch folders for assignments: ${foldersError.message}`)
-  }
-  
-  const folderIds = (folders ?? []).map((f) => f.id)
-  
-  if (folderIds.length === 0) return {}
-
-  // Fetch recordings linked to those folders
-  const { data, error } = await (supabase as any)
-    .from('personal_folder_recordings')
-    .select('recording_id, folder_id')
-    .in('folder_id', folderIds)
-
-  if (error) {
-    if (isTableMissing(error)) return {}
-    throw new Error(`Failed to fetch personal folder assignments: ${error.message}`)
-  }
-
-  const assignments: Record<string, string[]> = {}
-  ;(data ?? []).forEach((row) => {
-    const callId = String(row.recording_id)
-    if (!assignments[callId]) {
-      assignments[callId] = []
-    }
-    assignments[callId].push(row.folder_id)
-  })
-
-  return assignments
+// TODO: personal_folders table migration is pending — remove this stub when table exists
+export async function getPersonalFolderAssignments(_organizationId: string): Promise<Record<string, string[]>> {
+  return {}
 }
 
 export async function assignCallToPersonalFolder(recordingId: string, folderId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Stubs `getPersonalFolders` and `getPersonalFolderAssignments` in the service to return empty data immediately, bypassing DB calls to the non-existent `personal_folders` table
- Removes direct `personal_folders` and `personal_folder_recordings` queries from `AssignFolderDialog.tsx`
- Removes unused `isTableMissing` import from `AssignFolderDialog`

The `personal_folders` and `personal_folder_recordings` tables don't exist in production (migration pending). Every page load was firing queries against these tables, receiving HTTP 404 responses, and logging 404 warnings in the console. The existing `isTableMissing` guards caught the errors gracefully but the HTTP round-trip still produced noise.

Write mutations (create, assign, remove) are left intact with `isTableMissing` guards since they're triggered by explicit user action and will surface a clear "migration pending" error if invoked.

Closes #134

## Test plan
- [ ] No `personal_folders` 404 errors in console on page load
- [ ] Workspace sidebar pane loads without errors
- [ ] Assign Folder dialog opens and shows only legacy folders
- [ ] Type-check passes (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)