### PR TITLE
fix: Remove 'Fathom share link' missing data warning from call detail

### DIFF
--- a/src/components/call-detail/CallOverviewTab.tsx
+++ b/src/components/call-detail/CallOverviewTab.tsx
@@ -4,7 +4,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
-import { RiErrorWarningLine } from "@remixicon/react";
 import ReactMarkdown from "react-markdown";
 import { Meeting, Category, Speaker } from "@/types";
 
@@ -95,22 +94,6 @@ export function CallOverviewTab({
               </div>
             </div>
 
-            {/* Show warning if critical data is missing */}
-            {(!call.recording_start_time || !call.recording_end_time || !call.share_url) && (
-              <div className="mt-4 p-3 bg-cb-warning-bg border border-cb-warning-border rounded-md text-cb-warning-text">
-                <div className="flex gap-2 text-sm">
-                  <RiErrorWarningLine className="h-4 w-4 flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-medium">Some meeting data is unavailable:</p>
-                    <ul className="mt-1 text-xs space-y-0.5">
-                      {!call.recording_start_time && <li>• Recording start time</li>}
-                      {!call.recording_end_time && <li>• Recording end time</li>}
-                      {!call.share_url && <li>• Fathom share link</li>}
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
 
           <div className="space-y-6">

--- a/src/components/panels/CallDetailPanel.tsx
+++ b/src/components/panels/CallDetailPanel.tsx
@@ -29,7 +29,6 @@ import {
   RiCalendarLine,
   RiTimeLine,
   RiUserLine,
-  RiErrorWarningLine,
 } from "@remixicon/react";
 import { toast } from "sonner";
 import { usePanelStore } from "@/stores/panelStore";
@@ -479,15 +478,6 @@ export function CallDetailPanel({ recordingId }: CallDetailPanelProps) {
                 </div>
               </div>
 
-              {/* Missing Data Warning */}
-              {(!call.recording_start_time || !call.recording_end_time || !shareUrl) && (
-                <div className="p-3 bg-cb-warning-bg border border-cb-warning-border rounded-md text-cb-warning-text">
-                  <div className="flex gap-2 text-sm">
-                    <RiErrorWarningLine className="h-4 w-4 flex-shrink-0 mt-0.5" />
-                    <span>Some meeting data is unavailable</span>
-                  </div>
-                </div>
-              )}
 
               {/* Folders */}
               {callCategories && callCategories.length > 0 && (

--- a/src/components/panels/CallDetailPanel.tsx
+++ b/src/components/panels/CallDetailPanel.tsx
@@ -478,7 +478,6 @@ export function CallDetailPanel({ recordingId }: CallDetailPanelProps) {
                 </div>
               </div>
 
-
               {/* Folders */}
               {callCategories && callCategories.length > 0 && (
                 <div className="space-y-2">


### PR DESCRIPTION
## Summary

- Removes the 'Some meeting data is unavailable: Fathom share link' warning from `CallOverviewTab` and `CallDetailPanel`
- The warning was surfacing `share_url` (an internal Fathom field) to users with no actionable context
- Recording timestamps (`recording_start_time`, `recording_end_time`) were also in the condition but are not user-impacting enough to warrant a warning panel
- Since neither component was checking genuinely user-impacting fields (transcript, summary), the warning block was removed entirely from both files
- Cleaned up the now-unused `RiErrorWarningLine` imports in both files

## Test plan

- [ ] Open a call that previously showed the Fathom share link warning — confirm warning no longer appears
- [ ] Open a call with all data present — no visible change expected
- [ ] TypeScript: `npm run type-check` passes ✅

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)