### PR TITLE
fix(139): restore transcripts, speakers and tags for UUID recordings

### DIFF
--- a/src/hooks/useCallDetailQueries.ts
+++ b/src/hooks/useCallDetailQueries.ts
@@ -256,7 +256,7 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
   // After migration 20260310125000, call_tag_assignments.recording_id is UUID.
   // Use canonical_uuid when available (covers both legacy-migrated and new recordings).
   const { data: callCategories } = useQuery({
-    queryKey: queryKeys.calls.categories(call?.recording_id),
+    queryKey: [...queryKeys.calls.categories(call?.recording_id), call?.canonical_uuid],
     queryFn: async () => {
       if (!call || !userId) return [];
       // Resolve UUID — canonical_uuid is set by mapRecordingToMeeting for all recordings-table rows.
@@ -285,7 +285,7 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
   // Fetch tags for this call
   // After migration 20260310125000, transcript_tag_assignments.recording_id is UUID.
   const { data: callTags } = useQuery({
-    queryKey: queryKeys.calls.tags(call?.recording_id),
+    queryKey: [...queryKeys.calls.tags(call?.recording_id), call?.canonical_uuid],
     queryFn: async () => {
       if (!call || !userId) return [];
       const recordingUuid = call.canonical_uuid ?? (typeof call.recording_id === 'string' ? call.recording_id : null);
@@ -312,7 +312,7 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
   // For UUID recordings: query call_participants (canonical table, migration #120).
   // For legacy numeric recordings: query fathom_transcripts (BIGINT recording_id).
   const { data: callSpeakers } = useQuery({
-    queryKey: queryKeys.calls.speakers(call?.recording_id),
+    queryKey: [...queryKeys.calls.speakers(call?.recording_id), call?.canonical_uuid],
     queryFn: async () => {
       if (!call || !userId) return [];
 
@@ -324,10 +324,7 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
           .select("name, email, participant_type")
           .eq("recording_id", recordingUuid);
 
-        if (error) {
-          logger.error("Error fetching call_participants for speakers", error);
-          return [];
-        }
+        if (error) throw error;
 
         return (data || [])
           .filter(p => p.name)

--- a/src/hooks/useCallDetailQueries.ts
+++ b/src/hooks/useCallDetailQueries.ts
@@ -71,7 +71,23 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
       // This works for both legacy (fathom_calls) and new pipeline (recordings) calls.
       let fullTranscript = call.full_transcript || null;
 
-      // FALLBACK: If not on the Meeting object, try fathom_calls (legacy path)
+      // FALLBACK A: For UUID recordings where full_transcript wasn't on the Meeting object
+      // (e.g. list views that omit the column for performance), fetch directly from recordings table.
+      if (!fullTranscript && (call.canonical_uuid || typeof call.recording_id === 'string')) {
+        const uuid = call.canonical_uuid ?? (call.recording_id as string);
+        const { data: recData, error: recError } = await supabase
+          .from("recordings")
+          .select("full_transcript")
+          .eq("id", uuid)
+          .maybeSingle();
+
+        if (recError) {
+          logger.error("Error fetching full_transcript from recordings", recError);
+        }
+        fullTranscript = recData?.full_transcript || null;
+      }
+
+      // FALLBACK B: If not on the Meeting object, try fathom_calls (legacy path)
       if (!fullTranscript && typeof call.recording_id === 'number') {
         const { data: callData, error: callError } = await supabase
           .from("fathom_calls")
@@ -237,11 +253,17 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
   }, [transcripts]);
 
   // Fetch tags for this call (system tags like TEAM, etc.)
+  // After migration 20260310125000, call_tag_assignments.recording_id is UUID.
+  // Use canonical_uuid when available (covers both legacy-migrated and new recordings).
   const { data: callCategories } = useQuery({
     queryKey: queryKeys.calls.categories(call?.recording_id),
     queryFn: async () => {
       if (!call || !userId) return [];
-      // Use composite key (recording_id, user_id) for lookup
+      // Resolve UUID — canonical_uuid is set by mapRecordingToMeeting for all recordings-table rows.
+      // For UUID recordings recording_id is already a string; for legacy it's a number but
+      // call_tag_assignments.recording_id is now UUID, so we must use the canonical UUID.
+      const recordingUuid = call.canonical_uuid ?? (typeof call.recording_id === 'string' ? call.recording_id : null);
+      if (!recordingUuid) return [];
       const { data, error } = await supabase
         .from("call_tag_assignments")
         .select(`
@@ -252,7 +274,7 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
             color
           )
         `)
-        .eq("recording_id", call.recording_id)
+        .eq("recording_id", recordingUuid)
         .eq("user_id", userId);
       if (error) throw error;
       return data?.map(d => d.call_tags).filter(Boolean) || [];
@@ -261,11 +283,13 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
   });
 
   // Fetch tags for this call
+  // After migration 20260310125000, transcript_tag_assignments.recording_id is UUID.
   const { data: callTags } = useQuery({
     queryKey: queryKeys.calls.tags(call?.recording_id),
     queryFn: async () => {
       if (!call || !userId) return [];
-      // Use composite key (recording_id, user_id) for lookup
+      const recordingUuid = call.canonical_uuid ?? (typeof call.recording_id === 'string' ? call.recording_id : null);
+      if (!recordingUuid) return [];
       const { data, error } = await supabase
         .from("transcript_tag_assignments")
         .select(`
@@ -276,7 +300,7 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
             color
           )
         `)
-        .eq("recording_id", call.recording_id)
+        .eq("recording_id", recordingUuid)
         .eq("user_id", userId);
       if (error) throw error;
       return data?.map(d => d.transcript_tags).filter(Boolean) || [];
@@ -284,12 +308,40 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
     enabled: open && !!call && !!userId,
   });
 
-  // Fetch unique speakers from transcripts and enrich with calendar invitee data
+  // Fetch unique speakers from transcripts and enrich with calendar invitee data.
+  // For UUID recordings: query call_participants (canonical table, migration #120).
+  // For legacy numeric recordings: query fathom_transcripts (BIGINT recording_id).
   const { data: callSpeakers } = useQuery({
     queryKey: queryKeys.calls.speakers(call?.recording_id),
     queryFn: async () => {
       if (!call || !userId) return [];
-      // Use composite key (recording_id, user_id) for lookup
+
+      // UUID recordings path: call_participants is the canonical source
+      const recordingUuid = call.canonical_uuid ?? (typeof call.recording_id === 'string' ? call.recording_id : null);
+      if (recordingUuid) {
+        const { data, error } = await supabase
+          .from("call_participants")
+          .select("name, email, participant_type")
+          .eq("recording_id", recordingUuid);
+
+        if (error) {
+          logger.error("Error fetching call_participants for speakers", error);
+          return [];
+        }
+
+        return (data || [])
+          .filter(p => p.name)
+          .map(p => ({
+            speaker_name: p.name!,
+            speaker_email: p.email || null,
+          }));
+      }
+
+      // Legacy path: fathom_transcripts (BIGINT recording_id, numeric IDs only)
+      if (typeof call.recording_id !== 'number') {
+        return [];
+      }
+
       const { data: transcriptData, error } = await supabase
         .from("fathom_transcripts")
         .select("speaker_name, speaker_email")
@@ -311,7 +363,6 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
       // Enrich with calendar invitee data if email is missing
       const speakers = Array.from(speakerMap.entries()).map(([name, email]) => {
         let finalEmail = email;
-        // If we don't have an email from transcript, try to match with calendar invitees
         if (!finalEmail && call.calendar_invitees) {
           const matchedInvitee = call.calendar_invitees.find((inv) =>
             inv.matched_speaker_display_name === name ||
@@ -329,8 +380,8 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
 
       return speakers;
     },
-    // fathom_transcripts.recording_id is BIGINT — only query for legacy numeric IDs.
-    enabled: open && !!call && !!userId && typeof call?.recording_id === 'number',
+    // Enabled for all recordings — UUID path uses call_participants, legacy path uses fathom_transcripts
+    enabled: open && !!call && !!userId,
   });
 
   return {

--- a/src/hooks/useWorkspaces.ts
+++ b/src/hooks/useWorkspaces.ts
@@ -388,6 +388,9 @@ export function mapRecordingToMeeting(recording: WorkspaceRecording): Meeting {
   return {
     // Use legacy_recording_id for TranscriptTable compatibility (it expects number | string)
     recording_id: recording.legacy_recording_id ?? recording.id,
+    // Always expose the canonical UUID so detail queries can target UUID-keyed tables
+    // (call_tag_assignments, call_participants) regardless of recording_id type.
+    canonical_uuid: recording.id,
     title: recording.title,
     full_transcript: recording.full_transcript || null,
     summary: recording.summary || null,

--- a/src/types/meetings.ts
+++ b/src/types/meetings.ts
@@ -35,6 +35,8 @@ export interface TranscriptSegmentDisplay extends TranscriptSegment {
 
 export interface Meeting {
   recording_id: string | number;
+  /** Canonical UUID from recordings.id — always set for recordings-table rows. Used for UUID-keyed queries (call_tag_assignments, call_participants, etc.). */
+  canonical_uuid?: string;
   title: string;
   created_at: string;
   recording_start_time?: string | null;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -539,6 +539,54 @@ export type Database = {
         }
         Relationships: []
       }
+      call_participants: {
+        Row: {
+          id: string
+          recording_id: string
+          organization_id: string
+          name: string | null
+          email: string | null
+          participant_type: string
+          sources: string[]
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          recording_id: string
+          organization_id: string
+          name?: string | null
+          email?: string | null
+          participant_type?: string
+          sources?: string[]
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          recording_id?: string
+          organization_id?: string
+          name?: string | null
+          email?: string | null
+          participant_type?: string
+          sources?: string[]
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "call_participants_recording_id_fkey"
+            columns: ["recording_id"]
+            isOneToOne: false
+            referencedRelation: "recordings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "call_participants_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       call_speakers: {
         Row: {
           recording_id: string


### PR DESCRIPTION
## Summary

Fixes missing transcripts, speakers, and tags when opening the call detail panel for non-legacy (UUID) recordings after the BIGINT→UUID migration (#125).

Three separate bugs in `useCallDetailQueries.ts`:

- **Transcripts** — when `full_transcript` is null on the Meeting object (list queries skip the heavy column for performance), the code short-circuited with "no transcript for non-legacy call". Added a fallback that re-fetches `full_transcript` from `recordings` by canonical UUID before returning empty.

- **Speakers** — `callSpeakers` was gated behind `typeof recording_id === 'number'`, so UUID recordings never loaded speakers. Added a primary path that queries `call_participants` (canonical table, migration #120) when `canonical_uuid` is present; legacy `fathom_transcripts` path retained for numeric IDs.

- **Tags** (callCategories / callTags) — `call_tag_assignments.recording_id` is now UUID after migration #125, but the queries were passing the numeric legacy ID causing a type mismatch and empty results. Both queries now resolve `canonical_uuid` first.

Supporting changes:
- `Meeting.canonical_uuid?: string` — new optional field, always set for recordings-table rows, gives detail queries a reliable UUID without an extra DB round-trip
- `mapRecordingToMeeting` sets `canonical_uuid: recording.id` unconditionally

## Test plan

- [ ] Open call detail for a **legacy** (Fathom-synced) recording — transcripts, speakers, and tags should still load correctly
- [ ] Open call detail for a **new UUID** recording (no legacy_recording_id) — transcript should parse, speakers from `call_participants` should appear, tags should load
- [ ] Verify `callCategories` / `callTags` display correctly for both recording types
- [ ] TypeScript passes: `npm run type-check`

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)