### PR TITLE
feat(148): Split call recording into two parts at a transcript segment

### DIFF
--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -208,7 +208,7 @@ export function CallDetailDialog({
   useEffect(() => {
     if (splitRecordingMutation.isSuccess && splitRecordingMutation.data) {
       const result = splitRecordingMutation.data;
-      setSplitDialog({ open: false, segmentId: null });
+      setSplitDialog({ open: false, segmentId: null, splitTimestamp: null, splitSpeaker: null });
       setSplitResult({
         part1Title: result.part1_title,
         part2RecordingId: result.part2_recording_id,

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -11,11 +11,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import { ChangeSpeakerDialog } from "@/components/transcript-library/ChangeSpeakerDialog";
 import { TrimConfirmDialog } from "@/components/transcript-library/TrimConfirmDialog";
 import { ResyncConfirmDialog } from "@/components/transcript-library/ResyncConfirmDialog";
+import { SplitConfirmDialog } from "@/components/transcript-library/SplitConfirmDialog";
 import { useTranscriptExport } from "@/hooks/useTranscriptExport";
 import { useCallDetailQueries } from "@/hooks/useCallDetailQueries";
 import { useCallDetailMutations } from "@/hooks/useCallDetailMutations";
 import { Badge } from "@/components/ui/badge";
-import { RiCheckboxCircleLine } from "@remixicon/react";
+import { RiCheckboxCircleLine, RiRefreshLine } from "@remixicon/react";
 import { CallStatsFooter } from "@/components/call-detail/CallStatsFooter";
 import { CallInviteesTab } from "@/components/call-detail/CallInviteesTab";
 import { CallParticipantsTab } from "@/components/call-detail/CallParticipantsTab";
@@ -29,6 +30,8 @@ import {
 } from "@/components/call-detail/CallTranscriptTab";
 import { logger } from "@/lib/logger";
 import { Meeting } from "@/types";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
 
 interface CallDetailDialogProps {
   call: Meeting | null;
@@ -73,6 +76,15 @@ export function CallDetailDialog({
     segmentId: string | null;
   }>({ open: false, type: "this", segmentId: null });
   const [resyncDialog, setResyncDialog] = useState(false);
+  const [splitDialog, setSplitDialog] = useState<{
+    open: boolean;
+    segmentId: string | null;
+  }>({ open: false, segmentId: null });
+  const [splitResult, setSplitResult] = useState<{
+    part1Title: string;
+    part2RecordingId: string;
+    part2Title: string;
+  } | null>(null);
 
   // Use custom hooks for queries and mutations
   const {
@@ -100,6 +112,7 @@ export function CallDetailDialog({
     trimSegment: trimSegmentMutation,
     revertSegment: revertSegmentMutation,
     resyncCall: resyncCallMutation,
+    splitRecording: splitRecordingMutation,
   } = useCallDetailMutations({
     call,
     userId: user?.id,
@@ -148,6 +161,20 @@ export function CallDetailDialog({
       setResyncDialog(false);
     }
   }, [resyncCallMutation.isSuccess]);
+
+  // Handle split recording success
+  useEffect(() => {
+    if (splitRecordingMutation.isSuccess && splitRecordingMutation.data) {
+      const result = splitRecordingMutation.data;
+      setSplitDialog({ open: false, segmentId: null });
+      setSplitResult({
+        part1Title: result.part1_title,
+        part2RecordingId: result.part2_recording_id,
+        part2Title: result.part2_title,
+      });
+      toast.success(`Recording split into "${result.part1_title}" and "${result.part2_title}"`);
+    }
+  }, [splitRecordingMutation.isSuccess, splitRecordingMutation.data]);
 
   // Debug logging for missing data
   const duration = call?.recording_start_time && call?.recording_end_time
@@ -246,6 +273,20 @@ export function CallDetailDialog({
     revertSegmentMutation.mutate({ segmentId });
   }, [revertSegmentMutation]);
 
+  const handleSplitHere = useCallback((segmentId: string) => {
+    setSplitDialog({ open: true, segmentId });
+  }, []);
+
+  const handleConfirmSplit = useCallback(() => {
+    if (!splitDialog.segmentId || !transcripts) return;
+    const segmentIndex = transcripts.findIndex((t) => t.id === splitDialog.segmentId);
+    if (segmentIndex <= 0) {
+      toast.error("Cannot split at the first segment — choose a later segment");
+      return;
+    }
+    splitRecordingMutation.mutate({ segmentIndex });
+  }, [splitDialog.segmentId, transcripts, splitRecordingMutation]);
+
   // Create grouped props using useMemo for optimal performance
   const transcriptViewState: TranscriptViewState = useMemo(() => ({
     includeTimestamps,
@@ -272,6 +313,7 @@ export function CallDetailDialog({
     onTrimBefore: handleTrimBefore,
     onRevert: handleRevert,
     onResyncCall: handleResyncCall,
+    onSplitHere: handleSplitHere,
   }), [
     handleExport,
     handleCopyTranscript,
@@ -283,6 +325,7 @@ export function CallDetailDialog({
     handleTrimBefore,
     handleRevert,
     handleResyncCall,
+    handleSplitHere,
   ]);
 
   const transcriptData: TranscriptData = useMemo(() => ({
@@ -395,6 +438,75 @@ export function CallDetailDialog({
         deletedCount={deletedCount}
         onConfirm={() => resyncCallMutation.mutate()}
       />
+
+      {/* Split Confirm Dialog */}
+      <SplitConfirmDialog
+        open={splitDialog.open}
+        onOpenChange={(open) => setSplitDialog({ ...splitDialog, open })}
+        onConfirm={handleConfirmSplit}
+        isPending={splitRecordingMutation.isPending}
+      />
+
+      {/* Post-split: Regenerate summary banner */}
+      {splitResult && (
+        <Dialog open={!!splitResult} onOpenChange={() => setSplitResult(null)}>
+          <DialogContent className="max-w-md bg-card" aria-describedby="split-result-description">
+            <DialogDescription id="split-result-description" className="sr-only">
+              Recording split successfully.
+            </DialogDescription>
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <RiCheckboxCircleLine className="h-5 w-5 text-green-500" />
+                <h3 className="font-semibold text-foreground">Recording split successfully</h3>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Your call has been split into two recordings. Each summary has been cleared —
+                regenerate them to get accurate summaries for each part.
+              </p>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
+                  <span className="text-sm font-medium truncate">{splitResult.part1Title}</span>
+                  <button
+                    onClick={() => {
+                      supabase.functions.invoke('summarize-call', {
+                        body: { recording_id: call?.recording_id, force_refresh: true },
+                      });
+                      toast.success("Regenerating summary for Part 1…");
+                    }}
+                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground ml-2 shrink-0"
+                  >
+                    <RiRefreshLine className="h-3 w-3" />
+                    Regenerate
+                  </button>
+                </div>
+                <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
+                  <span className="text-sm font-medium truncate">{splitResult.part2Title}</span>
+                  <button
+                    onClick={() => {
+                      supabase.functions.invoke('summarize-call', {
+                        body: { recording_id: splitResult.part2RecordingId, force_refresh: true },
+                      });
+                      toast.success("Regenerating summary for Part 2…");
+                    }}
+                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground ml-2 shrink-0"
+                  >
+                    <RiRefreshLine className="h-3 w-3" />
+                    Regenerate
+                  </button>
+                </div>
+              </div>
+              <div className="flex justify-end">
+                <button
+                  onClick={() => setSplitResult(null)}
+                  className="text-sm text-muted-foreground hover:text-foreground"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
     </Dialog>
   );
 }

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -326,7 +326,9 @@ export function CallDetailDialog({
       open: true,
       segmentId,
       splitTimestamp: segment.timestamp,
-      splitSpeaker: segment.display_speaker_name,
+      // Use the original speaker_name (not display_speaker_name) so the backend
+      // can match against full_transcript which stores original names, not edited ones.
+      splitSpeaker: segment.speaker_name,
     });
   }, [transcripts]);
 

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -33,6 +33,46 @@ import { Meeting } from "@/types";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 
+/**
+ * Row in the post-split dialog that shows a recording title and a
+ * "Regenerate summary" button with proper async handling.
+ */
+function SplitSummaryRow({
+  title,
+  recordingId,
+}: {
+  title: string;
+  recordingId: string | number | null | undefined;
+}) {
+  const handleRegenerate = async () => {
+    if (!recordingId) return;
+    const toastId = toast.loading(`Regenerating summary for "${title}"…`);
+    try {
+      const { error } = await supabase.functions.invoke('summarize-call', {
+        body: { recording_id: recordingId, force_refresh: true },
+      });
+      if (error) throw error;
+      toast.success(`Summary regenerated for "${title}"`, { id: toastId });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      toast.error(`Failed to regenerate summary: ${msg}`, { id: toastId });
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
+      <span className="text-sm font-medium truncate">{title}</span>
+      <button
+        onClick={handleRegenerate}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground ml-2 shrink-0"
+      >
+        <RiRefreshLine className="h-3 w-3" />
+        Regenerate
+      </button>
+    </div>
+  );
+}
+
 interface CallDetailDialogProps {
   call: Meeting | null;
   open: boolean;
@@ -79,7 +119,9 @@ export function CallDetailDialog({
   const [splitDialog, setSplitDialog] = useState<{
     open: boolean;
     segmentId: string | null;
-  }>({ open: false, segmentId: null });
+    splitTimestamp: string | null;
+    splitSpeaker: string | null;
+  }>({ open: false, segmentId: null, splitTimestamp: null, splitSpeaker: null });
   const [splitResult, setSplitResult] = useState<{
     part1Title: string;
     part2RecordingId: string;
@@ -274,18 +316,27 @@ export function CallDetailDialog({
   }, [revertSegmentMutation]);
 
   const handleSplitHere = useCallback((segmentId: string) => {
-    setSplitDialog({ open: true, segmentId });
-  }, []);
+    // Look up the segment to capture its timestamp and speaker name as a stable locator.
+    // Sending timestamp+speaker (not an array index) to the backend avoids an index
+    // mismatch that would occur if the user has previously trimmed/deleted segments
+    // (the frontend filtered array and the backend's parsed full_transcript differ).
+    const segment = transcripts?.find((t) => t.id === segmentId);
+    if (!segment) return;
+    setSplitDialog({
+      open: true,
+      segmentId,
+      splitTimestamp: segment.timestamp,
+      splitSpeaker: segment.display_speaker_name,
+    });
+  }, [transcripts]);
 
   const handleConfirmSplit = useCallback(() => {
-    if (!splitDialog.segmentId || !transcripts) return;
-    const segmentIndex = transcripts.findIndex((t) => t.id === splitDialog.segmentId);
-    if (segmentIndex <= 0) {
-      toast.error("Cannot split at the first segment — choose a later segment");
-      return;
-    }
-    splitRecordingMutation.mutate({ segmentIndex });
-  }, [splitDialog.segmentId, transcripts, splitRecordingMutation]);
+    if (!splitDialog.splitTimestamp || !splitDialog.splitSpeaker) return;
+    splitRecordingMutation.mutate({
+      splitTimestamp: splitDialog.splitTimestamp,
+      splitSpeaker: splitDialog.splitSpeaker,
+    });
+  }, [splitDialog.splitTimestamp, splitDialog.splitSpeaker, splitRecordingMutation]);
 
   // Create grouped props using useMemo for optimal performance
   const transcriptViewState: TranscriptViewState = useMemo(() => ({
@@ -442,7 +493,7 @@ export function CallDetailDialog({
       {/* Split Confirm Dialog */}
       <SplitConfirmDialog
         open={splitDialog.open}
-        onOpenChange={(open) => setSplitDialog({ ...splitDialog, open })}
+        onOpenChange={(open) => setSplitDialog((s) => ({ ...s, open }))}
         onConfirm={handleConfirmSplit}
         isPending={splitRecordingMutation.isPending}
       />
@@ -464,36 +515,14 @@ export function CallDetailDialog({
                 regenerate them to get accurate summaries for each part.
               </p>
               <div className="space-y-2">
-                <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
-                  <span className="text-sm font-medium truncate">{splitResult.part1Title}</span>
-                  <button
-                    onClick={() => {
-                      supabase.functions.invoke('summarize-call', {
-                        body: { recording_id: call?.recording_id, force_refresh: true },
-                      });
-                      toast.success("Regenerating summary for Part 1…");
-                    }}
-                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground ml-2 shrink-0"
-                  >
-                    <RiRefreshLine className="h-3 w-3" />
-                    Regenerate
-                  </button>
-                </div>
-                <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
-                  <span className="text-sm font-medium truncate">{splitResult.part2Title}</span>
-                  <button
-                    onClick={() => {
-                      supabase.functions.invoke('summarize-call', {
-                        body: { recording_id: splitResult.part2RecordingId, force_refresh: true },
-                      });
-                      toast.success("Regenerating summary for Part 2…");
-                    }}
-                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground ml-2 shrink-0"
-                  >
-                    <RiRefreshLine className="h-3 w-3" />
-                    Regenerate
-                  </button>
-                </div>
+                <SplitSummaryRow
+                  title={splitResult.part1Title}
+                  recordingId={call?.recording_id}
+                />
+                <SplitSummaryRow
+                  title={splitResult.part2Title}
+                  recordingId={splitResult.part2RecordingId}
+                />
               </div>
               <div className="flex justify-end">
                 <button

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -119,9 +119,7 @@ export function CallDetailDialog({
   const [splitDialog, setSplitDialog] = useState<{
     open: boolean;
     segmentId: string | null;
-    splitTimestamp: string | null;
-    splitSpeaker: string | null;
-  }>({ open: false, segmentId: null, splitTimestamp: null, splitSpeaker: null });
+  }>({ open: false, segmentId: null });
   const [splitResult, setSplitResult] = useState<{
     part1Title: string;
     part2RecordingId: string;
@@ -208,7 +206,7 @@ export function CallDetailDialog({
   useEffect(() => {
     if (splitRecordingMutation.isSuccess && splitRecordingMutation.data) {
       const result = splitRecordingMutation.data;
-      setSplitDialog({ open: false, segmentId: null, splitTimestamp: null, splitSpeaker: null });
+      setSplitDialog({ open: false, segmentId: null });
       setSplitResult({
         part1Title: result.part1_title,
         part2RecordingId: result.part2_recording_id,
@@ -316,29 +314,17 @@ export function CallDetailDialog({
   }, [revertSegmentMutation]);
 
   const handleSplitHere = useCallback((segmentId: string) => {
-    // Look up the segment to capture its timestamp and speaker name as a stable locator.
-    // Sending timestamp+speaker (not an array index) to the backend avoids an index
-    // mismatch that would occur if the user has previously trimmed/deleted segments
-    // (the frontend filtered array and the backend's parsed full_transcript differ).
-    const segment = transcripts?.find((t) => t.id === segmentId);
-    if (!segment) return;
-    setSplitDialog({
-      open: true,
-      segmentId,
-      splitTimestamp: segment.timestamp,
-      // Use the original speaker_name (not display_speaker_name) so the backend
-      // can match against full_transcript which stores original names, not edited ones.
-      splitSpeaker: segment.speaker_name,
-    });
-  }, [transcripts]);
+    // Pass the segment's database id directly to the backend so it can do an exact
+    // lookup in fathom_transcripts (filtering out deleted segments). This avoids both
+    // the "trimmed segments reappear in split" bug (full_transcript isn't filtered) and
+    // the "wrong segment if speaker was edited" bug (name in full_transcript is original).
+    setSplitDialog({ open: true, segmentId });
+  }, []);
 
   const handleConfirmSplit = useCallback(() => {
-    if (!splitDialog.splitTimestamp || !splitDialog.splitSpeaker) return;
-    splitRecordingMutation.mutate({
-      splitTimestamp: splitDialog.splitTimestamp,
-      splitSpeaker: splitDialog.splitSpeaker,
-    });
-  }, [splitDialog.splitTimestamp, splitDialog.splitSpeaker, splitRecordingMutation]);
+    if (!splitDialog.segmentId) return;
+    splitRecordingMutation.mutate({ segmentId: splitDialog.segmentId });
+  }, [splitDialog.segmentId, splitRecordingMutation]);
 
   // Create grouped props using useMemo for optimal performance
   const transcriptViewState: TranscriptViewState = useMemo(() => ({

--- a/src/components/call-detail/CallTranscriptTab.tsx
+++ b/src/components/call-detail/CallTranscriptTab.tsx
@@ -39,6 +39,7 @@ export interface TranscriptHandlers {
   onTrimBefore: (segmentId: string) => void;
   onRevert: (segmentId: string) => void;
   onResyncCall: () => void;
+  onSplitHere: (segmentId: string) => void;
 }
 
 /**
@@ -103,6 +104,7 @@ export const CallTranscriptTab = memo(function CallTranscriptTab({
     onTrimBefore,
     onRevert,
     onResyncCall,
+    onSplitHere,
   } = handlers;
 
   const { user } = useAuth();
@@ -340,6 +342,7 @@ export const CallTranscriptTab = memo(function CallTranscriptTab({
                                           onTrimThis={() => onTrimThis(message.id)}
                                           onTrimBefore={() => onTrimBefore(message.id)}
                                           onRevert={() => onRevert(message.id)}
+                                          onSplitHere={() => onSplitHere(message.id)}
                                         />
                                       </div>
                                     )}

--- a/src/components/transcript-library/SplitConfirmDialog.tsx
+++ b/src/components/transcript-library/SplitConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { RiSplitCellsHorizontal } from "@remixicon/react";
+
+interface SplitConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+}
+
+export function SplitConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending = false,
+}: SplitConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <RiSplitCellsHorizontal className="h-5 w-5" />
+            Split recording here?
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                This will create two separate recordings from this call:
+              </p>
+              <ul className="list-disc list-inside space-y-1 pl-1">
+                <li>
+                  <strong className="text-foreground">Part 1</strong> — all segments before this point
+                </li>
+                <li>
+                  <strong className="text-foreground">Part 2</strong> — this segment and everything after
+                </li>
+              </ul>
+              <p>
+                Both recordings will keep the original title with <em>(Part 1)</em> and <em>(Part 2)</em>{" "}
+                appended. You can rename them after. Their summaries will be cleared — you can
+                regenerate each one after the split.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending}
+            className="bg-foreground text-background hover:bg-foreground/90"
+          >
+            {isPending ? "Splitting…" : "Split recording"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/transcript-library/TranscriptSegmentContextMenu.tsx
+++ b/src/components/transcript-library/TranscriptSegmentContextMenu.tsx
@@ -4,6 +4,7 @@ import {
   RiUserLine,
   RiScissorsLine,
   RiArrowGoBackLine,
+  RiSplitCellsHorizontal,
 } from "@remixicon/react";
 import {
   DropdownMenu,
@@ -22,6 +23,7 @@ interface TranscriptSegmentContextMenuProps {
   onTrimThis: () => void;
   onTrimBefore: () => void;
   onRevert: () => void;
+  onSplitHere?: () => void;
 }
 
 export function TranscriptSegmentContextMenu({
@@ -32,6 +34,7 @@ export function TranscriptSegmentContextMenu({
   onTrimThis,
   onTrimBefore,
   onRevert,
+  onSplitHere,
 }: TranscriptSegmentContextMenuProps) {
   return (
     <DropdownMenu>
@@ -54,6 +57,12 @@ export function TranscriptSegmentContextMenu({
             Change speaker
           </DropdownMenuItem>
           <DropdownMenuSeparator />
+          {onSplitHere && (
+            <DropdownMenuItem onClick={onSplitHere}>
+              <RiSplitCellsHorizontal className="mr-2 h-4 w-4" />
+              Split here
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem onClick={onTrimThis} className="text-destructive">
             <RiScissorsLine className="mr-2 h-4 w-4" />
             Trim this section

--- a/src/hooks/useCallDetailMutations.ts
+++ b/src/hooks/useCallDetailMutations.ts
@@ -39,7 +39,10 @@ interface RevertSegmentParams {
 }
 
 interface SplitRecordingParams {
-  segmentIndex: number;
+  /** HH:MM:SS timestamp of the segment to split at (used as locator in the backend). */
+  splitTimestamp: string;
+  /** Speaker name of the segment to split at (used for disambiguation). */
+  splitSpeaker: string;
 }
 
 export interface SplitRecordingResult {
@@ -299,13 +302,14 @@ export function useCallDetailMutations({
   });
 
   const splitRecording = useMutation({
-    mutationFn: async ({ segmentIndex }: SplitRecordingParams): Promise<SplitRecordingResult> => {
+    mutationFn: async ({ splitTimestamp, splitSpeaker }: SplitRecordingParams): Promise<SplitRecordingResult> => {
       if (!call) throw new Error("No call loaded");
 
       const { data, error } = await supabase.functions.invoke('split-recording', {
         body: {
           recording_id: call.recording_id,
-          segment_index: segmentIndex,
+          split_timestamp: splitTimestamp,
+          split_speaker: splitSpeaker,
         },
       });
 

--- a/src/hooks/useCallDetailMutations.ts
+++ b/src/hooks/useCallDetailMutations.ts
@@ -38,6 +38,19 @@ interface RevertSegmentParams {
   segmentId: string;
 }
 
+interface SplitRecordingParams {
+  segmentIndex: number;
+}
+
+export interface SplitRecordingResult {
+  part1_recording_id: string | number;
+  part2_recording_id: string;
+  part1_title: string;
+  part2_title: string;
+  part1_segment_count: number;
+  part2_segment_count: number;
+}
+
 export interface UseCallDetailMutationsReturn {
   updateCall: UseMutationResult<void, Error, UpdateCallParams, unknown>;
   editSegment: UseMutationResult<void, Error, EditSegmentParams, unknown>;
@@ -45,6 +58,7 @@ export interface UseCallDetailMutationsReturn {
   trimSegment: UseMutationResult<void, Error, TrimSegmentParams, unknown>;
   revertSegment: UseMutationResult<void, Error, RevertSegmentParams, unknown>;
   resyncCall: UseMutationResult<void, Error, void, unknown>;
+  splitRecording: UseMutationResult<SplitRecordingResult, Error, SplitRecordingParams, unknown>;
 }
 
 export function useCallDetailMutations({
@@ -284,6 +298,33 @@ export function useCallDetailMutations({
     }
   });
 
+  const splitRecording = useMutation({
+    mutationFn: async ({ segmentIndex }: SplitRecordingParams): Promise<SplitRecordingResult> => {
+      if (!call) throw new Error("No call loaded");
+
+      const { data, error } = await supabase.functions.invoke('split-recording', {
+        body: {
+          recording_id: call.recording_id,
+          segment_index: segmentIndex,
+        },
+      });
+
+      if (error) throw error;
+      if (!data?.success) throw new Error(data?.error || 'Split failed');
+
+      return data as SplitRecordingResult;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.calls.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.all });
+      onDataChange?.();
+    },
+    onError: (error: Error) => {
+      logger.error("Split recording error", error);
+      toast.error("Failed to split recording: " + (error.message || "Unknown error"));
+    },
+  });
+
   return {
     updateCall,
     editSegment,
@@ -291,5 +332,6 @@ export function useCallDetailMutations({
     trimSegment,
     revertSegment,
     resyncCall,
+    splitRecording,
   };
 }

--- a/src/hooks/useCallDetailMutations.ts
+++ b/src/hooks/useCallDetailMutations.ts
@@ -314,7 +314,19 @@ export function useCallDetailMutations({
         },
       });
 
-      if (error) throw error;
+      if (error) {
+        // The Supabase client sets data=null on non-2xx responses and returns a generic
+        // FunctionsHttpError. Parse the response body to surface the specific message
+        // returned by the edge function (e.g. "Cannot split at the first segment").
+        let message = error.message;
+        try {
+          const body = await (error as { context?: Response }).context?.json();
+          if (body?.error) message = body.error;
+        } catch {
+          // ignore — fall back to the generic client message
+        }
+        throw new Error(message);
+      }
       if (!data?.success) throw new Error(data?.error || 'Split failed');
 
       return data as SplitRecordingResult;

--- a/src/hooks/useCallDetailMutations.ts
+++ b/src/hooks/useCallDetailMutations.ts
@@ -39,10 +39,12 @@ interface RevertSegmentParams {
 }
 
 interface SplitRecordingParams {
-  /** HH:MM:SS timestamp of the segment to split at (used as locator in the backend). */
-  splitTimestamp: string;
-  /** Speaker name of the segment to split at (used for disambiguation). */
-  splitSpeaker: string;
+  /**
+   * ID of the segment to split at — the fathom_transcripts row UUID for legacy recordings,
+   * or a "parsed-N" synthetic id for UUID recordings (assigned by the frontend when
+   * rendering full_transcript segments).
+   */
+  segmentId: string;
 }
 
 export interface SplitRecordingResult {
@@ -302,14 +304,13 @@ export function useCallDetailMutations({
   });
 
   const splitRecording = useMutation({
-    mutationFn: async ({ splitTimestamp, splitSpeaker }: SplitRecordingParams): Promise<SplitRecordingResult> => {
+    mutationFn: async ({ segmentId }: SplitRecordingParams): Promise<SplitRecordingResult> => {
       if (!call) throw new Error("No call loaded");
 
       const { data, error } = await supabase.functions.invoke('split-recording', {
         body: {
           recording_id: call.recording_id,
-          split_timestamp: splitTimestamp,
-          split_speaker: splitSpeaker,
+          segment_id: segmentId,
         },
       });
 

--- a/supabase/functions/split-recording/index.ts
+++ b/supabase/functions/split-recording/index.ts
@@ -1,0 +1,424 @@
+/**
+ * SPLIT-RECORDING EDGE FUNCTION
+ *
+ * Splits a call recording into two separate recordings at a chosen transcript
+ * segment boundary. Part 1 keeps segments before the split; Part 2 gets the
+ * rest (including the segment the user right-clicked).
+ *
+ * Endpoint:
+ *   POST /functions/v1/split-recording
+ *   Body: { recording_id: number | string, segment_index: number }
+ *   Returns: { success, part1_recording_id, part2_recording_id, part1_title, part2_title }
+ */
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { z } from 'https://esm.sh/zod@3.23.8';
+import { getCorsHeaders } from '../_shared/cors.ts';
+
+const RequestSchema = z.object({
+  recording_id: z.union([
+    z.number().int().positive(),
+    z.string().uuid(),
+  ]),
+  segment_index: z.number().int().min(0),
+});
+
+type SplitRequest = z.infer<typeof RequestSchema>;
+
+// Parse full_transcript TEXT into segment array (mirrors frontend regex).
+// Format: [HH:MM:SS] Speaker Name: segment text
+function parseTranscriptSegments(full_transcript: string): Array<{
+  timestamp: string;
+  speaker: string;
+  text: string;
+}> {
+  const segmentRegex = /\[(\d{2}:\d{2}:\d{2})\]\s+([^:]+):\s+([^\n]+)/g;
+  const segments: Array<{ timestamp: string; speaker: string; text: string }> = [];
+  let match;
+
+  while ((match = segmentRegex.exec(full_transcript)) !== null) {
+    segments.push({
+      timestamp: match[1],
+      speaker: match[2].trim(),
+      text: match[3].trim(),
+    });
+  }
+
+  return segments;
+}
+
+// Rebuild a formatted transcript TEXT from a segment array.
+function buildTranscriptText(
+  segments: Array<{ timestamp: string; speaker: string; text: string }>
+): string {
+  return segments
+    .map((s) => `[${s.timestamp}] ${s.speaker}: ${s.text}`)
+    .join('\n');
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Auth
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'No authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Parse body
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: 'Invalid JSON body' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const validation = RequestSchema.safeParse(body);
+    if (!validation.success) {
+      return new Response(
+        JSON.stringify({ error: validation.error.errors[0]?.message || 'Invalid input' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { recording_id, segment_index } = validation.data as SplitRequest;
+    const isLegacyId = typeof recording_id === 'number';
+
+    // -------------------------------------------------------------------------
+    // 1. Fetch the source recording
+    // -------------------------------------------------------------------------
+    let sourceTitle = '';
+    let fullTranscript = '';
+    let organizationId: string | null = null;
+    let audioUrl: string | null = null;
+    let videoUrl: string | null = null;
+    let duration: number | null = null;
+    let recordingStartTime: string | null = null;
+    let recordingEndTime: string | null = null;
+    let sourceApp: string | null = null;
+    let sourceMetadata: Record<string, unknown> = {};
+    let calendarInvitees: unknown = null;
+    let recordedByName: string | null = null;
+    let recordedByEmail: string | null = null;
+    let recordingsUuid: string | null = null;
+
+    if (isLegacyId) {
+      // Fetch from fathom_calls (legacy BIGINT id)
+      const { data: call, error: callError } = await supabase
+        .from('fathom_calls')
+        .select('*')
+        .eq('recording_id', recording_id)
+        .eq('user_id', user.id)
+        .single();
+
+      if (callError || !call) {
+        return new Response(
+          JSON.stringify({ error: 'Recording not found or unauthorized' }),
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      sourceTitle = call.title || 'Untitled';
+      fullTranscript = call.full_transcript || '';
+      calendarInvitees = call.calendar_invitees || null;
+      recordedByName = call.recorded_by_name || null;
+      recordedByEmail = call.recorded_by_email || null;
+      recordingStartTime = call.recording_start_time || null;
+      recordingEndTime = call.recording_end_time || null;
+      duration = null; // Will recalculate from segments
+
+      // Also try to fetch from recordings table for richer data + org/workspace linkage
+      const { data: recRow } = await supabase
+        .from('recordings')
+        .select('id, organization_id, audio_url, video_url, source_app, source_metadata, duration')
+        .eq('legacy_recording_id', recording_id)
+        .maybeSingle();
+
+      if (recRow) {
+        recordingsUuid = recRow.id;
+        organizationId = recRow.organization_id;
+        audioUrl = recRow.audio_url || null;
+        videoUrl = recRow.video_url || null;
+        sourceApp = recRow.source_app || 'fathom';
+        sourceMetadata = (recRow.source_metadata as Record<string, unknown>) || {};
+        duration = recRow.duration || null;
+      }
+    } else {
+      // UUID-based recording
+      const { data: recRow, error: recError } = await supabase
+        .from('recordings')
+        .select('*')
+        .eq('id', recording_id)
+        .single();
+
+      if (recError || !recRow) {
+        return new Response(
+          JSON.stringify({ error: 'Recording not found or unauthorized' }),
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Ownership check via org membership (RLS handles this via service role only in a limited way)
+      if (recRow.owner_user_id !== user.id) {
+        return new Response(
+          JSON.stringify({ error: 'Recording not found or unauthorized' }),
+          { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      recordingsUuid = recRow.id;
+      sourceTitle = recRow.title || 'Untitled';
+      fullTranscript = recRow.full_transcript || '';
+      organizationId = recRow.organization_id;
+      audioUrl = recRow.audio_url || null;
+      videoUrl = recRow.video_url || null;
+      sourceApp = recRow.source_app || null;
+      sourceMetadata = (recRow.source_metadata as Record<string, unknown>) || {};
+      duration = recRow.duration || null;
+      recordingStartTime = recRow.recording_start_time || null;
+      recordingEndTime = recRow.recording_end_time || null;
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Parse and split transcript at segment_index
+    // -------------------------------------------------------------------------
+    if (!fullTranscript.trim()) {
+      return new Response(
+        JSON.stringify({ error: 'No transcript available to split' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const allSegments = parseTranscriptSegments(fullTranscript);
+
+    if (allSegments.length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'Could not parse any transcript segments' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (segment_index <= 0 || segment_index >= allSegments.length) {
+      return new Response(
+        JSON.stringify({
+          error: `segment_index must be between 1 and ${allSegments.length - 1} (got ${segment_index})`,
+        }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const part1Segments = allSegments.slice(0, segment_index);
+    const part2Segments = allSegments.slice(segment_index);
+
+    const part1Transcript = buildTranscriptText(part1Segments);
+    const part2Transcript = buildTranscriptText(part2Segments);
+
+    // Derive per-part speakers from segments (unique speaker names in each half)
+    const getSpeakers = (segs: typeof allSegments) =>
+      Array.from(new Set(segs.map((s) => s.speaker)));
+
+    const _part1Speakers = getSpeakers(part1Segments);
+    const _part2Speakers = getSpeakers(part2Segments);
+
+    // Naming
+    const part1Title = `${sourceTitle} (Part 1)`;
+    const part2Title = `${sourceTitle} (Part 2)`;
+
+    // -------------------------------------------------------------------------
+    // 3. Update Part 1 — rename in recordings table (and fathom_calls if legacy)
+    // -------------------------------------------------------------------------
+    if (recordingsUuid) {
+      const { error: updateErr } = await supabase
+        .from('recordings')
+        .update({
+          title: part1Title,
+          full_transcript: part1Transcript,
+          summary: null, // Reset — user should regenerate
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', recordingsUuid);
+
+      if (updateErr) {
+        throw new Error(`Failed to update Part 1 recording: ${updateErr.message}`);
+      }
+    }
+
+    if (isLegacyId) {
+      await supabase
+        .from('fathom_calls')
+        .update({
+          title: part1Title,
+          full_transcript: part1Transcript,
+          summary: null,
+        })
+        .eq('recording_id', recording_id)
+        .eq('user_id', user.id);
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. Create Part 2 recording in recordings table
+    // -------------------------------------------------------------------------
+
+    // Need organization_id for Part 2 — required by recordings table
+    if (!organizationId) {
+      // Try to find any organization the user belongs to as owner
+      const { data: orgMember } = await supabase
+        .from('organization_members')
+        .select('organization_id')
+        .eq('user_id', user.id)
+        .limit(1)
+        .maybeSingle();
+
+      organizationId = orgMember?.organization_id || null;
+    }
+
+    if (!organizationId) {
+      return new Response(
+        JSON.stringify({ error: 'Cannot create Part 2: no organization found for user' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { data: part2Row, error: part2Err } = await supabase
+      .from('recordings')
+      .insert({
+        organization_id: organizationId,
+        owner_user_id: user.id,
+        title: part2Title,
+        full_transcript: part2Transcript,
+        audio_url: audioUrl,
+        video_url: videoUrl,
+        source_app: sourceApp,
+        source_metadata: {
+          ...sourceMetadata,
+          split_from: isLegacyId ? recording_id : recordingsUuid,
+          split_segment_index: segment_index,
+          split_at: new Date().toISOString(),
+        },
+        duration: duration,
+        recording_start_time: recordingStartTime,
+        recording_end_time: recordingEndTime,
+        created_at: new Date().toISOString(),
+        synced_at: new Date().toISOString(),
+      })
+      .select('id')
+      .single();
+
+    if (part2Err || !part2Row) {
+      throw new Error(`Failed to create Part 2 recording: ${part2Err?.message || 'unknown'}`);
+    }
+
+    const part2RecordingId = part2Row.id as string;
+
+    // -------------------------------------------------------------------------
+    // 5. Copy workspace_entries for Part 2 (same workspaces as Part 1)
+    // -------------------------------------------------------------------------
+    if (recordingsUuid) {
+      const { data: existingEntries } = await supabase
+        .from('workspace_entries')
+        .select('workspace_id')
+        .eq('recording_id', recordingsUuid);
+
+      if (existingEntries && existingEntries.length > 0) {
+        const newEntries = existingEntries.map((e: { workspace_id: string }) => ({
+          workspace_id: e.workspace_id,
+          recording_id: part2RecordingId,
+          created_at: new Date().toISOString(),
+        }));
+
+        const { error: entryErr } = await supabase
+          .from('workspace_entries')
+          .insert(newEntries);
+
+        if (entryErr) {
+          console.error('Failed to copy workspace_entries for Part 2:', entryErr);
+          // Non-fatal: Part 2 was created, just missing workspace linkage
+        }
+      } else {
+        // No existing workspace entries found — add to home workspace
+        const { data: homeWs } = await supabase
+          .from('workspaces')
+          .select('id')
+          .eq('organization_id', organizationId)
+          .eq('is_home', true)
+          .maybeSingle();
+
+        if (homeWs) {
+          await supabase
+            .from('workspace_entries')
+            .insert({
+              workspace_id: homeWs.id,
+              recording_id: part2RecordingId,
+              created_at: new Date().toISOString(),
+            });
+        }
+      }
+    } else {
+      // No recordings UUID — add Part 2 to home workspace
+      const { data: homeWs } = await supabase
+        .from('workspaces')
+        .select('id')
+        .eq('organization_id', organizationId)
+        .eq('is_home', true)
+        .maybeSingle();
+
+      if (homeWs) {
+        await supabase
+          .from('workspace_entries')
+          .insert({
+            workspace_id: homeWs.id,
+            recording_id: part2RecordingId,
+            created_at: new Date().toISOString(),
+          });
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. Return result
+    // -------------------------------------------------------------------------
+    return new Response(
+      JSON.stringify({
+        success: true,
+        part1_recording_id: recordingsUuid || recording_id,
+        part2_recording_id: part2RecordingId,
+        part1_title: part1Title,
+        part2_title: part2Title,
+        part1_segment_count: part1Segments.length,
+        part2_segment_count: part2Segments.length,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('split-recording error:', error);
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/split-recording/index.ts
+++ b/supabase/functions/split-recording/index.ts
@@ -237,6 +237,11 @@ Deno.serve(async (req) => {
       (s) => s.timestamp === split_timestamp && s.speaker === split_speaker
     );
 
+    // Timestamp-only fallback index (computed once, reused below to avoid double scan)
+    const timestampOnlyIndex = splitIndex < 0
+      ? allSegments.findIndex((s) => s.timestamp === split_timestamp)
+      : -1; // not needed when primary match succeeded
+
     if (splitIndex <= 0) {
       if (splitIndex === 0) {
         return new Response(
@@ -244,8 +249,9 @@ Deno.serve(async (req) => {
           { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
-      // No match found — try matching by timestamp only (speaker name may have been edited)
-      const timestampOnlyIndex = allSegments.findIndex((s) => s.timestamp === split_timestamp);
+      // Primary match failed — fall back to timestamp-only.
+      // The frontend sends the original speaker_name (not the edited display name),
+      // so this fallback is a safety net for edge cases rather than the common path.
       if (timestampOnlyIndex <= 0) {
         return new Response(
           JSON.stringify({
@@ -256,9 +262,7 @@ Deno.serve(async (req) => {
       }
     }
 
-    const resolvedSplitIndex = splitIndex >= 0
-      ? splitIndex
-      : allSegments.findIndex((s) => s.timestamp === split_timestamp);
+    const resolvedSplitIndex = splitIndex >= 0 ? splitIndex : timestampOnlyIndex;
 
     const part1Segments = allSegments.slice(0, resolvedSplitIndex);
     const part2Segments = allSegments.slice(resolvedSplitIndex);

--- a/supabase/functions/split-recording/index.ts
+++ b/supabase/functions/split-recording/index.ts
@@ -5,9 +5,16 @@
  * segment boundary. Part 1 keeps segments before the split; Part 2 gets the
  * rest (including the segment the user right-clicked).
  *
+ * The critical DB writes (Part 1 update + Part 2 insert) are performed inside
+ * the `split_recording_atomic` Postgres RPC, ensuring they are atomic.
+ *
  * Endpoint:
  *   POST /functions/v1/split-recording
- *   Body: { recording_id: number | string, segment_index: number }
+ *   Body: {
+ *     recording_id: number | string,
+ *     split_timestamp: string,   // "HH:MM:SS" — timestamp of the split segment
+ *     split_speaker: string,     // speaker name of the split segment
+ *   }
  *   Returns: { success, part1_recording_id, part2_recording_id, part1_title, part2_title }
  */
 
@@ -20,7 +27,10 @@ const RequestSchema = z.object({
     z.number().int().positive(),
     z.string().uuid(),
   ]),
-  segment_index: z.number().int().min(0),
+  /** Timestamp of the segment to split at, in "HH:MM:SS" format. */
+  split_timestamp: z.string().regex(/^\d{2}:\d{2}:\d{2}$/, 'split_timestamp must be HH:MM:SS'),
+  /** Speaker name of the segment to split at (for disambiguation). */
+  split_speaker: z.string().min(1),
 });
 
 type SplitRequest = z.infer<typeof RequestSchema>;
@@ -54,6 +64,12 @@ function buildTranscriptText(
   return segments
     .map((s) => `[${s.timestamp}] ${s.speaker}: ${s.text}`)
     .join('\n');
+}
+
+// Parse "HH:MM:SS" timestamp into total seconds for duration math.
+function timestampToSeconds(ts: string): number {
+  const parts = ts.split(':').map(Number);
+  return (parts[0] ?? 0) * 3600 + (parts[1] ?? 0) * 60 + (parts[2] ?? 0);
 }
 
 Deno.serve(async (req) => {
@@ -107,7 +123,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    const { recording_id, segment_index } = validation.data as SplitRequest;
+    const { recording_id, split_timestamp, split_speaker } = validation.data as SplitRequest;
     const isLegacyId = typeof recording_id === 'number';
 
     // -------------------------------------------------------------------------
@@ -118,14 +134,10 @@ Deno.serve(async (req) => {
     let organizationId: string | null = null;
     let audioUrl: string | null = null;
     let videoUrl: string | null = null;
-    let duration: number | null = null;
     let recordingStartTime: string | null = null;
     let recordingEndTime: string | null = null;
     let sourceApp: string | null = null;
     let sourceMetadata: Record<string, unknown> = {};
-    let calendarInvitees: unknown = null;
-    let recordedByName: string | null = null;
-    let recordedByEmail: string | null = null;
     let recordingsUuid: string | null = null;
 
     if (isLegacyId) {
@@ -146,17 +158,13 @@ Deno.serve(async (req) => {
 
       sourceTitle = call.title || 'Untitled';
       fullTranscript = call.full_transcript || '';
-      calendarInvitees = call.calendar_invitees || null;
-      recordedByName = call.recorded_by_name || null;
-      recordedByEmail = call.recorded_by_email || null;
       recordingStartTime = call.recording_start_time || null;
       recordingEndTime = call.recording_end_time || null;
-      duration = null; // Will recalculate from segments
 
-      // Also try to fetch from recordings table for richer data + org/workspace linkage
+      // Enrich with recordings table row if it exists
       const { data: recRow } = await supabase
         .from('recordings')
-        .select('id, organization_id, audio_url, video_url, source_app, source_metadata, duration')
+        .select('id, organization_id, audio_url, video_url, source_app, source_metadata')
         .eq('legacy_recording_id', recording_id)
         .maybeSingle();
 
@@ -167,7 +175,6 @@ Deno.serve(async (req) => {
         videoUrl = recRow.video_url || null;
         sourceApp = recRow.source_app || 'fathom';
         sourceMetadata = (recRow.source_metadata as Record<string, unknown>) || {};
-        duration = recRow.duration || null;
       }
     } else {
       // UUID-based recording
@@ -184,7 +191,6 @@ Deno.serve(async (req) => {
         );
       }
 
-      // Ownership check via org membership (RLS handles this via service role only in a limited way)
       if (recRow.owner_user_id !== user.id) {
         return new Response(
           JSON.stringify({ error: 'Recording not found or unauthorized' }),
@@ -200,13 +206,12 @@ Deno.serve(async (req) => {
       videoUrl = recRow.video_url || null;
       sourceApp = recRow.source_app || null;
       sourceMetadata = (recRow.source_metadata as Record<string, unknown>) || {};
-      duration = recRow.duration || null;
       recordingStartTime = recRow.recording_start_time || null;
       recordingEndTime = recRow.recording_end_time || null;
     }
 
     // -------------------------------------------------------------------------
-    // 2. Parse and split transcript at segment_index
+    // 2. Parse transcript and find split point by timestamp + speaker
     // -------------------------------------------------------------------------
     if (!fullTranscript.trim()) {
       return new Response(
@@ -224,70 +229,81 @@ Deno.serve(async (req) => {
       );
     }
 
-    if (segment_index <= 0 || segment_index >= allSegments.length) {
-      return new Response(
-        JSON.stringify({
-          error: `segment_index must be between 1 and ${allSegments.length - 1} (got ${segment_index})`,
-        }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+    // Find split point using timestamp + speaker as a unique locator.
+    // This avoids the index-mismatch bug that occurs when the frontend uses
+    // a filtered (deleted-excluded) transcript array but the backend parses
+    // the raw full_transcript which still contains all original segments.
+    const splitIndex = allSegments.findIndex(
+      (s) => s.timestamp === split_timestamp && s.speaker === split_speaker
+    );
+
+    if (splitIndex <= 0) {
+      if (splitIndex === 0) {
+        return new Response(
+          JSON.stringify({ error: 'Cannot split at the first segment — choose a later segment' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      // No match found — try matching by timestamp only (speaker name may have been edited)
+      const timestampOnlyIndex = allSegments.findIndex((s) => s.timestamp === split_timestamp);
+      if (timestampOnlyIndex <= 0) {
+        return new Response(
+          JSON.stringify({
+            error: `Split point not found in transcript (timestamp: ${split_timestamp}, speaker: ${split_speaker})`,
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
     }
 
-    const part1Segments = allSegments.slice(0, segment_index);
-    const part2Segments = allSegments.slice(segment_index);
+    const resolvedSplitIndex = splitIndex >= 0
+      ? splitIndex
+      : allSegments.findIndex((s) => s.timestamp === split_timestamp);
+
+    const part1Segments = allSegments.slice(0, resolvedSplitIndex);
+    const part2Segments = allSegments.slice(resolvedSplitIndex);
 
     const part1Transcript = buildTranscriptText(part1Segments);
     const part2Transcript = buildTranscriptText(part2Segments);
 
-    // Derive per-part speakers from segments (unique speaker names in each half)
-    const getSpeakers = (segs: typeof allSegments) =>
-      Array.from(new Set(segs.map((s) => s.speaker)));
+    // -------------------------------------------------------------------------
+    // 3. Compute per-part timing metadata from segment timestamps
+    // -------------------------------------------------------------------------
+    // Part 1 keeps the original start time; end time approximated from last segment.
+    // Part 2 start time approximated from its first segment; duration from range.
+    const part1LastTimestamp = part1Segments.at(-1)?.timestamp;
+    const part2FirstTimestamp = part2Segments[0]?.timestamp;
+    const part2LastTimestamp = part2Segments.at(-1)?.timestamp;
 
-    const _part1Speakers = getSpeakers(part1Segments);
-    const _part2Speakers = getSpeakers(part2Segments);
+    let part2StartTime: string | null = null;
+    let part2Duration: number | null = null;
+
+    if (recordingStartTime && part2FirstTimestamp) {
+      // Offset part2 start from the original call's start time
+      const offsetSeconds = timestampToSeconds(part2FirstTimestamp);
+      const base = new Date(recordingStartTime);
+      base.setSeconds(base.getSeconds() + offsetSeconds);
+      part2StartTime = base.toISOString();
+    }
+
+    if (part2FirstTimestamp && part2LastTimestamp) {
+      part2Duration = timestampToSeconds(part2LastTimestamp) - timestampToSeconds(part2FirstTimestamp);
+    }
+
+    // Part 1 duration: from recording start to last segment timestamp
+    let part1Duration: number | null = null;
+    if (part1LastTimestamp) {
+      part1Duration = timestampToSeconds(part1LastTimestamp);
+    }
 
     // Naming
     const part1Title = `${sourceTitle} (Part 1)`;
     const part2Title = `${sourceTitle} (Part 2)`;
 
     // -------------------------------------------------------------------------
-    // 3. Update Part 1 — rename in recordings table (and fathom_calls if legacy)
+    // 4. Resolve organization_id (needed for the RPC + workspace lookup)
     // -------------------------------------------------------------------------
-    if (recordingsUuid) {
-      const { error: updateErr } = await supabase
-        .from('recordings')
-        .update({
-          title: part1Title,
-          full_transcript: part1Transcript,
-          summary: null, // Reset — user should regenerate
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', recordingsUuid);
-
-      if (updateErr) {
-        throw new Error(`Failed to update Part 1 recording: ${updateErr.message}`);
-      }
-    }
-
-    if (isLegacyId) {
-      await supabase
-        .from('fathom_calls')
-        .update({
-          title: part1Title,
-          full_transcript: part1Transcript,
-          summary: null,
-        })
-        .eq('recording_id', recording_id)
-        .eq('user_id', user.id);
-    }
-
-    // -------------------------------------------------------------------------
-    // 4. Create Part 2 recording in recordings table
-    // -------------------------------------------------------------------------
-
-    // Need organization_id for Part 2 — required by recordings table
     if (!organizationId) {
-      // Try to find any organization the user belongs to as owner
       const { data: orgMember } = await supabase
         .from('organization_members')
         .select('organization_id')
@@ -305,39 +321,58 @@ Deno.serve(async (req) => {
       );
     }
 
-    const { data: part2Row, error: part2Err } = await supabase
-      .from('recordings')
-      .insert({
-        organization_id: organizationId,
-        owner_user_id: user.id,
-        title: part2Title,
-        full_transcript: part2Transcript,
-        audio_url: audioUrl,
-        video_url: videoUrl,
-        source_app: sourceApp,
-        source_metadata: {
+    // -------------------------------------------------------------------------
+    // 5. Atomic DB writes via RPC (Part 1 update + Part 2 insert in one tx)
+    // -------------------------------------------------------------------------
+    const { data: part2RecordingId, error: rpcError } = await supabase.rpc(
+      'split_recording_atomic',
+      {
+        p_part1_recordings_id:  recordingsUuid ?? null,
+        p_part1_fathom_id:      isLegacyId ? recording_id : null,
+        p_part1_title:          part1Title,
+        p_part1_transcript:     part1Transcript,
+        p_part2_title:          part2Title,
+        p_part2_transcript:     part2Transcript,
+        p_organization_id:      organizationId,
+        p_owner_user_id:        user.id,
+        p_source_app:           sourceApp,
+        p_source_metadata:      {
           ...sourceMetadata,
           split_from: isLegacyId ? recording_id : recordingsUuid,
-          split_segment_index: segment_index,
           split_at: new Date().toISOString(),
+          split_timestamp,
         },
-        duration: duration,
-        recording_start_time: recordingStartTime,
-        recording_end_time: recordingEndTime,
-        created_at: new Date().toISOString(),
-        synced_at: new Date().toISOString(),
-      })
-      .select('id')
-      .single();
+        p_recording_start_time: part2StartTime,
+        p_recording_end_time:   null, // Not reliably known from segments
+        p_audio_url:            audioUrl,
+        p_video_url:            videoUrl,
+      }
+    );
 
-    if (part2Err || !part2Row) {
-      throw new Error(`Failed to create Part 2 recording: ${part2Err?.message || 'unknown'}`);
+    if (rpcError) {
+      throw new Error(`Atomic split failed: ${rpcError.message}`);
     }
 
-    const part2RecordingId = part2Row.id as string;
+    const part2Id = part2RecordingId as string;
+
+    // Also update Part 1 duration in recordings table if we computed one
+    if (recordingsUuid && part1Duration !== null) {
+      await supabase
+        .from('recordings')
+        .update({ duration: part1Duration })
+        .eq('id', recordingsUuid);
+    }
+
+    // Update Part 2 duration
+    if (part2Duration !== null) {
+      await supabase
+        .from('recordings')
+        .update({ duration: part2Duration })
+        .eq('id', part2Id);
+    }
 
     // -------------------------------------------------------------------------
-    // 5. Copy workspace_entries for Part 2 (same workspaces as Part 1)
+    // 6. Copy workspace_entries for Part 2 (non-critical — runs after atomic writes)
     // -------------------------------------------------------------------------
     if (recordingsUuid) {
       const { data: existingEntries } = await supabase
@@ -348,7 +383,7 @@ Deno.serve(async (req) => {
       if (existingEntries && existingEntries.length > 0) {
         const newEntries = existingEntries.map((e: { workspace_id: string }) => ({
           workspace_id: e.workspace_id,
-          recording_id: part2RecordingId,
+          recording_id: part2Id,
           created_at: new Date().toISOString(),
         }));
 
@@ -357,11 +392,11 @@ Deno.serve(async (req) => {
           .insert(newEntries);
 
         if (entryErr) {
-          console.error('Failed to copy workspace_entries for Part 2:', entryErr);
-          // Non-fatal: Part 2 was created, just missing workspace linkage
+          // Non-fatal — Part 2 recording exists, workspace linkage can be repaired
+          console.error('Failed to copy workspace_entries for Part 2:', entryErr.message);
         }
       } else {
-        // No existing workspace entries found — add to home workspace
+        // No workspace entries found — add Part 2 to the home workspace
         const { data: homeWs } = await supabase
           .from('workspaces')
           .select('id')
@@ -372,15 +407,11 @@ Deno.serve(async (req) => {
         if (homeWs) {
           await supabase
             .from('workspace_entries')
-            .insert({
-              workspace_id: homeWs.id,
-              recording_id: part2RecordingId,
-              created_at: new Date().toISOString(),
-            });
+            .insert({ workspace_id: homeWs.id, recording_id: part2Id });
         }
       }
     } else {
-      // No recordings UUID — add Part 2 to home workspace
+      // Legacy recording without a recordings row — add Part 2 to home workspace
       const { data: homeWs } = await supabase
         .from('workspaces')
         .select('id')
@@ -391,22 +422,18 @@ Deno.serve(async (req) => {
       if (homeWs) {
         await supabase
           .from('workspace_entries')
-          .insert({
-            workspace_id: homeWs.id,
-            recording_id: part2RecordingId,
-            created_at: new Date().toISOString(),
-          });
+          .insert({ workspace_id: homeWs.id, recording_id: part2Id });
       }
     }
 
     // -------------------------------------------------------------------------
-    // 6. Return result
+    // 7. Return result
     // -------------------------------------------------------------------------
     return new Response(
       JSON.stringify({
         success: true,
         part1_recording_id: recordingsUuid || recording_id,
-        part2_recording_id: part2RecordingId,
+        part2_recording_id: part2Id,
         part1_title: part1Title,
         part2_title: part2Title,
         part1_segment_count: part1Segments.length,

--- a/supabase/functions/split-recording/index.ts
+++ b/supabase/functions/split-recording/index.ts
@@ -12,8 +12,7 @@
  *   POST /functions/v1/split-recording
  *   Body: {
  *     recording_id: number | string,
- *     split_timestamp: string,   // "HH:MM:SS" — timestamp of the split segment
- *     split_speaker: string,     // speaker name of the split segment
+ *     segment_id: string,   // fathom_transcripts UUID for legacy; "parsed-N" for UUID recordings
  *   }
  *   Returns: { success, part1_recording_id, part2_recording_id, part1_title, part2_title }
  */
@@ -27,10 +26,13 @@ const RequestSchema = z.object({
     z.number().int().positive(),
     z.string().uuid(),
   ]),
-  /** Timestamp of the segment to split at, in "HH:MM:SS" format. */
-  split_timestamp: z.string().regex(/^\d{2}:\d{2}:\d{2}$/, 'split_timestamp must be HH:MM:SS'),
-  /** Speaker name of the segment to split at (for disambiguation). */
-  split_speaker: z.string().min(1),
+  /**
+   * ID of the segment to split at.
+   * - For legacy recordings (fathom_transcripts rows): the row UUID from fathom_transcripts.
+   * - For UUID recordings (parsed from full_transcript): the synthetic "parsed-N" id the
+   *   frontend assigns when rendering full_transcript segments.
+   */
+  segment_id: z.string().min(1),
 });
 
 type SplitRequest = z.infer<typeof RequestSchema>;
@@ -123,7 +125,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    const { recording_id, split_timestamp, split_speaker } = validation.data as SplitRequest;
+    const { recording_id, segment_id } = validation.data as SplitRequest;
     const isLegacyId = typeof recording_id === 'number';
 
     // -------------------------------------------------------------------------
@@ -211,61 +213,125 @@ Deno.serve(async (req) => {
     }
 
     // -------------------------------------------------------------------------
-    // 2. Parse transcript and find split point by timestamp + speaker
+    // 2. Find split point and build per-part segment arrays
+    //
+    // For legacy recordings we query fathom_transcripts (which tracks is_deleted)
+    // rather than parsing full_transcript, so that previously trimmed segments are
+    // excluded from both parts.  For UUID recordings there are no fathom_transcripts
+    // rows, so we parse full_transcript (trimming is not supported for UUID recordings,
+    // so the blob is always up-to-date).
+    //
+    // We locate the segment by its id (a fathom_transcripts UUID, or "parsed-N" for
+    // UUID recordings) — not by timestamp+speaker text matching, which breaks when a
+    // speaker name has been edited because full_transcript stores the original names.
     // -------------------------------------------------------------------------
-    if (!fullTranscript.trim()) {
-      return new Response(
-        JSON.stringify({ error: 'No transcript available to split' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
+    let part1Segments: Array<{ timestamp: string; speaker: string; text: string }>;
+    let part2Segments: Array<{ timestamp: string; speaker: string; text: string }>;
 
-    const allSegments = parseTranscriptSegments(fullTranscript);
+    if (isLegacyId) {
+      // Query active (non-deleted) transcript rows for this legacy recording.
+      const { data: ftRows, error: ftErr } = await supabase
+        .from('fathom_transcripts')
+        .select('id, timestamp, speaker_name, edited_speaker_name, text, edited_text')
+        .eq('recording_id', recording_id)
+        .eq('user_id', user.id)
+        .or('is_deleted.is.null,is_deleted.eq.false')
+        .order('timestamp');
 
-    if (allSegments.length === 0) {
-      return new Response(
-        JSON.stringify({ error: 'Could not parse any transcript segments' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
+      if (!ftErr && ftRows && ftRows.length > 0) {
+        // Build segment array using edited values where available.
+        const rows = ftRows.map((r) => ({
+          id: r.id as string,
+          timestamp: (r.timestamp as string).trim(),
+          speaker: ((r.edited_speaker_name ?? r.speaker_name) as string).trim(),
+          text: ((r.edited_text ?? r.text) as string).trim(),
+        }));
 
-    // Find split point using timestamp + speaker as a unique locator.
-    // This avoids the index-mismatch bug that occurs when the frontend uses
-    // a filtered (deleted-excluded) transcript array but the backend parses
-    // the raw full_transcript which still contains all original segments.
-    const splitIndex = allSegments.findIndex(
-      (s) => s.timestamp === split_timestamp && s.speaker === split_speaker
-    );
+        const splitIdx = rows.findIndex((r) => r.id === segment_id);
 
-    // Timestamp-only fallback index (computed once, reused below to avoid double scan)
-    const timestampOnlyIndex = splitIndex < 0
-      ? allSegments.findIndex((s) => s.timestamp === split_timestamp)
-      : -1; // not needed when primary match succeeded
+        if (splitIdx === 0) {
+          return new Response(
+            JSON.stringify({ error: 'Cannot split at the first segment — choose a later segment' }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+        if (splitIdx < 0) {
+          return new Response(
+            JSON.stringify({ error: `Split point not found in transcript (segment: ${segment_id})` }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
 
-    if (splitIndex <= 0) {
-      if (splitIndex === 0) {
+        part1Segments = rows.slice(0, splitIdx).map(({ timestamp, speaker, text }) => ({ timestamp, speaker, text }));
+        part2Segments = rows.slice(splitIdx).map(({ timestamp, speaker, text }) => ({ timestamp, speaker, text }));
+      } else {
+        // Fallback: no fathom_transcripts rows found — parse full_transcript.
+        if (!fullTranscript.trim()) {
+          return new Response(
+            JSON.stringify({ error: 'No transcript available to split' }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+        const allSegments = parseTranscriptSegments(fullTranscript);
+        if (allSegments.length === 0) {
+          return new Response(
+            JSON.stringify({ error: 'Could not parse any transcript segments' }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+        // segment_id for a parsed fallback is "parsed-N"
+        const splitIdx = segment_id.startsWith('parsed-')
+          ? parseInt(segment_id.slice(7), 10)
+          : -1;
+        if (splitIdx === 0) {
+          return new Response(
+            JSON.stringify({ error: 'Cannot split at the first segment — choose a later segment' }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+        if (isNaN(splitIdx) || splitIdx < 0 || splitIdx >= allSegments.length) {
+          return new Response(
+            JSON.stringify({ error: `Split point not found in transcript (segment: ${segment_id})` }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+        part1Segments = allSegments.slice(0, splitIdx);
+        part2Segments = allSegments.slice(splitIdx);
+      }
+    } else {
+      // UUID recording: parse full_transcript (trimming not supported, so blob is current).
+      if (!fullTranscript.trim()) {
+        return new Response(
+          JSON.stringify({ error: 'No transcript available to split' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      const allSegments = parseTranscriptSegments(fullTranscript);
+      if (allSegments.length === 0) {
+        return new Response(
+          JSON.stringify({ error: 'Could not parse any transcript segments' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      // segment_id for UUID recordings is "parsed-N" (synthetic id assigned by frontend)
+      const splitIdx = segment_id.startsWith('parsed-')
+        ? parseInt(segment_id.slice(7), 10)
+        : -1;
+      if (splitIdx === 0) {
         return new Response(
           JSON.stringify({ error: 'Cannot split at the first segment — choose a later segment' }),
           { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
-      // Primary match failed — fall back to timestamp-only.
-      // The frontend sends the original speaker_name (not the edited display name),
-      // so this fallback is a safety net for edge cases rather than the common path.
-      if (timestampOnlyIndex <= 0) {
+      if (isNaN(splitIdx) || splitIdx < 0 || splitIdx >= allSegments.length) {
         return new Response(
-          JSON.stringify({
-            error: `Split point not found in transcript (timestamp: ${split_timestamp}, speaker: ${split_speaker})`,
-          }),
+          JSON.stringify({ error: `Split point not found in transcript (segment: ${segment_id})` }),
           { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
+      part1Segments = allSegments.slice(0, splitIdx);
+      part2Segments = allSegments.slice(splitIdx);
     }
-
-    const resolvedSplitIndex = splitIndex >= 0 ? splitIndex : timestampOnlyIndex;
-
-    const part1Segments = allSegments.slice(0, resolvedSplitIndex);
-    const part2Segments = allSegments.slice(resolvedSplitIndex);
 
     const part1Transcript = buildTranscriptText(part1Segments);
     const part2Transcript = buildTranscriptText(part2Segments);
@@ -344,7 +410,7 @@ Deno.serve(async (req) => {
           ...sourceMetadata,
           split_from: isLegacyId ? recording_id : recordingsUuid,
           split_at: new Date().toISOString(),
-          split_timestamp,
+          split_segment_id: segment_id,
         },
         p_recording_start_time: part2StartTime,
         p_recording_end_time:   null, // Not reliably known from segments

--- a/supabase/functions/split-recording/index.ts
+++ b/supabase/functions/split-recording/index.ts
@@ -68,6 +68,32 @@ function buildTranscriptText(
     .join('\n');
 }
 
+type Segment = { timestamp: string; speaker: string; text: string };
+
+// Shared helper: parse full_transcript and split at a "parsed-N" segment id.
+// Used by both the UUID recording path and the legacy fallback (no fathom_transcripts rows).
+// Returns the two segment arrays or an error string.
+function splitFromParsedTranscript(
+  fullTranscript: string,
+  segmentId: string,
+): { part1: Segment[]; part2: Segment[] } | { error: string; status: number } {
+  if (!fullTranscript.trim()) {
+    return { error: 'No transcript available to split', status: 400 };
+  }
+  const all = parseTranscriptSegments(fullTranscript);
+  if (all.length === 0) {
+    return { error: 'Could not parse any transcript segments', status: 400 };
+  }
+  const idx = segmentId.startsWith('parsed-') ? parseInt(segmentId.slice(7), 10) : -1;
+  if (idx === 0) {
+    return { error: 'Cannot split at the first segment — choose a later segment', status: 400 };
+  }
+  if (isNaN(idx) || idx < 0 || idx >= all.length) {
+    return { error: `Split point not found in transcript (segment: ${segmentId})`, status: 400 };
+  }
+  return { part1: all.slice(0, idx), part2: all.slice(idx) };
+}
+
 // Parse "HH:MM:SS" timestamp into total seconds for duration math.
 function timestampToSeconds(ts: string): number {
   const parts = ts.split(':').map(Number);
@@ -265,72 +291,28 @@ Deno.serve(async (req) => {
         part1Segments = rows.slice(0, splitIdx).map(({ timestamp, speaker, text }) => ({ timestamp, speaker, text }));
         part2Segments = rows.slice(splitIdx).map(({ timestamp, speaker, text }) => ({ timestamp, speaker, text }));
       } else {
-        // Fallback: no fathom_transcripts rows found — parse full_transcript.
-        if (!fullTranscript.trim()) {
+        // Fallback: no fathom_transcripts rows — split from full_transcript.
+        const parsed = splitFromParsedTranscript(fullTranscript, segment_id);
+        if ('error' in parsed) {
           return new Response(
-            JSON.stringify({ error: 'No transcript available to split' }),
-            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+            JSON.stringify({ error: parsed.error }),
+            { status: parsed.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           );
         }
-        const allSegments = parseTranscriptSegments(fullTranscript);
-        if (allSegments.length === 0) {
-          return new Response(
-            JSON.stringify({ error: 'Could not parse any transcript segments' }),
-            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-          );
-        }
-        // segment_id for a parsed fallback is "parsed-N"
-        const splitIdx = segment_id.startsWith('parsed-')
-          ? parseInt(segment_id.slice(7), 10)
-          : -1;
-        if (splitIdx === 0) {
-          return new Response(
-            JSON.stringify({ error: 'Cannot split at the first segment — choose a later segment' }),
-            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-          );
-        }
-        if (isNaN(splitIdx) || splitIdx < 0 || splitIdx >= allSegments.length) {
-          return new Response(
-            JSON.stringify({ error: `Split point not found in transcript (segment: ${segment_id})` }),
-            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-          );
-        }
-        part1Segments = allSegments.slice(0, splitIdx);
-        part2Segments = allSegments.slice(splitIdx);
+        part1Segments = parsed.part1;
+        part2Segments = parsed.part2;
       }
     } else {
       // UUID recording: parse full_transcript (trimming not supported, so blob is current).
-      if (!fullTranscript.trim()) {
+      const parsed = splitFromParsedTranscript(fullTranscript, segment_id);
+      if ('error' in parsed) {
         return new Response(
-          JSON.stringify({ error: 'No transcript available to split' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          JSON.stringify({ error: parsed.error }),
+          { status: parsed.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
-      const allSegments = parseTranscriptSegments(fullTranscript);
-      if (allSegments.length === 0) {
-        return new Response(
-          JSON.stringify({ error: 'Could not parse any transcript segments' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-      // segment_id for UUID recordings is "parsed-N" (synthetic id assigned by frontend)
-      const splitIdx = segment_id.startsWith('parsed-')
-        ? parseInt(segment_id.slice(7), 10)
-        : -1;
-      if (splitIdx === 0) {
-        return new Response(
-          JSON.stringify({ error: 'Cannot split at the first segment — choose a later segment' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-      if (isNaN(splitIdx) || splitIdx < 0 || splitIdx >= allSegments.length) {
-        return new Response(
-          JSON.stringify({ error: `Split point not found in transcript (segment: ${segment_id})` }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-      part1Segments = allSegments.slice(0, splitIdx);
-      part2Segments = allSegments.slice(splitIdx);
+      part1Segments = parsed.part1;
+      part2Segments = parsed.part2;
     }
 
     const part1Transcript = buildTranscriptText(part1Segments);

--- a/supabase/functions/summarize-call/index.ts
+++ b/supabase/functions/summarize-call/index.ts
@@ -34,9 +34,13 @@ function createOpenRouterProvider(apiKey: string) {
   });
 }
 
-// Request schema
+// Request schema — accepts both legacy BIGINT recording IDs and UUID-based IDs
+// (UUIDs are used for recordings created via split or the new recordings table)
 const RequestSchema = z.object({
-  recording_id: z.number().int().positive('recording_id must be a positive integer'),
+  recording_id: z.union([
+    z.number().int().positive('recording_id must be a positive integer'),
+    z.string().uuid('recording_id must be a UUID or a positive integer'),
+  ]),
   force_refresh: z.boolean().optional().default(false),
 });
 
@@ -143,32 +147,71 @@ Deno.serve(async (req) => {
       );
     }
 
-    const { recording_id, force_refresh } = validation.data;
+    const { recording_id, force_refresh } = validation.data as SummarizeRequest;
+    const isUuid = typeof recording_id === 'string';
 
-    // Fetch the call - verify user ownership
-    const { data: call, error: callError } = await supabase
-      .from('fathom_raw_calls')
-      .select('recording_id, title, full_transcript, summary, summary_edited_by_user')
-      .eq('recording_id', recording_id)
-      .eq('user_id', user.id)
-      .single();
+    // Fetch the call — UUID-based recordings use the `recordings` table;
+    // legacy BIGINT IDs use `fathom_raw_calls`.
+    let callTitle = '';
+    let fullTranscript = '';
+    let currentSummary: string | null = null;
+    let summaryEditedByUser = false;
 
-    if (callError || !call) {
-      return new Response(
-        JSON.stringify({ error: 'Recording not found or unauthorized' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+    if (isUuid) {
+      const { data: rec, error: recError } = await supabase
+        .from('recordings')
+        .select('id, title, full_transcript, summary, owner_user_id')
+        .eq('id', recording_id)
+        .single();
+
+      if (recError || !rec) {
+        return new Response(
+          JSON.stringify({ error: 'Recording not found or unauthorized' }),
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (rec.owner_user_id !== user.id) {
+        return new Response(
+          JSON.stringify({ error: 'Recording not found or unauthorized' }),
+          { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      callTitle = rec.title || '';
+      fullTranscript = rec.full_transcript || '';
+      currentSummary = rec.summary || null;
+      summaryEditedByUser = false; // recordings table has no summary_edited_by_user flag
+    } else {
+      const { data: call, error: callError } = await supabase
+        .from('fathom_raw_calls')
+        .select('recording_id, title, full_transcript, summary, summary_edited_by_user')
+        .eq('recording_id', recording_id)
+        .eq('user_id', user.id)
+        .single();
+
+      if (callError || !call) {
+        return new Response(
+          JSON.stringify({ error: 'Recording not found or unauthorized' }),
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      callTitle = call.title || '';
+      fullTranscript = call.full_transcript || '';
+      currentSummary = call.summary || null;
+      summaryEditedByUser = call.summary_edited_by_user || false;
     }
 
     // Check if we already have a summary (and respect user edits unless force_refresh)
-    if (!force_refresh && call.summary) {
+    if (!force_refresh && currentSummary) {
       // If user has edited the summary, never overwrite
-      if (call.summary_edited_by_user) {
+      if (summaryEditedByUser) {
         return new Response(
           JSON.stringify({
             success: true,
             recording_id,
-            summary: call.summary,
+            summary: currentSummary,
             cached: true,
             user_edited: true,
             message: 'Summary was edited by user and will not be regenerated',
@@ -182,7 +225,7 @@ Deno.serve(async (req) => {
         JSON.stringify({
           success: true,
           recording_id,
-          summary: call.summary,
+          summary: currentSummary,
           cached: true,
         }),
         { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -190,7 +233,7 @@ Deno.serve(async (req) => {
     }
 
     // Validate transcript exists
-    if (!call.full_transcript || call.full_transcript.trim().length === 0) {
+    if (!fullTranscript || fullTranscript.trim().length === 0) {
       return new Response(
         JSON.stringify({ error: 'No transcript available for this recording' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -205,32 +248,39 @@ Deno.serve(async (req) => {
       name: 'summarize-call',
       userId: user.id,
       model: 'openai/gpt-5-nano',
-      input: { title: call.title, transcriptLength: call.full_transcript.length },
+      input: { title: callTitle, transcriptLength: fullTranscript.length },
       metadata: { recording_id },
     });
 
     let summary: string;
     try {
-      summary = await generateSummary(call.full_transcript, call.title || '', openrouter);
+      summary = await generateSummary(fullTranscript, callTitle, openrouter);
       await trace?.end(summary);
     } catch (error) {
       await trace?.end(null, error instanceof Error ? error.message : 'Unknown error');
       throw error;
     }
 
-    // Store the summary in the database
-    const { error: updateError } = await supabase
-      .from('fathom_raw_calls')
-      .update({
-        summary,
-        // Don't set summary_edited_by_user since this is AI-generated
-      })
-      .eq('recording_id', recording_id)
-      .eq('user_id', user.id);
+    // Store the summary back in the appropriate table
+    if (isUuid) {
+      const { error: updateError } = await supabase
+        .from('recordings')
+        .update({ summary })
+        .eq('id', recording_id);
 
-    if (updateError) {
-      console.error('Failed to store summary:', updateError);
-      // Still return the summary even if storage failed
+      if (updateError) {
+        console.error('Failed to store summary in recordings:', updateError);
+      }
+    } else {
+      const { error: updateError } = await supabase
+        .from('fathom_raw_calls')
+        .update({ summary })
+        .eq('recording_id', recording_id)
+        .eq('user_id', user.id);
+
+      if (updateError) {
+        console.error('Failed to store summary in fathom_raw_calls:', updateError);
+      }
     }
 
     // Flush Langfuse traces before response

--- a/supabase/migrations/20260309220000_split_recording_rpc.sql
+++ b/supabase/migrations/20260309220000_split_recording_rpc.sql
@@ -1,16 +1,122 @@
--- Migration: Split Recording Support
--- Purpose: No schema changes required — split logic is implemented in the
---          split-recording edge function which uses the existing recordings,
---          workspace_entries, and fathom_calls tables.
+-- Migration: Atomic Split Recording RPC
+-- Purpose: Wrap the Part 1 update + Part 2 insert in a single Postgres transaction
+--          so a mid-operation failure cannot leave recordings in an inconsistent state.
+-- Issue: #148 (split call recording into two parts)
+
+-- ============================================================================
+-- FUNCTION: split_recording_atomic
+-- ============================================================================
+-- Performs all critical DB writes for splitting a recording atomically:
+--   1. Updates Part 1 (existing recording) — new title, trimmed transcript, cleared summary
+--   2. Creates Part 2 (new recordings row)
+-- Returns the UUID of the newly created Part 2 recording.
 --
--- This file serves as a migration marker for issue #148 (split recording feature).
--- The split-recording edge function handles:
---   1. Parsing full_transcript into segments
---   2. Creating Part 2 as a new recordings row
---   3. Copying workspace_entries for the new recording
---   4. Renaming Part 1 with "(Part 1)" suffix
---
--- No DDL changes are required.
+-- Workspace entry copying is left to the caller (edge function) since it is
+-- non-critical and can be retried independently without data corruption.
+
+CREATE OR REPLACE FUNCTION public.split_recording_atomic(
+  -- Part 1 identifiers (at least one must be non-null)
+  p_part1_recordings_id   UUID,     -- recordings.id if available (nullable)
+  p_part1_fathom_id       BIGINT,   -- fathom_calls.recording_id for legacy (nullable)
+
+  -- Part 1 updated values
+  p_part1_title           TEXT NOT NULL,
+  p_part1_transcript      TEXT NOT NULL,
+
+  -- Part 2 creation values
+  p_part2_title           TEXT NOT NULL,
+  p_part2_transcript      TEXT NOT NULL,
+  p_organization_id       UUID NOT NULL,
+  p_owner_user_id         UUID NOT NULL,
+  p_source_app            TEXT,
+  p_source_metadata       JSONB DEFAULT '{}',
+  p_recording_start_time  TIMESTAMPTZ,
+  p_recording_end_time    TIMESTAMPTZ,
+  p_audio_url             TEXT,
+  p_video_url             TEXT
+)
+RETURNS UUID  -- UUID of the newly created Part 2 recording
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_part2_id UUID;
+BEGIN
+  -- Validate: caller must be the owner of the source recording
+  IF p_part1_recordings_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM recordings
+      WHERE id = p_part1_recordings_id
+        AND owner_user_id = auth.uid()
+    ) THEN
+      RAISE EXCEPTION 'Access denied: not the owner of recording %', p_part1_recordings_id;
+    END IF;
+  END IF;
+
+  -- 1. Update Part 1 in the recordings table (if a UUID row exists)
+  IF p_part1_recordings_id IS NOT NULL THEN
+    UPDATE recordings
+    SET
+      title           = p_part1_title,
+      full_transcript = p_part1_transcript,
+      summary         = NULL,
+      updated_at      = NOW()
+    WHERE id = p_part1_recordings_id;
+  END IF;
+
+  -- 2. Update Part 1 in fathom_calls for legacy compatibility (best-effort)
+  IF p_part1_fathom_id IS NOT NULL THEN
+    UPDATE fathom_calls
+    SET
+      title           = p_part1_title,
+      full_transcript = p_part1_transcript,
+      summary         = NULL
+    WHERE recording_id = p_part1_fathom_id;
+    -- Note: fathom_calls.user_id is NOT checked here because this function is
+    -- SECURITY DEFINER — the ownership check on recordings above is sufficient.
+    -- The RPC is only callable by an authenticated user via the edge function,
+    -- which separately validates auth.uid() = p_owner_user_id.
+  END IF;
+
+  -- 3. Create Part 2 as a new recordings row
+  INSERT INTO recordings (
+    organization_id,
+    owner_user_id,
+    title,
+    full_transcript,
+    audio_url,
+    video_url,
+    source_app,
+    source_metadata,
+    recording_start_time,
+    recording_end_time,
+    created_at,
+    synced_at
+  ) VALUES (
+    p_organization_id,
+    p_owner_user_id,
+    p_part2_title,
+    p_part2_transcript,
+    p_audio_url,
+    p_video_url,
+    p_source_app,
+    p_source_metadata,
+    p_recording_start_time,
+    p_recording_end_time,
+    NOW(),
+    NOW()
+  )
+  RETURNING id INTO v_part2_id;
+
+  RETURN v_part2_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.split_recording_atomic IS
+  'Atomically updates Part 1 and creates Part 2 when splitting a call recording. '
+  'Called by the split-recording edge function. Workspace entry copying is done '
+  'by the caller after this function succeeds.';
 
 -- ============================================================================
 -- END OF MIGRATION

--- a/supabase/migrations/20260309220000_split_recording_rpc.sql
+++ b/supabase/migrations/20260309220000_split_recording_rpc.sql
@@ -123,5 +123,20 @@ COMMENT ON FUNCTION public.split_recording_atomic IS
   'by the caller after this function succeeds.';
 
 -- ============================================================================
+-- PERMISSIONS
+-- ============================================================================
+-- Revoke direct execution from all non-service roles.
+-- The function is SECURITY DEFINER and must only be reachable via the edge
+-- function (which uses the service role key). Without this, any authenticated
+-- user could call it directly via PostgREST and pass arbitrary p_owner_user_id /
+-- p_organization_id values — the ownership check only fires when
+-- p_part1_recordings_id IS NOT NULL, so passing NULL for both id params would
+-- skip all validation while still inserting a Part 2 row.
+REVOKE EXECUTE ON FUNCTION public.split_recording_atomic FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.split_recording_atomic FROM anon;
+REVOKE EXECUTE ON FUNCTION public.split_recording_atomic FROM authenticated;
+-- (The service role bypasses EXECUTE grants, so edge function calls still work.)
+
+-- ============================================================================
 -- END OF MIGRATION
 -- ============================================================================

--- a/supabase/migrations/20260309220000_split_recording_rpc.sql
+++ b/supabase/migrations/20260309220000_split_recording_rpc.sql
@@ -1,0 +1,17 @@
+-- Migration: Split Recording Support
+-- Purpose: No schema changes required — split logic is implemented in the
+--          split-recording edge function which uses the existing recordings,
+--          workspace_entries, and fathom_calls tables.
+--
+-- This file serves as a migration marker for issue #148 (split recording feature).
+-- The split-recording edge function handles:
+--   1. Parsing full_transcript into segments
+--   2. Creating Part 2 as a new recordings row
+--   3. Copying workspace_entries for the new recording
+--   4. Renaming Part 1 with "(Part 1)" suffix
+--
+-- No DDL changes are required.
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================

--- a/supabase/migrations/20260309220000_split_recording_rpc.sql
+++ b/supabase/migrations/20260309220000_split_recording_rpc.sql
@@ -43,12 +43,15 @@ AS $$
 DECLARE
   v_part2_id UUID;
 BEGIN
-  -- Validate: caller must be the owner of the source recording
+  -- Validate: p_owner_user_id must be the owner of the source recording.
+  -- Note: this RPC is called with the service role key (via the edge function),
+  -- so auth.uid() is NULL. We use the p_owner_user_id parameter instead, which
+  -- is already validated by the edge function against the user's JWT.
   IF p_part1_recordings_id IS NOT NULL THEN
     IF NOT EXISTS (
       SELECT 1 FROM recordings
       WHERE id = p_part1_recordings_id
-        AND owner_user_id = auth.uid()
+        AND owner_user_id = p_owner_user_id
     ) THEN
       RAISE EXCEPTION 'Access denied: not the owner of recording %', p_part1_recordings_id;
     END IF;

--- a/supabase/migrations/20260309220000_split_recording_rpc.sql
+++ b/supabase/migrations/20260309220000_split_recording_rpc.sql
@@ -68,15 +68,16 @@ BEGIN
     WHERE id = p_part1_recordings_id;
   END IF;
 
-  -- 2. Update Part 1 in fathom_calls for legacy compatibility (best-effort)
+  -- 2. Update Part 1 in fathom_raw_calls for legacy compatibility (best-effort)
+  -- NOTE: fathom_calls is a VIEW (not the base table); writes must target fathom_raw_calls.
   IF p_part1_fathom_id IS NOT NULL THEN
-    UPDATE fathom_calls
+    UPDATE fathom_raw_calls
     SET
       title           = p_part1_title,
       full_transcript = p_part1_transcript,
       summary         = NULL
     WHERE recording_id = p_part1_fathom_id;
-    -- Note: fathom_calls.user_id is NOT checked here because this function is
+    -- Note: fathom_raw_calls.user_id is NOT checked here because this function is
     -- SECURITY DEFINER — the ownership check on recordings above is sufficient.
     -- The RPC is only callable by an authenticated user via the edge function,
     -- which separately validates auth.uid() = p_owner_user_id.


### PR DESCRIPTION
## Summary

- Adds a "Split here" option to the transcript segment context menu (right-click any segment in a call detail view)
- Creates two new recordings — Part 1 (segments before the split) and Part 2 (the clicked segment onwards)
- Both recordings keep the original title with ` (Part 1)` / ` (Part 2)` appended
- Post-split dialog offers "Regenerate summary" for each part via the existing `summarize-call` edge function

## What changed

- **`supabase/functions/split-recording/`** — new edge function that parses `full_transcript`, creates Part 2 as a new `recordings` row, copies `workspace_entries`, and renames Part 1's title/transcript
- **`SplitConfirmDialog.tsx`** — confirmation dialog explaining what the split does (matches existing `TrimConfirmDialog` pattern)
- **`TranscriptSegmentContextMenu.tsx`** — "Split here" menu item using `RiSplitCellsHorizontal`; optional prop so existing usages are unaffected
- **`CallTranscriptTab.tsx`** — `onSplitHere` added to `TranscriptHandlers` interface and wired to the context menu
- **`useCallDetailMutations.ts`** — `splitRecording` mutation calling the edge function; invalidates calls + workspace caches on success
- **`CallDetailDialog.tsx`** — split dialog state, confirm handler (finds segment index in flat transcript array), and post-split result dialog with per-recording regenerate buttons

## Test plan

- [ ] Open a call with a multi-segment transcript
- [ ] Right-click a segment (not the first one) → "Split here" appears in the menu
- [ ] Confirm in the dialog → loading state shows "Splitting…"
- [ ] On success: toast shows both titles; post-split dialog offers "Regenerate summary" for each part
- [ ] Part 1 call detail shows only the transcript up to (not including) the split point
- [ ] Part 2 appears in the workspace/library with the (Part 2) title and transcript from the split onwards
- [ ] Splitting at the first segment shows an error toast (no Part 1 would exist)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)