### PR TITLE
feat(149): restore auto-naming and auto-tagging for imported calls

### DIFF
--- a/src/components/settings/AccountTab.tsx
+++ b/src/components/settings/AccountTab.tsx
@@ -438,7 +438,7 @@ export default function AccountTab() {
             <div className="space-y-1">
               <Label htmlFor="auto-naming">Auto-Naming</Label>
               <p className="text-sm text-gray-500 dark:text-gray-500">
-                Generate AI-powered titles for imported calls
+                Generate descriptive titles for imported calls
               </p>
             </div>
             <Switch

--- a/src/components/settings/AccountTab.tsx
+++ b/src/components/settings/AccountTab.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -15,6 +16,7 @@ import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import { supabase } from "@/integrations/supabase/client";
 import { getSafeUser } from "@/lib/auth-utils";
+import { usePreferencesStore } from "@/stores/preferencesStore";
 
 const timezones = [
   { value: "America/New_York", label: "Eastern Time (ET)" },
@@ -55,8 +57,11 @@ export default function AccountTab() {
   const [_showCurrentPassword, _setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
 
+  const { preferences, isLoading: prefsLoading, loadPreferences, updatePreference } = usePreferencesStore();
+
   useEffect(() => {
     loadProfileData();
+    loadPreferences();
   }, []);
 
   const loadProfileData = async () => {
@@ -414,6 +419,62 @@ export default function AccountTab() {
                 </div>
               </div>
             )}
+          </div>
+        </div>
+      </div>
+
+      <Separator className="my-16" />
+
+      {/* Auto-Processing Section */}
+      <div className="grid grid-cols-1 gap-x-10 gap-y-8 lg:grid-cols-3">
+        <div>
+          <h2 className="font-semibold text-gray-900 dark:text-gray-50">Auto-Processing</h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
+            Automatically enhance calls when they are imported
+          </p>
+        </div>
+        <div className="lg:col-span-2 space-y-6">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Label htmlFor="auto-naming">Auto-Naming</Label>
+              <p className="text-sm text-gray-500 dark:text-gray-500">
+                Generate AI-powered titles for imported calls
+              </p>
+            </div>
+            <Switch
+              id="auto-naming"
+              checked={preferences.autoProcessingTitleGeneration}
+              disabled={prefsLoading}
+              onCheckedChange={async (checked) => {
+                try {
+                  await updatePreference("autoProcessingTitleGeneration", checked);
+                  toast.success(checked ? "Auto-naming enabled" : "Auto-naming disabled");
+                } catch {
+                  toast.error("Failed to update preference");
+                }
+              }}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Label htmlFor="auto-tagging">Auto-Tagging</Label>
+              <p className="text-sm text-gray-500 dark:text-gray-500">
+                Automatically assign tags to imported calls
+              </p>
+            </div>
+            <Switch
+              id="auto-tagging"
+              checked={preferences.autoProcessingTagging}
+              disabled={prefsLoading}
+              onCheckedChange={async (checked) => {
+                try {
+                  await updatePreference("autoProcessingTagging", checked);
+                  toast.success(checked ? "Auto-tagging enabled" : "Auto-tagging disabled");
+                } catch {
+                  toast.error("Failed to update preference");
+                }
+              }}
+            />
           </div>
         </div>
       </div>

--- a/supabase/functions/auto-tag-calls/index.ts
+++ b/supabase/functions/auto-tag-calls/index.ts
@@ -277,7 +277,7 @@ Deno.serve(async (req) => {
         .maybeSingle();
 
       const prefs = profile?.auto_processing_preferences as { autoProcessingTagging?: boolean } | null;
-      if (prefs?.autoProcessingTagging === false) {
+      if (prefs?.autoProcessingTagging !== true) {
         console.log(`Auto-tagging disabled for user ${userId}, skipping`);
         return new Response(
           JSON.stringify({ success: true, message: 'Auto-tagging disabled by user preference', totalProcessed: 0 }),
@@ -452,7 +452,8 @@ Select the ONE most appropriate tag from the approved list.`;
             auto_tags: [selectedTag], // Single tag in array
             auto_tags_generated_at: new Date().toISOString(),
           })
-          .eq('recording_id', recordingId);
+          .eq('recording_id', recordingId)
+          .eq('user_id', userId);
 
         if (updateError) {
           console.error(`Error updating tag for ${recordingId}:`, updateError);

--- a/supabase/functions/auto-tag-calls/index.ts
+++ b/supabase/functions/auto-tag-calls/index.ts
@@ -17,7 +17,11 @@ function createOpenRouterProvider(apiKey: string) {
 }
 
 interface AutoTagRequest {
-  recordingIds: number[];
+  recordingIds?: number[];
+  user_id?: string;            // For internal service calls (bypasses JWT auth)
+  auto_discover?: boolean;     // Find all calls without auto_tags
+  limit?: number;              // Max calls when auto_discover is true
+  respectPreference?: boolean; // When true, skip if user has autoProcessingTagging=false
 }
 
 // Approved tag list - MUST use only these tags
@@ -220,40 +224,112 @@ Deno.serve(async (req) => {
 
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    // Verify authorization
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
-      return new Response(
-        JSON.stringify({ error: 'No authorization header' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+    // Parse body first to check for internal service call
+    const body: AutoTagRequest = await req.json();
+    const { recordingIds: bodyRecordingIds, user_id: internalUserId, auto_discover, limit = 50, respectPreference = false } = body;
+
+    let userId: string;
+
+    // Check for internal service call (from webhook or other Edge Functions)
+    if (internalUserId) {
+      const { data: userExists } = await supabase
+        .from('user_settings')
+        .select('user_id')
+        .eq('user_id', internalUserId)
+        .maybeSingle();
+
+      if (!userExists) {
+        return new Response(
+          JSON.stringify({ error: 'Invalid user_id for internal call' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      userId = internalUserId;
+      console.log(`Internal service call for user: ${userId}`);
+    } else {
+      // External call - verify JWT authorization
+      const authHeader = req.headers.get('Authorization');
+      if (!authHeader) {
+        return new Response(
+          JSON.stringify({ error: 'No authorization header' }),
+          { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const token = authHeader.replace('Bearer ', '');
+      const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+
+      if (userError || !user) {
+        return new Response(
+          JSON.stringify({ error: 'Unauthorized' }),
+          { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      userId = user.id;
     }
 
-    const token = authHeader.replace('Bearer ', '');
-    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+    // Check user preference when called from automated pipeline
+    if (respectPreference) {
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('auto_processing_preferences')
+        .eq('user_id', userId)
+        .maybeSingle();
 
-    if (userError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+      const prefs = profile?.auto_processing_preferences as { autoProcessingTagging?: boolean } | null;
+      if (prefs?.autoProcessingTagging === false) {
+        console.log(`Auto-tagging disabled for user ${userId}, skipping`);
+        return new Response(
+          JSON.stringify({ success: true, message: 'Auto-tagging disabled by user preference', totalProcessed: 0 }),
+          { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
     }
 
-    const { recordingIds }: AutoTagRequest = await req.json();
+    let recordingIds: number[];
 
-    if (!recordingIds || recordingIds.length === 0) {
+    if (auto_discover) {
+      // Find all calls without auto_tags
+      console.log(`Auto-discovering untagged calls for user ${userId} (limit: ${limit})`);
+      const { data: untaggedCalls, error: discoverError } = await supabase
+        .from('fathom_raw_calls')
+        .select('recording_id')
+        .eq('user_id', userId)
+        .is('auto_tags', null)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+
+      if (discoverError) {
+        return new Response(
+          JSON.stringify({ error: `Failed to discover calls: ${discoverError.message}` }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      recordingIds = (untaggedCalls || []).map(c => c.recording_id);
+      console.log(`Found ${recordingIds.length} calls needing auto-tagging`);
+    } else if (bodyRecordingIds && bodyRecordingIds.length > 0) {
+      recordingIds = bodyRecordingIds;
+    } else {
       return new Response(
-        JSON.stringify({ error: 'No recording IDs provided' }),
+        JSON.stringify({ error: 'Either recordingIds or auto_discover=true is required' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    console.log(`Auto-tagging ${recordingIds.length} calls for user ${user.id}`);
+    if (recordingIds.length === 0) {
+      return new Response(
+        JSON.stringify({ success: true, message: 'No calls to process', totalProcessed: 0 }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    console.log(`Auto-tagging ${recordingIds.length} calls for user ${userId}`);
 
     // Load user preferences and historical patterns ONCE
     const [preferences, historicalPatterns] = await Promise.all([
-      getUserTagPreferences(supabase, user.id),
-      getHistoricalPatterns(supabase, user.id, ''),
+      getUserTagPreferences(supabase, userId),
+      getHistoricalPatterns(supabase, userId, ''),
     ]);
 
     const preferencesContext = buildPreferencesContext(preferences);
@@ -269,7 +345,7 @@ Deno.serve(async (req) => {
           .from('fathom_raw_calls')
           .select('recording_id, title, full_transcript, summary, calendar_invitees')
           .eq('recording_id', recordingId)
-          .eq('user_id', user.id)
+          .eq('user_id', userId)
           .single();
 
         if (callError || !call) {
@@ -347,7 +423,7 @@ Select the ONE most appropriate tag from the approved list.`;
         // Start Langfuse trace
         const trace = startTrace({
           name: 'auto-tag-calls',
-          userId: user.id,
+          userId,
           model: 'openai/gpt-5-nano',
           input: { prompt: tagPrompt.substring(0, 500) + '...' },
           metadata: { recordingId, attendeeCount },

--- a/supabase/functions/generate-ai-titles/index.ts
+++ b/supabase/functions/generate-ai-titles/index.ts
@@ -20,6 +20,7 @@ interface GenerateTitlesRequest {
   auto_discover?: boolean;  // Find all calls without AI titles
   limit?: number;           // Max calls to process when auto_discover is true
   user_id?: string;         // For internal service calls (bypasses JWT auth)
+  respectPreference?: boolean; // When true, skip if user has autoProcessingTitleGeneration=false
 }
 
 /**
@@ -168,7 +169,7 @@ Deno.serve(async (req) => {
 
     // Parse body first to check for internal service call
     const body: GenerateTitlesRequest = await req.json();
-    const { recordingIds, auto_discover, limit = 50, user_id: internalUserId } = body;
+    const { recordingIds, auto_discover, limit = 50, user_id: internalUserId, respectPreference = false } = body;
 
     let userId: string;
 
@@ -210,6 +211,24 @@ Deno.serve(async (req) => {
         );
       }
       userId = user.id;
+    }
+
+    // Check user preference when called from automated pipeline
+    if (respectPreference) {
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('auto_processing_preferences')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      const prefs = profile?.auto_processing_preferences as { autoProcessingTitleGeneration?: boolean } | null;
+      if (prefs?.autoProcessingTitleGeneration === false) {
+        console.log(`Auto-naming disabled for user ${userId}, skipping`);
+        return new Response(
+          JSON.stringify({ success: true, message: 'Auto-naming disabled by user preference', totalProcessed: 0 }),
+          { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
     }
 
     let idsToProcess: number[] = [];

--- a/supabase/functions/generate-ai-titles/index.ts
+++ b/supabase/functions/generate-ai-titles/index.ts
@@ -222,7 +222,7 @@ Deno.serve(async (req) => {
         .maybeSingle();
 
       const prefs = profile?.auto_processing_preferences as { autoProcessingTitleGeneration?: boolean } | null;
-      if (prefs?.autoProcessingTitleGeneration === false) {
+      if (prefs?.autoProcessingTitleGeneration !== true) {
         console.log(`Auto-naming disabled for user ${userId}, skipping`);
         return new Response(
           JSON.stringify({ success: true, message: 'Auto-naming disabled by user preference', totalProcessed: 0 }),

--- a/supabase/functions/sync-meetings/index.ts
+++ b/supabase/functions/sync-meetings/index.ts
@@ -649,11 +649,12 @@ Deno.serve(async (req) => {
 
         // Fire-and-forget: invoke generate-ai-titles for the synced recordings
         if (synced.length > 0) {
-          // This generates descriptive AI titles and auto-categorizes calls
+          // This generates descriptive AI titles - respects user preference
           console.log(`Triggering AI title generation for ${synced.length} synced meetings...`);
           supabase.functions.invoke('generate-ai-titles', {
             body: {
               recordingIds: synced,
+              respectPreference: true,
             },
             headers: {
               Authorization: `Bearer ${jwt}`,
@@ -666,6 +667,26 @@ Deno.serve(async (req) => {
             }
           }).catch((err) => {
             console.error(`AI title invocation failed for sync job ${jobId}:`, err);
+          });
+
+          // Fire-and-forget: invoke auto-tag-calls for the synced recordings
+          console.log(`Triggering auto-tagging for ${synced.length} synced meetings...`);
+          supabase.functions.invoke('auto-tag-calls', {
+            body: {
+              recordingIds: synced,
+              respectPreference: true,
+            },
+            headers: {
+              Authorization: `Bearer ${jwt}`,
+            },
+          }).then(({ data, error }) => {
+            if (error) {
+              console.error(`Auto-tagging failed for sync job ${jobId}:`, error);
+            } else {
+              console.log(`Auto-tagging completed for ${synced.length} meetings:`, data);
+            }
+          }).catch((err) => {
+            console.error(`Auto-tag invocation failed for sync job ${jobId}:`, err);
           });
         }
       } catch (error) {

--- a/supabase/functions/webhook/index.ts
+++ b/supabase/functions/webhook/index.ts
@@ -833,14 +833,15 @@ Deno.serve(async (req) => {
         //   console.error('Failed to invoke embed-chunks:', embedErr);
         // }
 
-        // Trigger AI title generation for each synced user
-        console.log(`🏷️ Triggering AI title generation for meeting ${meeting.recording_id}...`);
+        // Trigger AI title generation and auto-tagging for each synced user
+        console.log(`🏷️ Triggering AI title generation and auto-tagging for meeting ${meeting.recording_id}...`);
         for (const syncedUserId of syncedUserIds) {
           try {
             const { error: titleError } = await supabase.functions.invoke('generate-ai-titles', {
               body: {
                 recordingIds: [meeting.recording_id],
-                user_id: syncedUserId  // Pass user_id for internal service call
+                user_id: syncedUserId,  // Pass user_id for internal service call
+                respectPreference: true,
               },
             });
             if (titleError) {
@@ -850,6 +851,23 @@ Deno.serve(async (req) => {
             }
           } catch (titleErr) {
             console.error(`Failed to invoke generate-ai-titles for user ${syncedUserId}:`, titleErr);
+          }
+
+          try {
+            const { error: tagError } = await supabase.functions.invoke('auto-tag-calls', {
+              body: {
+                recordingIds: [meeting.recording_id],
+                user_id: syncedUserId,  // Pass user_id for internal service call
+                respectPreference: true,
+              },
+            });
+            if (tagError) {
+              console.error(`Auto-tagging failed for user ${syncedUserId}:`, tagError);
+            } else {
+              console.log(`✅ Auto-tagging triggered for user ${syncedUserId}`);
+            }
+          } catch (tagErr) {
+            console.error(`Failed to invoke auto-tag-calls for user ${syncedUserId}:`, tagErr);
           }
         }
 


### PR DESCRIPTION
## Summary

Restores auto-naming and auto-tagging as first-class features in the import pipeline. Both edge functions existed but were never wired into sync/webhook, and neither respected user preferences.

- **generate-ai-titles**: Add `respectPreference` flag — when called internally from sync/webhook, checks `autoProcessingTitleGeneration` preference before running
- **auto-tag-calls**: Add internal service call support (`user_id` bypass, matching generate-ai-titles pattern), `auto_discover` mode, and `respectPreference` flag for `autoProcessingTagging` preference
- **sync-meetings**: Fire-and-forget `auto-tag-calls` alongside existing title generation after batch sync
- **webhook**: Fire-and-forget `auto-tag-calls` for each synced user after title generation
- **AccountTab**: New "Auto-Processing" section with toggle switches for both features, backed by `preferencesStore`

Both features default to **off** (opt-in) via `autoProcessingTitleGeneration: false` / `autoProcessingTagging: false` in `user_profiles.auto_processing_preferences`. Manual invocations (e.g. button clicks) bypass the preference check and always run.

## Test plan

- [ ] Enable auto-naming toggle in Account settings → trigger a sync → verify `ai_generated_title` is populated on imported calls
- [ ] Disable auto-naming toggle → trigger a sync → verify titles are NOT generated
- [ ] Enable auto-tagging toggle → trigger a sync → verify `auto_tags` is populated on imported calls
- [ ] Disable auto-tagging toggle → trigger a sync → verify tags are NOT set
- [ ] Webhook delivery with auto-naming/tagging enabled → verify both fire after import
- [ ] Preference toggle persists across page reload

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)