### PR TITLE
feat: Add 'Trim all after this' option to transcript context menu

### DIFF
--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -69,7 +69,7 @@ export function CallDetailDialog({
   }>({ open: false, segmentId: null, currentSpeaker: "", currentEmail: undefined });
   const [trimDialog, setTrimDialog] = useState<{
     open: boolean;
-    type: "this" | "before";
+    type: "this" | "before" | "after";
     segmentId: string | null;
   }>({ open: false, type: "this", segmentId: null });
   const [resyncDialog, setResyncDialog] = useState(false);
@@ -196,12 +196,19 @@ export function CallDetailDialog({
 
     if (trimDialog.type === "this") {
       trimSegmentMutation.mutate({ segmentIds: [trimDialog.segmentId] });
-    } else {
+    } else if (trimDialog.type === "before") {
       // Find the index in VISIBLE transcripts (excluding deleted)
       const segmentIndex = transcripts.findIndex((t: { id: string }) => t.id === trimDialog.segmentId);
       // Get all VISIBLE segments before it
       const segmentIds = transcripts.slice(0, segmentIndex).map((t: { id: string }) => t.id);
       logger.info("Trimming segments", segmentIds);
+      trimSegmentMutation.mutate({ segmentIds });
+    } else {
+      // Find the index in VISIBLE transcripts (excluding deleted)
+      const segmentIndex = transcripts.findIndex((t: { id: string }) => t.id === trimDialog.segmentId);
+      // Get all VISIBLE segments after it (not including the selected segment)
+      const segmentIds = transcripts.slice(segmentIndex + 1).map((t: { id: string }) => t.id);
+      logger.info("Trimming segments after", segmentIds);
       trimSegmentMutation.mutate({ segmentIds });
     }
   };
@@ -242,6 +249,10 @@ export function CallDetailDialog({
     setTrimDialog({ open: true, type: "before", segmentId });
   }, []);
 
+  const handleTrimAfter = useCallback((segmentId: string) => {
+    setTrimDialog({ open: true, type: "after", segmentId });
+  }, []);
+
   const handleRevert = useCallback((segmentId: string) => {
     revertSegmentMutation.mutate({ segmentId });
   }, [revertSegmentMutation]);
@@ -270,6 +281,7 @@ export function CallDetailDialog({
     onChangeSpeaker: handleChangeSpeaker,
     onTrimThis: handleTrimThis,
     onTrimBefore: handleTrimBefore,
+    onTrimAfter: handleTrimAfter,
     onRevert: handleRevert,
     onResyncCall: handleResyncCall,
   }), [
@@ -281,6 +293,7 @@ export function CallDetailDialog({
     handleChangeSpeaker,
     handleTrimThis,
     handleTrimBefore,
+    handleTrimAfter,
     handleRevert,
     handleResyncCall,
   ]);

--- a/src/components/call-detail/CallTranscriptTab.tsx
+++ b/src/components/call-detail/CallTranscriptTab.tsx
@@ -37,6 +37,7 @@ export interface TranscriptHandlers {
   onChangeSpeaker: (segmentId: string, currentSpeaker: string, currentEmail?: string) => void;
   onTrimThis: (segmentId: string) => void;
   onTrimBefore: (segmentId: string) => void;
+  onTrimAfter: (segmentId: string) => void;
   onRevert: (segmentId: string) => void;
   onResyncCall: () => void;
 }
@@ -101,6 +102,7 @@ export const CallTranscriptTab = memo(function CallTranscriptTab({
     onChangeSpeaker,
     onTrimThis,
     onTrimBefore,
+    onTrimAfter,
     onRevert,
     onResyncCall,
   } = handlers;
@@ -339,6 +341,7 @@ export const CallTranscriptTab = memo(function CallTranscriptTab({
                                           onChangeSpeaker={() => onChangeSpeaker(message.id, message.display_speaker_name, message.display_speaker_email)}
                                           onTrimThis={() => onTrimThis(message.id)}
                                           onTrimBefore={() => onTrimBefore(message.id)}
+                                          onTrimAfter={() => onTrimAfter(message.id)}
                                           onRevert={() => onRevert(message.id)}
                                         />
                                       </div>

--- a/src/components/transcript-library/TranscriptSegmentContextMenu.tsx
+++ b/src/components/transcript-library/TranscriptSegmentContextMenu.tsx
@@ -21,6 +21,7 @@ interface TranscriptSegmentContextMenuProps {
   onChangeSpeaker: () => void;
   onTrimThis: () => void;
   onTrimBefore: () => void;
+  onTrimAfter: () => void;
   onRevert: () => void;
 }
 
@@ -31,6 +32,7 @@ export function TranscriptSegmentContextMenu({
   onChangeSpeaker,
   onTrimThis,
   onTrimBefore,
+  onTrimAfter,
   onRevert,
 }: TranscriptSegmentContextMenuProps) {
   return (
@@ -61,6 +63,10 @@ export function TranscriptSegmentContextMenu({
           <DropdownMenuItem onClick={onTrimBefore} className="text-destructive">
             <RiScissorsLine className="mr-2 h-4 w-4" />
             Trim all before this
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onTrimAfter} className="text-destructive">
+            <RiScissorsLine className="mr-2 h-4 w-4" />
+            Trim all after this
           </DropdownMenuItem>
           {hasEdits && (
             <>

--- a/src/components/transcript-library/TrimConfirmDialog.tsx
+++ b/src/components/transcript-library/TrimConfirmDialog.tsx
@@ -5,7 +5,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 interface TrimConfirmDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  type: "this" | "before";
+  type: "this" | "before" | "after";
   onConfirm: () => void;
 }
 
@@ -20,14 +20,16 @@ export function TrimConfirmDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>
-            {type === "this" ? "Trim This Section?" : "Trim All Before This?"}
+            {type === "this" ? "Trim This Section?" : type === "before" ? "Trim All Before This?" : "Trim All After This?"}
           </AlertDialogTitle>
           <AlertDialogDescription asChild>
             <div className="space-y-2">
               <p>
                 {type === "this"
                   ? "This will hide this section from the transcript."
-                  : "This will hide all sections before this one from the transcript."}
+                  : type === "before"
+                  ? "This will hide all sections before this one from the transcript."
+                  : "This will hide all sections after this one from the transcript."}
               </p>
               <div className="flex items-start gap-2 p-3 bg-muted rounded-md">
                 <RiInformationLine className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
@@ -58,7 +60,7 @@ export function TrimConfirmDialog({
             onClick={onConfirm}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
-            Yes, trim {type === "this" ? "this section" : "all before"}
+            Yes, trim {type === "this" ? "this section" : type === "before" ? "all before" : "all after"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
## Summary

- Adds the missing **Trim all after this** menu item to `TranscriptSegmentContextMenu`, completing the trim action set alongside "Trim this section" and "Trim all before this"
- Keeps the selected segment and hides all segments that follow it
- Updates `TrimConfirmDialog` to handle the new `"after"` type with appropriate title, description, and button label
- Wires `handleTrimAfter` through `CallDetailDialog` → `TranscriptHandlers` → `CallTranscriptTab` → `TranscriptSegmentContextMenu`

## Test plan

- [ ] Open a call with multiple transcript segments
- [ ] Right-click / open context menu on a segment that is not the last one
- [ ] Confirm "Trim all after this" appears in the menu
- [ ] Click it — confirm dialog appears with correct title "Trim All After This?" and description
- [ ] Confirm trim — verify all segments after the selected one are hidden; selected segment is preserved
- [ ] Verify "Trim all before this" and "Trim this section" still work as expected

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)