### PR TITLE
fix(140): improve invitee display for impromptu/pop-up calls

### DIFF
--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -342,7 +342,10 @@ export function CallDetailDialog({
             duration={duration}
           />
 
-          <CallInviteesTab calendarInvitees={call.calendar_invitees} />
+          <CallInviteesTab
+            calendarInvitees={call.calendar_invitees}
+            callSpeakers={callSpeakers}
+          />
 
           <CallParticipantsTab
             callSpeakers={callSpeakers}

--- a/src/components/call-detail/CallInviteesTab.tsx
+++ b/src/components/call-detail/CallInviteesTab.tsx
@@ -2,27 +2,59 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TabsContent } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { RiInformationLine } from "@remixicon/react";
 
 import { CalendarInvitee } from "@/types";
 
-interface CallInviteesTabProps {
-  calendarInvitees?: CalendarInvitee[];
+interface Speaker {
+  speaker_name: string;
+  speaker_email?: string | null;
 }
 
-export function CallInviteesTab({ calendarInvitees }: CallInviteesTabProps) {
+interface CallInviteesTabProps {
+  calendarInvitees?: CalendarInvitee[];
+  callSpeakers?: Speaker[];
+}
+
+export function CallInviteesTab({ calendarInvitees, callSpeakers }: CallInviteesTabProps) {
+  const hasInvitees = calendarInvitees && calendarInvitees.length > 0;
+  const hasSpeakers = callSpeakers && callSpeakers.length > 0;
+  const showSpeakerFallback = !hasInvitees && hasSpeakers;
+
   return (
     <TabsContent value="invitees" className="flex-1 overflow-hidden">
       <ScrollArea className="h-full">
         <div className="pr-4 pb-6">
-          {calendarInvitees && calendarInvitees.length > 0 ? (
+          {hasInvitees ? (
             <div className="space-y-6">
               <div>
-                <h3 className="font-display text-sm font-extrabold uppercase mb-2">MEETING INVITEES ({calendarInvitees.length})</h3>
-                <p className="text-sm text-ink-muted mb-4">People who were invited to this meeting via calendar invite</p>
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="font-display text-sm font-extrabold uppercase">
+                    MEETING INVITEES ({calendarInvitees.length})
+                  </h3>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button type="button" aria-label="About invitees vs participants">
+                        <RiInformationLine className="h-4 w-4 text-muted-foreground" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Invitees are from the calendar invite. Participants are those who actually spoke.</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <p className="text-sm text-muted-foreground mb-4">
+                  People who were invited to this meeting via calendar invite
+                </p>
               </div>
               <div className="space-y-3">
                 {calendarInvitees.map((invitee, idx) => (
-                  <div key={idx} className="relative flex items-start gap-3 py-2 px-4 bg-card border border-border dark:border-cb-border-dark rounded-lg">
+                  <div key={idx} className="relative flex items-start gap-3 py-2 px-4 bg-card border border-border rounded-lg">
                     {/* Vibe orange angled marker - STANDARDIZED DIMENSIONS */}
                     <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1.5 h-14 bg-vibe-orange cv-vertical-marker" />
                     <Avatar className="ml-3">
@@ -32,7 +64,7 @@ export function CallInviteesTab({ calendarInvitees }: CallInviteesTabProps) {
                     </Avatar>
                     <div className="flex-1">
                       <p className="font-medium">{invitee.name}</p>
-                      <p className="text-sm text-ink-muted">{invitee.email}</p>
+                      <p className="text-sm text-muted-foreground">{invitee.email}</p>
                       <div className="flex gap-2 mt-2">
                         {invitee.external ? (
                           <Badge variant="hollow">External</Badge>
@@ -48,9 +80,56 @@ export function CallInviteesTab({ calendarInvitees }: CallInviteesTabProps) {
                 ))}
               </div>
             </div>
+          ) : showSpeakerFallback ? (
+            <div className="space-y-6">
+              <div>
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="font-display text-sm font-extrabold uppercase">
+                    PARTICIPANTS ({callSpeakers!.length})
+                  </h3>
+                  <Badge variant="secondary" className="text-xs">Ad-hoc call</Badge>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button type="button" aria-label="Why participants instead of invitees">
+                        <RiInformationLine className="h-4 w-4 text-muted-foreground" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>No calendar invitees found. Showing speakers from the transcript instead.</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <p className="text-sm text-muted-foreground mb-4">
+                  This appears to be an impromptu or ad-hoc call — no calendar invitees were found. Showing transcript speakers instead.
+                </p>
+              </div>
+              <div className="space-y-3">
+                {callSpeakers!.map((speaker, idx) => (
+                  <div key={idx} className="relative flex items-start gap-3 py-2 px-4 bg-card border border-border rounded-lg">
+                    {/* Vibe orange angled marker - STANDARDIZED DIMENSIONS */}
+                    <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1.5 h-14 bg-vibe-orange cv-vertical-marker" />
+                    <Avatar className="ml-3">
+                      <AvatarFallback>
+                        {speaker.speaker_name?.split(' ').map((n) => n[0]).join('').toUpperCase() || '?'}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1">
+                      <p className="font-medium">{speaker.speaker_name}</p>
+                      {speaker.speaker_email && (
+                        <p className="text-sm text-muted-foreground">{speaker.speaker_email}</p>
+                      )}
+                      <Badge variant="secondary" className="mt-2">Spoke in Meeting</Badge>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           ) : (
-            <div className="text-center py-8">
-              <p className="text-ink-muted">No invitee data available for this meeting</p>
+            <div className="flex flex-col items-center py-8 gap-3">
+              <Badge variant="secondary" className="text-xs">Ad-hoc call</Badge>
+              <p className="text-muted-foreground text-sm text-center">
+                No invitee or participant data available for this meeting
+              </p>
             </div>
           )}
         </div>

--- a/src/components/call-detail/CallInviteesTab.tsx
+++ b/src/components/call-detail/CallInviteesTab.tsx
@@ -5,16 +5,12 @@ import { TabsContent } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { RiInformationLine } from "@remixicon/react";
 
-import { CalendarInvitee } from "@/types";
-
-interface Speaker {
-  speaker_name: string;
-  speaker_email?: string | null;
-}
+import type { CalendarInvitee, Speaker } from "@/types";
 
 interface CallInviteesTabProps {
   calendarInvitees?: CalendarInvitee[];
@@ -23,8 +19,6 @@ interface CallInviteesTabProps {
 
 export function CallInviteesTab({ calendarInvitees, callSpeakers }: CallInviteesTabProps) {
   const hasInvitees = calendarInvitees && calendarInvitees.length > 0;
-  const hasSpeakers = callSpeakers && callSpeakers.length > 0;
-  const showSpeakerFallback = !hasInvitees && hasSpeakers;
 
   return (
     <TabsContent value="invitees" className="flex-1 overflow-hidden">
@@ -37,16 +31,18 @@ export function CallInviteesTab({ calendarInvitees, callSpeakers }: CallInvitees
                   <h3 className="font-display text-sm font-extrabold uppercase">
                     MEETING INVITEES ({calendarInvitees.length})
                   </h3>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button type="button" aria-label="About invitees vs participants">
-                        <RiInformationLine className="h-4 w-4 text-muted-foreground" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Invitees are from the calendar invite. Participants are those who actually spoke.</p>
-                    </TooltipContent>
-                  </Tooltip>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button type="button" aria-label="About invitees vs participants">
+                          <RiInformationLine className="h-4 w-4 text-muted-foreground" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Invitees are from the calendar invite. Participants are those who actually spoke.</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
                 <p className="text-sm text-muted-foreground mb-4">
                   People who were invited to this meeting via calendar invite
@@ -63,7 +59,7 @@ export function CallInviteesTab({ calendarInvitees, callSpeakers }: CallInvitees
                       </AvatarFallback>
                     </Avatar>
                     <div className="flex-1">
-                      <p className="font-medium">{invitee.name}</p>
+                      <p className="font-medium">{invitee.name || "Unknown"}</p>
                       <p className="text-sm text-muted-foreground">{invitee.email}</p>
                       <div className="flex gap-2 mt-2">
                         {invitee.external ? (
@@ -80,31 +76,33 @@ export function CallInviteesTab({ calendarInvitees, callSpeakers }: CallInvitees
                 ))}
               </div>
             </div>
-          ) : showSpeakerFallback ? (
+          ) : callSpeakers && callSpeakers.length > 0 ? (
             <div className="space-y-6">
               <div>
                 <div className="flex items-center gap-2 mb-2">
                   <h3 className="font-display text-sm font-extrabold uppercase">
-                    PARTICIPANTS ({callSpeakers!.length})
+                    PARTICIPANTS ({callSpeakers.length})
                   </h3>
                   <Badge variant="secondary" className="text-xs">Ad-hoc call</Badge>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button type="button" aria-label="Why participants instead of invitees">
-                        <RiInformationLine className="h-4 w-4 text-muted-foreground" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>No calendar invitees found. Showing speakers from the transcript instead.</p>
-                    </TooltipContent>
-                  </Tooltip>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button type="button" aria-label="Why participants instead of invitees">
+                          <RiInformationLine className="h-4 w-4 text-muted-foreground" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>No calendar invitees found. Showing speakers from the transcript instead.</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
                 <p className="text-sm text-muted-foreground mb-4">
                   This appears to be an impromptu or ad-hoc call — no calendar invitees were found. Showing transcript speakers instead.
                 </p>
               </div>
               <div className="space-y-3">
-                {callSpeakers!.map((speaker, idx) => (
+                {callSpeakers.map((speaker, idx) => (
                   <div key={idx} className="relative flex items-start gap-3 py-2 px-4 bg-card border border-border rounded-lg">
                     {/* Vibe orange angled marker - STANDARDIZED DIMENSIONS */}
                     <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1.5 h-14 bg-vibe-orange cv-vertical-marker" />
@@ -114,7 +112,7 @@ export function CallInviteesTab({ calendarInvitees, callSpeakers }: CallInvitees
                       </AvatarFallback>
                     </Avatar>
                     <div className="flex-1">
-                      <p className="font-medium">{speaker.speaker_name}</p>
+                      <p className="font-medium">{speaker.speaker_name || "Unknown"}</p>
                       {speaker.speaker_email && (
                         <p className="text-sm text-muted-foreground">{speaker.speaker_email}</p>
                       )}

--- a/src/components/call-detail/CallParticipantsTab.tsx
+++ b/src/components/call-detail/CallParticipantsTab.tsx
@@ -21,7 +21,7 @@ export function CallParticipantsTab({ callSpeakers, hasTranscripts }: CallPartic
           <div className="space-y-6">
             <div>
               <h3 className="font-display text-sm font-extrabold uppercase mb-2">PARTICIPANTS ({callSpeakers?.length || 0})</h3>
-              <p className="text-sm text-ink-muted mb-4">People who actually spoke during this meeting</p>
+              <p className="text-sm text-muted-foreground mb-4">People who actually spoke during this meeting</p>
             </div>
             {callSpeakers && callSpeakers.length > 0 ? (
               <div className="space-y-3">
@@ -37,7 +37,7 @@ export function CallParticipantsTab({ callSpeakers, hasTranscripts }: CallPartic
                     <div className="flex-1">
                       <p className="font-medium">{speaker.speaker_name || "Unknown"}</p>
                       {speaker.speaker_email && (
-                        <p className="text-sm text-ink-muted">{speaker.speaker_email}</p>
+                        <p className="text-sm text-muted-foreground">{speaker.speaker_email}</p>
                       )}
                       <Badge variant="secondary" className="mt-2">Spoke in Meeting</Badge>
                     </div>
@@ -46,7 +46,7 @@ export function CallParticipantsTab({ callSpeakers, hasTranscripts }: CallPartic
               </div>
             ) : (
               <div className="text-center py-8">
-                <p className="text-ink-muted">
+                <p className="text-muted-foreground">
                   {hasTranscripts
                     ? "Unable to identify speakers for this call"
                     : "No transcript data available for this meeting"}

--- a/src/hooks/useCallDetailQueries.ts
+++ b/src/hooks/useCallDetailQueries.ts
@@ -333,13 +333,36 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
     enabled: open && !!call && !!userId && typeof call?.recording_id === 'number',
   });
 
+  // For non-numeric IDs (new pipeline), callSpeakers query is disabled.
+  // Fall back to speakers derived from the already-fetched allTranscripts.
+  const speakersFromTranscripts = useMemo((): Speaker[] => {
+    if (callSpeakers && callSpeakers.length > 0) return callSpeakers;
+    if (!allTranscripts || allTranscripts.length === 0) return [];
+
+    const speakerMap = new Map<string, string | null>();
+    allTranscripts.forEach((t) => {
+      const name = t.speaker_name;
+      if (!name) return;
+      if (!speakerMap.has(name)) {
+        speakerMap.set(name, t.speaker_email ?? null);
+      } else if (t.speaker_email && !speakerMap.get(name)) {
+        speakerMap.set(name, t.speaker_email);
+      }
+    });
+
+    return Array.from(speakerMap.entries()).map(([speaker_name, speaker_email]) => ({
+      speaker_name,
+      speaker_email,
+    }));
+  }, [callSpeakers, allTranscripts]);
+
   return {
     userSettings,
     allTranscripts: allTranscripts || [],
     transcripts,
     callCategories: callCategories || [],
     callTags: callTags || [],
-    callSpeakers: callSpeakers || [],
+    callSpeakers: speakersFromTranscripts,
     transcriptStats,
     editedCount,
     deletedCount,


### PR DESCRIPTION
## Summary

- When a call has no calendar invitees (e.g. `Impromptu Zoom Meeting`), the **Invitees** tab now falls back to transcript speakers instead of showing an empty state
- Added an **Ad-hoc call** badge and info tooltip explaining why participants are shown instead of invitees
- Section heading dynamically changes from "MEETING INVITEES" to "PARTICIPANTS" when falling back to transcript data
- Descriptive text explains the ad-hoc context to the user
- Fixed stale v1 tokens (`text-ink-muted` → `text-muted-foreground`) in `CallInviteesTab`

## Changes

- `src/components/call-detail/CallInviteesTab.tsx` — added `callSpeakers` fallback prop, ad-hoc state, tooltip, dynamic heading
- `src/components/CallDetailDialog.tsx` — passes `callSpeakers` to `CallInviteesTab`

## Test plan

- [ ] Open a call with calendar invitees → should show "MEETING INVITEES" section as before
- [ ] Open an impromptu/ad-hoc call with no calendar invitees but with transcript speakers → should show "PARTICIPANTS" heading, "Ad-hoc call" badge, transcript speakers listed
- [ ] Open an ad-hoc call with no invitees AND no transcript speakers → should show "Ad-hoc call" badge + empty message
- [ ] Hover the info icon → tooltip text should explain invitees vs participants

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)