### PR TITLE
feat(156): AI credits system — Free/Pro/Team pricing tiers

### DIFF
--- a/src/components/billing/AiUsageBar.tsx
+++ b/src/components/billing/AiUsageBar.tsx
@@ -82,10 +82,6 @@ export function AiUsageBar() {
             </UpgradeButton>
           )}
         </div>
-      ) : isNearLimit ? (
-        <p className="text-xs text-muted-foreground">
-          {remaining.toLocaleString()} action{remaining !== 1 ? 's' : ''} remaining this month
-        </p>
       ) : (
         <p className="text-xs text-muted-foreground">
           {remaining.toLocaleString()} action{remaining !== 1 ? 's' : ''} remaining this month

--- a/src/components/billing/AiUsageBar.tsx
+++ b/src/components/billing/AiUsageBar.tsx
@@ -1,0 +1,96 @@
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useAiUsage } from '@/hooks/useAiUsage';
+import { useSubscription } from '@/hooks/useSubscription';
+import { UpgradeButton } from './UpgradeButton';
+
+/**
+ * AiUsageBar - Displays current AI actions used vs monthly limit
+ *
+ * Shows a progress bar with used/limit counts.
+ * When the limit is reached, shows an inline upgrade CTA.
+ *
+ * Place in Settings > Billing or Settings > Usage sections.
+ */
+export function AiUsageBar() {
+  const { used, limit, remaining, percentage, canPerformAction, isLoading } = useAiUsage();
+  const { tier, isTrialing, periodEnd } = useSubscription();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-2 w-full rounded-full" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+    );
+  }
+
+  const isNearLimit = percentage >= 80 && canPerformAction;
+  const isAtLimit = !canPerformAction;
+
+  const barColor = isAtLimit
+    ? 'bg-destructive'
+    : isNearLimit
+    ? 'bg-orange-500'
+    : 'bg-primary';
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-foreground">AI Actions</p>
+          {isTrialing && periodEnd && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Pro trial ends {periodEnd.toLocaleDateString()}
+            </p>
+          )}
+        </div>
+        <span className="text-sm tabular-nums text-muted-foreground">
+          {used.toLocaleString()} / {limit.toLocaleString()}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+        <div
+          className={cn('h-full rounded-full transition-all duration-300', barColor)}
+          style={{ width: `${percentage}%` }}
+          role="progressbar"
+          aria-valuenow={used}
+          aria-valuemin={0}
+          aria-valuemax={limit}
+        />
+      </div>
+
+      {/* Status message */}
+      {isAtLimit ? (
+        <div className="space-y-2">
+          <p className="text-xs text-destructive font-medium">
+            {tier === 'free'
+              ? 'Upgrade to Pro to keep using smart features'
+              : 'Upgrade to Team or contact us for higher limits'}
+          </p>
+          {tier !== 'team' && (
+            <UpgradeButton
+              productId={tier === 'free' ? 'pro-monthly' : 'team-monthly'}
+              variant="default"
+              className="h-8 text-xs px-3"
+            >
+              {tier === 'free' ? 'Upgrade to Pro' : 'Upgrade to Team'}
+            </UpgradeButton>
+          )}
+        </div>
+      ) : isNearLimit ? (
+        <p className="text-xs text-muted-foreground">
+          {remaining.toLocaleString()} action{remaining !== 1 ? 's' : ''} remaining this month
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          {remaining.toLocaleString()} action{remaining !== 1 ? 's' : ''} remaining this month
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/billing/PlanCards.tsx
+++ b/src/components/billing/PlanCards.tsx
@@ -91,8 +91,6 @@ export interface PlanCardsProps {
   currentTier: SubscriptionTier;
   /** Whether user is currently on a trial */
   isTrialing?: boolean;
-  /** Callback when upgrade is requested (optional — UpgradeButton handles checkout internally) */
-  onUpgrade?: (productId: string) => void;
   /** Loading state */
   isLoading?: boolean;
   /** Whether to show annual pricing toggle (default: show monthly) */
@@ -110,7 +108,6 @@ export interface PlanCardsProps {
 export function PlanCards({
   currentTier,
   isTrialing = false,
-  onUpgrade: _onUpgrade, // Legacy prop — UpgradeButton handles checkout internally
   isLoading = false,
   showAnnual = false,
 }: PlanCardsProps) {

--- a/src/components/billing/PlanCards.tsx
+++ b/src/components/billing/PlanCards.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { RiCheckLine, RiStarLine } from "@remixicon/react";
+import { RiCheckLine, RiStarLine, RiFlashlightLine } from "@remixicon/react";
 import type { SubscriptionTier } from "@/hooks/useSubscription";
 import { UpgradeButton } from "./UpgradeButton";
 
@@ -13,79 +13,85 @@ interface PlanTier {
   id: string;
   name: string;
   tier: SubscriptionTier;
-  monthlyPrice: number;
-  annualPrice: number;
-  annualSavings: number;
+  monthlyPrice: number | null; // null = free
+  annualPrice: number | null;
+  annualSavings: number | null;
   description: string;
   features: string[];
   highlighted?: boolean;
-  productIdMonthly: string;
-  productIdAnnual: string;
+  productIdMonthly: string | null; // null = free (no checkout)
+  productIdAnnual: string | null;
 }
 
 /**
- * Plan definitions per CONTEXT.md
- * Solo ($29/mo), Team ($99/mo), Business ($249/mo)
+ * Plan definitions per Issue #156 — Free / Pro / Team
  */
 const PLANS: PlanTier[] = [
   {
-    id: 'solo',
-    name: 'Solo',
-    tier: 'solo',
+    id: 'free',
+    name: 'Free',
+    tier: 'free',
+    monthlyPrice: 0,
+    annualPrice: null,
+    annualSavings: null,
+    description: 'Get started with core import features and a taste of AI.',
+    features: [
+      '1 user, 1 workspace',
+      '10 imports / month',
+      '25 AI actions / month',
+      'Smart import (titles + tags)',
+      'No MCP / External AI integrations',
+      'No AI chat',
+    ],
+    productIdMonthly: null,
+    productIdAnnual: null,
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    tier: 'pro',
     monthlyPrice: 29,
     annualPrice: 278,
     annualSavings: 70,
-    description: 'Perfect for individuals with unlimited calls and transcription features.',
+    description: 'Unlimited imports, full MCP access, and 1,000 AI actions / month.',
     features: [
       '1 user',
-      'Unlimited calls & transcriptions',
-      'Folders, tags, global search',
-      '10 notes per call',
+      'Unlimited imports',
+      'Multiple workspaces',
+      'Full MCP / External AI access',
+      '1,000 AI actions / month',
+      'Minimal AI chat (5 transcripts per chat)',
     ],
-    productIdMonthly: 'solo-monthly',
-    productIdAnnual: 'solo-annual',
+    highlighted: true,
+    productIdMonthly: 'pro-monthly',
+    productIdAnnual: 'pro-annual',
   },
   {
     id: 'team',
     name: 'Team',
     tier: 'team',
-    monthlyPrice: 99,
-    annualPrice: 950,
-    annualSavings: 238,
-    description: 'Up to 5 users with team hierarchy and shared collaboration.',
+    monthlyPrice: 79,
+    annualPrice: 758,
+    annualSavings: 190,
+    description: 'Everything in Pro, shared workspaces, roles, and 5,000 pooled AI actions.',
     features: [
-      'Up to 5 full users',
-      'Team hierarchy & manager auto-access',
-      'Shared folders',
-      'Unlimited notes',
+      '3–10 users',
+      'Shared workspaces + roles',
+      'Admin dashboard',
+      '5,000 AI actions / month (pooled)',
+      'Everything in Pro',
     ],
-    highlighted: true,
     productIdMonthly: 'team-monthly',
     productIdAnnual: 'team-annual',
-  },
-  {
-    id: 'business',
-    name: 'Business',
-    tier: 'business',
-    monthlyPrice: 249,
-    annualPrice: 2390,
-    annualSavings: 598,
-    description: 'Up to 20 users with advanced admin controls and priority support.',
-    features: [
-      'Up to 20 full users',
-      'Advanced admin controls',
-      'Priority support',
-      'Custom integrations',
-    ],
-    productIdMonthly: 'business-monthly',
-    productIdAnnual: 'business-annual',
   },
 ];
 
 export interface PlanCardsProps {
   /** Current user's tier */
   currentTier: SubscriptionTier;
-  /** Callback when upgrade is requested (optional - UpgradeButton handles checkout internally) */
+  /** Whether user is currently on a trial */
+  isTrialing?: boolean;
+  /** Callback when upgrade is requested (optional — UpgradeButton handles checkout internally) */
   onUpgrade?: (productId: string) => void;
   /** Loading state */
   isLoading?: boolean;
@@ -95,15 +101,16 @@ export interface PlanCardsProps {
 
 /**
  * PlanCards - Side-by-side plan comparison component
- * 
- * Displays Solo, Team, and Business tiers with feature lists.
+ *
+ * Displays Free, Pro, and Team tiers with feature lists.
  * Highlights current plan and shows upgrade buttons for higher tiers.
- * 
- * @brand-version v4.2
+ *
+ * @brand-version v4.3
  */
 export function PlanCards({
   currentTier,
-  onUpgrade: _onUpgrade, // Legacy prop - UpgradeButton handles checkout internally
+  isTrialing = false,
+  onUpgrade: _onUpgrade, // Legacy prop — UpgradeButton handles checkout internally
   isLoading = false,
   showAnnual = false,
 }: PlanCardsProps) {
@@ -126,7 +133,7 @@ export function PlanCards({
     );
   }
 
-  const tierHierarchy: SubscriptionTier[] = ['free', 'solo', 'team', 'business'];
+  const tierHierarchy: SubscriptionTier[] = ['free', 'pro', 'team'];
   const currentTierIndex = tierHierarchy.indexOf(currentTier);
 
   return (
@@ -136,10 +143,10 @@ export function PlanCards({
         const isCurrentPlan = currentTier === plan.tier;
         const isUpgrade = planTierIndex > currentTierIndex;
         const isDowngrade = planTierIndex < currentTierIndex;
-        
+
         const price = showAnnual ? plan.annualPrice : plan.monthlyPrice;
         const productId = showAnnual ? plan.productIdAnnual : plan.productIdMonthly;
-        const interval = showAnnual ? '/yr' : '/mo';
+        const interval = plan.monthlyPrice === 0 ? '' : showAnnual ? '/yr' : '/mo';
 
         return (
           <div
@@ -151,7 +158,7 @@ export function PlanCards({
               !isCurrentPlan && !plan.highlighted && "border-border"
             )}
           >
-            {/* Popular badge for highlighted plan */}
+            {/* Most Popular badge */}
             {plan.highlighted && !isCurrentPlan && (
               <div className="absolute -top-3 left-1/2 -translate-x-1/2">
                 <Badge className="bg-primary text-primary-foreground px-3">
@@ -161,13 +168,23 @@ export function PlanCards({
               </div>
             )}
 
-            {/* Current plan badge */}
+            {/* Current Plan badge */}
             {isCurrentPlan && (
               <div className="absolute -top-3 left-1/2 -translate-x-1/2">
                 <Badge variant="default" className="px-3">
                   <RiCheckLine className="h-3 w-3 mr-1" />
-                  Current Plan
+                  {isTrialing && plan.tier === 'pro' ? 'Trial Active' : 'Current Plan'}
                 </Badge>
+              </div>
+            )}
+
+            {/* Trial banner inside card */}
+            {isCurrentPlan && isTrialing && plan.tier === 'pro' && (
+              <div className="mb-3 -mx-6 -mt-6 pt-8 px-6 pb-3 bg-primary/5 rounded-t-xl border-b border-primary/10">
+                <div className="flex items-center gap-1.5 text-xs text-primary font-medium">
+                  <RiFlashlightLine className="h-3.5 w-3.5" />
+                  Pro trial — upgrade to keep full access
+                </div>
               </div>
             )}
 
@@ -175,10 +192,14 @@ export function PlanCards({
             <div className="mb-4 pt-2">
               <h3 className="text-lg font-semibold text-foreground">{plan.name}</h3>
               <div className="flex items-baseline gap-1 mt-1">
-                <span className="text-3xl font-bold text-foreground">${price}</span>
-                <span className="text-sm text-muted-foreground">{interval}</span>
+                <span className="text-3xl font-bold text-foreground tabular-nums">
+                  {price === 0 ? 'Free' : `$${price}`}
+                </span>
+                {interval && (
+                  <span className="text-sm text-muted-foreground">{interval}</span>
+                )}
               </div>
-              {showAnnual && (
+              {showAnnual && plan.annualSavings != null && (
                 <p className="text-xs text-success-text mt-1">
                   Save ${plan.annualSavings}/year
                 </p>
@@ -202,30 +223,44 @@ export function PlanCards({
 
             {/* Action button */}
             <div className="mt-auto">
-              {isCurrentPlan ? (
+              {isCurrentPlan && !isTrialing ? (
                 <Button variant="outline" className="w-full" disabled>
                   Current Plan
                 </Button>
-              ) : isUpgrade ? (
-                <UpgradeButton 
+              ) : isCurrentPlan && isTrialing ? (
+                // On trial — offer upgrade to paid Pro
+                <UpgradeButton
+                  productId="pro-monthly"
+                  variant="default"
+                  className="w-full"
+                >
+                  Upgrade to Pro
+                </UpgradeButton>
+              ) : plan.tier === 'free' ? (
+                // Free tier — no checkout needed, just a disabled button
+                <Button variant="outline" className="w-full" disabled={currentTier !== 'free'}>
+                  {isDowngrade ? 'Downgrade to Free' : 'Get Started Free'}
+                </Button>
+              ) : isUpgrade && productId ? (
+                <UpgradeButton
                   productId={productId}
-                  variant="default" 
+                  variant="default"
                   className="w-full"
                 >
                   Upgrade to {plan.name}
                 </UpgradeButton>
-              ) : isDowngrade ? (
-                <UpgradeButton 
+              ) : isDowngrade && productId ? (
+                <UpgradeButton
                   productId={productId}
-                  variant="outline" 
+                  variant="outline"
                   className="w-full"
                 >
                   Downgrade to {plan.name}
                 </UpgradeButton>
               ) : (
-                <UpgradeButton 
-                  productId={productId}
-                  variant="default" 
+                <UpgradeButton
+                  productId={productId ?? ''}
+                  variant="default"
                   className="w-full"
                 >
                   Get Started
@@ -236,7 +271,7 @@ export function PlanCards({
             {/* Downgrade notice */}
             {isDowngrade && currentTierIndex > 0 && (
               <p className="text-xs text-muted-foreground mt-3 text-center">
-                Excess features become read-only
+                Extra workspaces + MCP become read-only
               </p>
             )}
           </div>

--- a/src/components/settings/BillingTab.tsx
+++ b/src/components/settings/BillingTab.tsx
@@ -1,100 +1,60 @@
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
-import { RiBankCardLine, RiCpuLine, RiCalendarLine } from "@remixicon/react";
-import { BarChart } from "@tremor/react";
+import { RiBankCardLine, RiCalendarLine } from "@remixicon/react";
 import { useSubscription, type SubscriptionTier } from "@/hooks/useSubscription";
 import { PlanCards } from "@/components/billing/PlanCards";
+import { AiUsageBar } from "@/components/billing/AiUsageBar";
 import { UpgradeButton } from "@/components/billing/UpgradeButton";
 
 /**
- * Format USD with appropriate precision
- * Shows more decimals for small amounts
- */
-function formatUsd(amount: number): string {
-  if (amount === 0) return "$0.00";
-  if (amount < 0.01) return `$${amount.toFixed(6)}`;
-  if (amount < 1) return `$${amount.toFixed(4)}`;
-  return `$${amount.toFixed(2)}`;
-}
-
-/**
- * Format large numbers with K/M suffix
- */
-function formatTokens(tokens: number): string {
-  if (tokens >= 1_000_000) {
-    return `${(tokens / 1_000_000).toFixed(1)}M`;
-  }
-  if (tokens >= 1_000) {
-    return `${(tokens / 1_000).toFixed(1)}K`;
-  }
-  return tokens.toString();
-}
-
-/**
  * Get plan details based on subscription tier
- * Maps Polar tiers to display information
  */
 function getPlanDetails(tier: SubscriptionTier) {
   switch (tier) {
-    case "business":
-      return {
-        name: "Business",
-        displayName: "Business",
-        price: "$249/mo",
-        annualPrice: "$2,390/yr (save $598)",
-        description: "Up to 20 users with advanced admin controls and priority support.",
-        badgeVariant: "default" as const,
-        features: [
-          "Up to 20 full users",
-          "Advanced admin controls",
-          "Priority support",
-          "Custom integrations",
-        ],
-      };
     case "team":
       return {
         name: "Team",
-        displayName: "Team",
-        price: "$99/mo",
-        annualPrice: "$950/yr (save $238)",
-        description: "Up to 5 users with team hierarchy and shared collaboration.",
+        price: "$79/mo",
+        annualPrice: "$758/yr (save $190)",
+        description: "3–10 users, shared workspaces, roles, and 5,000 pooled AI actions/month.",
         badgeVariant: "default" as const,
         features: [
-          "Up to 5 full users",
-          "Team hierarchy & manager auto-access",
-          "Shared folders",
-          "Unlimited notes",
+          "3–10 users",
+          "Shared workspaces + roles/permissions",
+          "Admin dashboard",
+          "5,000 AI actions / month (pooled)",
+          "Everything in Pro",
         ],
       };
-    case "solo":
+    case "pro":
       return {
-        name: "Solo",
-        displayName: "Solo",
+        name: "Pro",
         price: "$29/mo",
         annualPrice: "$278/yr (save $70)",
-        description: "Perfect for individuals with unlimited calls and transcription features.",
+        description: "Unlimited imports, full MCP access, and 1,000 AI actions/month.",
         badgeVariant: "default" as const,
         features: [
           "1 user",
-          "Unlimited calls & transcriptions",
-          "Folders, tags, global search",
-          "10 notes per call",
+          "Unlimited imports",
+          "Multiple workspaces",
+          "Full MCP / External AI access",
+          "1,000 AI actions / month",
         ],
       };
     case "free":
     default:
       return {
         name: "Free",
-        displayName: "Free",
         price: "$0",
-        description: "Limited usage with core features. Can view shared calls from paid users.",
+        annualPrice: undefined,
+        description: "Core import features and a taste of AI.",
         badgeVariant: "outline" as const,
         features: [
-          "1 user",
-          "300 minutes/month limit",
-          "Limited storage",
-          "View-only for shared calls",
+          "1 user, 1 workspace",
+          "10 imports / month",
+          "25 AI actions / month",
+          "Smart import (titles + tags)",
         ],
       };
   }
@@ -138,9 +98,12 @@ export default function BillingTab() {
     status,
     periodEnd,
     isPaid,
+    isTrialing,
     isLoading: subscriptionLoading,
     error: subscriptionError,
   } = useSubscription();
+
+  const plan = getPlanDetails(tier);
 
   return (
     <div>
@@ -179,21 +142,28 @@ export default function BillingTab() {
                 </div>
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-1">
-                    <h3 className="text-lg font-semibold">{getPlanDetails(tier).displayName} Plan</h3>
-                    <Badge variant={formatStatus(status).variant}>{formatStatus(status).label}</Badge>
-                    {getPlanDetails(tier).price && (
-                      <span className="text-sm font-medium text-muted-foreground">
-                        {getPlanDetails(tier).price}
-                      </span>
-                    )}
+                    <h3 className="text-lg font-semibold">
+                      {plan.name} Plan
+                      {isTrialing && (
+                        <span className="ml-2 text-sm font-normal text-muted-foreground">
+                          (14-day trial)
+                        </span>
+                      )}
+                    </h3>
+                    <Badge variant={formatStatus(status).variant}>
+                      {formatStatus(status).label}
+                    </Badge>
+                    <span className="text-sm font-medium text-muted-foreground">
+                      {plan.price}
+                    </span>
                   </div>
-                  {getPlanDetails(tier).annualPrice && (
+                  {plan.annualPrice && (
                     <p className="text-xs text-muted-foreground mb-2">
-                      Or {getPlanDetails(tier).annualPrice}
+                      Or {plan.annualPrice}
                     </p>
                   )}
                   <p className="text-sm text-muted-foreground">
-                    {getPlanDetails(tier).description}
+                    {plan.description}
                   </p>
                 </div>
               </div>
@@ -204,7 +174,11 @@ export default function BillingTab() {
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <RiCalendarLine className="h-4 w-4" />
                     <span>
-                      {status === 'canceled' ? 'Access until: ' : 'Renews: '}
+                      {isTrialing
+                        ? 'Trial ends: '
+                        : status === 'canceled'
+                        ? 'Access until: '
+                        : 'Renews: '}
                       {formatDate(periodEnd)}
                     </span>
                   </div>
@@ -217,7 +191,7 @@ export default function BillingTab() {
                   What's included
                 </h4>
                 <ul className="space-y-2 text-sm text-muted-foreground">
-                  {getPlanDetails(tier).features?.map((feature, index) => (
+                  {plan.features.map((feature, index) => (
                     <li key={index} className="flex items-center gap-2">
                       <div className="h-1.5 w-1.5 rounded-full bg-primary" />
                       {feature}
@@ -229,8 +203,8 @@ export default function BillingTab() {
               {/* Upgrade CTA for free users */}
               {tier === 'free' && (
                 <div className="pl-16">
-                  <UpgradeButton productId="solo-monthly" className="mt-2">
-                    Upgrade to Solo
+                  <UpgradeButton productId="pro-monthly" className="mt-2">
+                    Upgrade to Pro
                   </UpgradeButton>
                 </div>
               )}
@@ -239,7 +213,25 @@ export default function BillingTab() {
         </div>
       </div>
 
-      {/* All Plans - Interactive plan comparison with PlanCards */}
+      {/* AI Usage Section */}
+      <Separator className="my-16" />
+      <div className="grid grid-cols-1 gap-x-10 gap-y-8 lg:grid-cols-3">
+        <div>
+          <h2 className="font-semibold text-gray-900 dark:text-gray-50">
+            Usage
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
+            Monthly AI action consumption
+          </p>
+        </div>
+        <div className="lg:col-span-2">
+          <div className="p-4 rounded-lg border border-border bg-card">
+            <AiUsageBar />
+          </div>
+        </div>
+      </div>
+
+      {/* All Plans */}
       <Separator className="my-16" />
       <div className="grid grid-cols-1 gap-x-10 gap-y-8 lg:grid-cols-3">
         <div>
@@ -253,12 +245,10 @@ export default function BillingTab() {
         <div className="lg:col-span-2">
           <PlanCards
             currentTier={tier}
-            onUpgrade={() => {
-              // Handled internally by PlanCards' UpgradeButton components
-            }}
+            isTrialing={isTrialing}
             isLoading={subscriptionLoading}
           />
-          
+
           {/* Enterprise callout */}
           <div className="mt-6 p-4 bg-muted/30 rounded-lg">
             <div className="flex items-center justify-between mb-2">
@@ -266,7 +256,7 @@ export default function BillingTab() {
               <span className="text-sm text-muted-foreground">Custom pricing</span>
             </div>
             <p className="text-xs text-muted-foreground">
-              Unlimited users • SSO • Dedicated CSM • SLA • Custom security
+              Unlimited users · SSO · Dedicated CSM · SLA · Custom security
             </p>
             <p className="text-xs text-muted-foreground mt-2">
               Contact us for enterprise pricing and features.

--- a/src/hooks/useAiUsage.ts
+++ b/src/hooks/useAiUsage.ts
@@ -6,11 +6,11 @@ import { useSubscription } from '@/hooks/useSubscription';
 
 export type AiActionType = 'smart_import' | 'auto_name' | 'auto_tag' | 'chat_message';
 
-/** Returns the current month in YYYY-MM format */
+/** Returns the current month in YYYY-MM format (UTC — matches edge function) */
 function currentMonthYear(): string {
   const now = new Date();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  return `${now.getFullYear()}-${month}`;
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  return `${now.getUTCFullYear()}-${month}`;
 }
 
 export interface AiUsageState {
@@ -67,7 +67,7 @@ export function useAiUsage(): AiUsageState {
       const { user, error: authError } = await getSafeUser();
       if (authError || !user) return 0;
 
-      const { data, error } = await supabase
+      const { count, error } = await supabase
         .from('ai_usage')
         .select('id', { count: 'exact', head: true })
         .eq('user_id', user.id)
@@ -78,7 +78,7 @@ export function useAiUsage(): AiUsageState {
         return 0;
       }
 
-      return data?.length ?? 0;
+      return count ?? 0;
     },
     staleTime: 30000, // 30 seconds — relatively fresh for enforcement
     gcTime: 120000,

--- a/src/hooks/useAiUsage.ts
+++ b/src/hooks/useAiUsage.ts
@@ -1,0 +1,171 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { getSafeUser } from '@/lib/auth-utils';
+import { logger } from '@/lib/logger';
+import { useSubscription } from '@/hooks/useSubscription';
+
+export type AiActionType = 'smart_import' | 'auto_name' | 'auto_tag' | 'chat_message';
+
+/** Returns the current month in YYYY-MM format */
+function currentMonthYear(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `${now.getFullYear()}-${month}`;
+}
+
+export interface AiUsageState {
+  /** Loading state */
+  isLoading: boolean;
+  /** AI actions used this month */
+  used: number;
+  /** Monthly limit for the current tier */
+  limit: number;
+  /** Remaining actions this month */
+  remaining: number;
+  /** Usage percentage 0–100 */
+  percentage: number;
+  /** Whether the user can still perform an AI action */
+  canPerformAction: boolean;
+  /** Track an AI action — returns true if allowed */
+  trackAction: (params: {
+    actionType: AiActionType;
+    recordingId?: string;
+    orgId?: string;
+  }) => Promise<boolean>;
+}
+
+/**
+ * useAiUsage - Track and enforce AI action limits
+ *
+ * Reads current month's usage from the ai_usage table and exposes
+ * helpers to track new actions via the track-ai-usage edge function.
+ *
+ * @example
+ * ```tsx
+ * const { canPerformAction, trackAction, used, limit } = useAiUsage();
+ *
+ * async function handleSmartImport() {
+ *   const allowed = await trackAction({ actionType: 'smart_import', recordingId });
+ *   if (!allowed) {
+ *     toast.error('AI action limit reached. Upgrade to continue.');
+ *     return;
+ *   }
+ *   // proceed with import
+ * }
+ * ```
+ */
+export function useAiUsage(): AiUsageState {
+  const queryClient = useQueryClient();
+  const { aiActionsLimit, isLoading: subLoading } = useSubscription();
+
+  const monthYear = currentMonthYear();
+
+  // Fetch current month usage from ai_usage table
+  const { data: usageData, isLoading: usageLoading } = useQuery({
+    queryKey: ['ai-usage', monthYear],
+    queryFn: async () => {
+      const { user, error: authError } = await getSafeUser();
+      if (authError || !user) return 0;
+
+      const { data, error } = await supabase
+        .from('ai_usage')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .eq('month_year', monthYear);
+
+      if (error) {
+        logger.error('Error fetching AI usage', error);
+        return 0;
+      }
+
+      return data?.length ?? 0;
+    },
+    staleTime: 30000, // 30 seconds — relatively fresh for enforcement
+    gcTime: 120000,
+  });
+
+  // Call the edge function to track an action (checks limit server-side)
+  const trackMutation = useMutation({
+    mutationFn: async (params: {
+      actionType: AiActionType;
+      recordingId?: string;
+      orgId?: string;
+    }) => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) {
+        throw new Error('Not authenticated');
+      }
+
+      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+      const response = await fetch(
+        `${supabaseUrl}/functions/v1/track-ai-usage`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({
+            actionType: params.actionType,
+            recordingId: params.recordingId,
+            orgId: params.orgId,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const err = await response.json() as { error?: string };
+        throw new Error(err.error ?? 'Failed to track AI action');
+      }
+
+      const result = await response.json() as {
+        allowed: boolean;
+        used: number;
+        limit: number;
+        remaining: number;
+      };
+
+      return result;
+    },
+    onSuccess: (result) => {
+      // Update cached usage count with the server-confirmed value
+      queryClient.setQueryData(['ai-usage', monthYear], result.used);
+    },
+    onError: (err) => {
+      logger.error('Failed to track AI action', err);
+    },
+  });
+
+  const used = usageData ?? 0;
+  const limit = aiActionsLimit;
+  const remaining = Math.max(0, limit - used);
+  const percentage = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+  const canPerformAction = used < limit;
+  const isLoading = subLoading || usageLoading;
+
+  const trackAction = async (params: {
+    actionType: AiActionType;
+    recordingId?: string;
+    orgId?: string;
+  }): Promise<boolean> => {
+    try {
+      const result = await trackMutation.mutateAsync(params);
+      return result.allowed;
+    } catch {
+      // If tracking fails, default to allowing the action
+      // (don't block users due to tracking infrastructure issues)
+      logger.warn('AI usage tracking failed — allowing action');
+      return true;
+    }
+  };
+
+  return {
+    isLoading,
+    used,
+    limit,
+    remaining,
+    percentage,
+    canPerformAction,
+    trackAction,
+  };
+}

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -5,28 +5,41 @@ import { logger } from '@/lib/logger';
 
 /**
  * Subscription tier derived from product_id
- * Free: No product_id (null)
- * Solo: solo-monthly, solo-annual
+ * Free: No active subscription (null product_id or expired trial)
+ * Pro: pro-monthly, pro-annual, pro-trial (trialing)
  * Team: team-monthly, team-annual
- * Business: business-monthly, business-annual
  */
-export type SubscriptionTier = 'free' | 'solo' | 'team' | 'business';
+export type SubscriptionTier = 'free' | 'pro' | 'team';
 
 /**
  * Subscription status from Polar
  * Maps to subscription_status column in user_profiles
  */
-export type SubscriptionStatus = 
-  | 'active' 
-  | 'canceled' 
-  | 'revoked' 
-  | 'incomplete' 
-  | 'incomplete_expired' 
-  | 'trialing' 
-  | 'past_due' 
-  | 'unpaid' 
-  | 'free' 
+export type SubscriptionStatus =
+  | 'active'
+  | 'canceled'
+  | 'revoked'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'trialing'
+  | 'past_due'
+  | 'unpaid'
+  | 'free'
   | null;
+
+/** Monthly AI action limits per tier */
+export const AI_ACTION_LIMITS: Record<SubscriptionTier, number> = {
+  free: 25,
+  pro: 1000,
+  team: 5000,
+};
+
+/** Monthly import limits per tier (null = unlimited) */
+export const IMPORT_LIMITS: Record<SubscriptionTier, number | null> = {
+  free: 10,
+  pro: null,
+  team: null,
+};
 
 /**
  * Subscription state returned by useSubscription hook
@@ -40,17 +53,23 @@ export interface SubscriptionState {
   subscriptionId: string | null;
   /** Current subscription status */
   status: SubscriptionStatus;
-  /** Polar product ID (e.g., 'solo-monthly') */
+  /** Polar product ID (e.g., 'pro-monthly', 'team-annual') */
   productId: string | null;
   /** Subscription period end date */
   periodEnd: Date | null;
   /** Derived tier from product_id */
   tier: SubscriptionTier;
+  /** Whether the user is currently on a trial */
+  isTrialing: boolean;
+  /** Monthly AI action limit for the current tier */
+  aiActionsLimit: number;
+  /** Monthly import limit for the current tier (null = unlimited) */
+  importLimit: number | null;
   /** Can upgrade to a higher tier */
   canUpgrade: boolean;
   /** Can downgrade to a lower tier */
   canDowngrade: boolean;
-  /** Has active paid subscription */
+  /** Has active paid subscription (not free, not expired) */
   isPaid: boolean;
   /** Refetch subscription state */
   refetch: () => void;
@@ -60,36 +79,45 @@ export interface SubscriptionState {
  * Tier hierarchy for upgrade/downgrade logic
  * Higher index = higher tier
  */
-const TIER_HIERARCHY: SubscriptionTier[] = ['free', 'solo', 'team', 'business'];
+const TIER_HIERARCHY: SubscriptionTier[] = ['free', 'pro', 'team'];
 
 /**
- * Derive tier from product_id
- * Product IDs follow format: {tier}-{interval} (e.g., solo-monthly, team-annual)
+ * Derive tier from product_id and subscription status.
+ * Handles trial expiry inline — expired pro-trial → free.
  */
-function deriveTier(productId: string | null): SubscriptionTier {
+function deriveTier(
+  productId: string | null,
+  status: SubscriptionStatus,
+  periodEnd: Date | null,
+): SubscriptionTier {
   if (!productId) return 'free';
-  
-  const lowerProductId = productId.toLowerCase();
-  
-  if (lowerProductId.startsWith('solo')) return 'solo';
-  if (lowerProductId.startsWith('team')) return 'team';
-  if (lowerProductId.startsWith('business')) return 'business';
-  
-  // Unknown product_id - treat as free
+
+  const lower = productId.toLowerCase();
+
+  // Pro trial: only active if still within trial window
+  if (lower === 'pro-trial') {
+    if (status !== 'trialing') return 'free';
+    if (periodEnd && periodEnd < new Date()) return 'free';
+    return 'pro';
+  }
+
+  if (lower.startsWith('pro')) return 'pro';
+  if (lower.startsWith('team')) return 'team';
+
+  // Unknown product_id — treat as free
   return 'free';
 }
 
 /**
  * useSubscription - Fetch and manage subscription state
- * 
+ *
  * Queries user_profiles for billing fields and derives tier information.
  * Uses TanStack Query for caching and automatic refetching.
- * 
+ *
  * @example
  * ```tsx
- * const { tier, canUpgrade, isPaid, isLoading } = useSubscription();
- * 
- * if (isLoading) return <Skeleton />;
+ * const { tier, aiActionsLimit, canUpgrade, isTrialing } = useSubscription();
+ *
  * if (tier === 'free' && canUpgrade) {
  *   return <UpgradePrompt />;
  * }
@@ -105,46 +133,53 @@ export function useSubscription(): SubscriptionState {
     queryKey: ['subscription'],
     queryFn: async () => {
       const { user, error: authError } = await getSafeUser();
-      
+
       if (authError || !user) {
         logger.debug('No authenticated user for subscription check');
         return null;
       }
-      
+
       const { data: profile, error: profileError } = await supabase
         .from('user_profiles')
         .select('subscription_id, subscription_status, product_id, current_period_end')
         .eq('user_id', user.id)
         .maybeSingle();
-      
+
       if (profileError) {
         logger.error('Error fetching subscription data', profileError);
         throw new Error(`Failed to fetch subscription: ${profileError.message}`);
       }
-      
+
       return profile;
     },
-    staleTime: 60000, // 1 minute
-    gcTime: 300000, // 5 minutes
+    staleTime: 60000,  // 1 minute
+    gcTime: 300000,    // 5 minutes
   });
-  
+
   // Extract values from query result
   const subscriptionId = data?.subscription_id ?? null;
-  const status = (data?.subscription_status as SubscriptionStatus) ?? 'free';
+  const status = (data?.subscription_status as SubscriptionStatus) ?? null;
   const productId = data?.product_id ?? null;
   const periodEnd = data?.current_period_end ? new Date(data.current_period_end) : null;
-  
-  // Derive tier from product_id
-  const tier = deriveTier(productId);
-  
+
+  // Derive tier (handles expired trials → free)
+  const tier = deriveTier(productId, status, periodEnd);
+
+  // Trial: product_id is pro-trial and tier resolved to pro (not expired)
+  const isTrialing = productId === 'pro-trial' && tier === 'pro' && status === 'trialing';
+
+  // AI action limit for current tier
+  const aiActionsLimit = AI_ACTION_LIMITS[tier];
+  const importLimit = IMPORT_LIMITS[tier];
+
   // Calculate upgrade/downgrade capability
   const tierIndex = TIER_HIERARCHY.indexOf(tier);
   const canUpgrade = tierIndex < TIER_HIERARCHY.length - 1;
   const canDowngrade = tierIndex > 0;
-  
-  // Has active paid subscription
+
+  // Has active paid subscription (not free, not expired)
   const isPaid = tier !== 'free' && (status === 'active' || status === 'trialing');
-  
+
   return {
     isLoading,
     error: error as Error | null,
@@ -153,6 +188,9 @@ export function useSubscription(): SubscriptionState {
     productId,
     periodEnd,
     tier,
+    isTrialing,
+    aiActionsLimit,
+    importLimit,
     canUpgrade,
     canDowngrade,
     isPaid,

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -193,8 +193,14 @@ Deno.serve(async (req) => {
           product_id: string | null;
           subscription_status: string | null;
         } | null;
-        effectiveProductId = ownerData?.product_id ?? effectiveProductId;
-        effectiveStatus = ownerData?.subscription_status ?? effectiveStatus;
+        // Always use the org owner's values when ownerData is found — even if
+        // they are null (null product_id = free tier). Using ?? here would
+        // incorrectly fall back to the caller's personal subscription when the
+        // org owner is on the free plan, potentially granting a higher limit.
+        if (ownerData) {
+          effectiveProductId = ownerData.product_id;
+          effectiveStatus = ownerData.subscription_status;
+        }
       }
     }
 

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -28,6 +28,7 @@
  */
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { z } from 'https://esm.sh/zod@3.23.8';
 import { getCorsHeaders } from '../_shared/cors.ts';
 
 /** AI action limits per product tier */
@@ -40,13 +41,11 @@ const AI_ACTION_LIMITS: Record<string, number> = {
   'team-annual': 5000,
 };
 
-/** Derive action limit from product_id stored in user_profiles */
+/** Derive action limit from product_id + status */
 function getActionLimit(productId: string | null, status: string | null): number {
-  // Expired trial or revoked → free limit
   if (!productId || !status || status === 'revoked' || status === 'incomplete_expired') {
     return AI_ACTION_LIMITS['free'];
   }
-  // Active trial for Pro
   if (productId === 'pro-trial' && status === 'trialing') {
     return AI_ACTION_LIMITS['pro-trial'];
   }
@@ -60,8 +59,12 @@ function currentMonthYear(): string {
   return `${now.getUTCFullYear()}-${month}`;
 }
 
-const VALID_ACTION_TYPES = ['smart_import', 'auto_name', 'auto_tag', 'chat_message'] as const;
-type ActionType = typeof VALID_ACTION_TYPES[number];
+/** Zod schema for the request body */
+const bodySchema = z.object({
+  actionType: z.enum(['smart_import', 'auto_name', 'auto_tag', 'chat_message']),
+  recordingId: z.string().uuid().optional(),
+  orgId: z.string().uuid().optional(),
+});
 
 Deno.serve(async (req) => {
   const corsHeaders = getCorsHeaders(req.headers.get('Origin'));
@@ -104,30 +107,27 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Parse request body
-    const body = await req.json() as { actionType?: unknown; recordingId?: unknown; orgId?: unknown };
-    const { actionType, recordingId, orgId } = body;
-
-    // Validate action type
-    if (!actionType || !VALID_ACTION_TYPES.includes(actionType as ActionType)) {
+    // Validate request body with Zod (validates UUIDs and enum values)
+    const parseResult = bodySchema.safeParse(await req.json());
+    if (!parseResult.success) {
+      const errorMessage = parseResult.error.errors[0]?.message ?? 'Invalid input';
       return new Response(
-        JSON.stringify({
-          error: `actionType must be one of: ${VALID_ACTION_TYPES.join(', ')}`,
-        }),
+        JSON.stringify({ error: errorMessage }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
+    const { actionType, recordingId, orgId: resolvedOrgId } = parseResult.data;
     const monthYear = currentMonthYear();
 
-    // Fetch user subscription state
+    // Fetch caller's subscription state (used for personal-tier limit)
     const { data: profile } = await supabase
       .from('user_profiles')
       .select('product_id, subscription_status, current_period_end')
       .eq('user_id', user.id)
       .maybeSingle();
 
-    // Check if trial has expired (handle expired trial as free)
+    // Check if personal trial has expired
     let effectiveProductId = profile?.product_id ?? null;
     let effectiveStatus = profile?.subscription_status ?? null;
 
@@ -138,7 +138,6 @@ Deno.serve(async (req) => {
     ) {
       const trialEnd = new Date(profile.current_period_end);
       if (trialEnd < new Date()) {
-        // Trial expired — treat as free
         effectiveProductId = null;
         effectiveStatus = null;
 
@@ -157,12 +156,14 @@ Deno.serve(async (req) => {
       }
     }
 
-    const limit = getActionLimit(effectiveProductId, effectiveStatus);
-
-    // Validate org membership before using orgId for pooled counting.
-    // Without this check, a user could pass any org's ID to consume their quota
-    // or benefit from a higher team limit they're not entitled to.
-    const resolvedOrgId = typeof orgId === 'string' && orgId ? orgId : null;
+    // Validate org membership and resolve org-level limit when orgId is provided.
+    // Security: without this check a user could pass any org's ID to consume their
+    // quota or benefit from a higher team limit they're not entitled to.
+    //
+    // Limit resolution: the org's Team subscription is owned by the org_owner, so we
+    // look up the owner's subscription — not the caller's — to get the correct pooled
+    // limit. This ensures all org members are gated by the Team 5,000 limit, not their
+    // own personal tier (which might be Free).
     if (resolvedOrgId) {
       const { data: membership } = await supabase
         .from('organization_memberships')
@@ -177,9 +178,29 @@ Deno.serve(async (req) => {
           { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
+
+      // Fetch the org owner's subscription to get the correct tier limit
+      const { data: ownerProfile } = await supabase
+        .from('organization_memberships')
+        .select('user_profiles!inner(product_id, subscription_status)')
+        .eq('organization_id', resolvedOrgId)
+        .eq('role', 'organization_owner')
+        .maybeSingle();
+
+      if (ownerProfile) {
+        // deno-lint-ignore no-explicit-any
+        const ownerData = (ownerProfile as any).user_profiles as {
+          product_id: string | null;
+          subscription_status: string | null;
+        } | null;
+        effectiveProductId = ownerData?.product_id ?? effectiveProductId;
+        effectiveStatus = ownerData?.subscription_status ?? effectiveStatus;
+      }
     }
 
-    // Count current month usage (org-level for team pooling, user-level otherwise)
+    const limit = getActionLimit(effectiveProductId, effectiveStatus);
+
+    // Count current month usage (org-level pooled or personal)
     let used: number;
     if (resolvedOrgId) {
       const { data: orgCount } = await supabase.rpc('get_monthly_org_ai_usage', {
@@ -213,9 +234,9 @@ Deno.serve(async (req) => {
       .from('ai_usage')
       .insert({
         user_id: user.id,
-        org_id: resolvedOrgId,
-        action_type: actionType as ActionType,
-        recording_id: (typeof recordingId === 'string' && recordingId) ? recordingId : null,
+        org_id: resolvedOrgId ?? null,
+        action_type: actionType,
+        recording_id: recordingId ?? null,
         month_year: monthYear,
       });
 

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -1,0 +1,213 @@
+/**
+ * Track AI Usage Edge Function
+ *
+ * Records an AI action for the authenticated user and enforces monthly limits.
+ * Returns whether the action was allowed and the updated usage count.
+ *
+ * POST /track-ai-usage
+ * Body: {
+ *   actionType: 'smart_import' | 'auto_name' | 'auto_tag' | 'chat_message'
+ *   recordingId?: string  // optional UUID reference
+ *   orgId?: string        // optional org UUID for team pooling
+ * }
+ * Returns: {
+ *   allowed: boolean
+ *   used: number
+ *   limit: number
+ *   remaining: number
+ * }
+ */
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/cors.ts';
+
+/** AI action limits per product tier */
+const AI_ACTION_LIMITS: Record<string, number> = {
+  'free': 25,
+  'pro-monthly': 1000,
+  'pro-annual': 1000,
+  'pro-trial': 1000,
+  'team-monthly': 5000,
+  'team-annual': 5000,
+};
+
+/** Derive action limit from product_id stored in user_profiles */
+function getActionLimit(productId: string | null, status: string | null): number {
+  // Expired trial or revoked → free limit
+  if (!productId || !status || status === 'revoked' || status === 'incomplete_expired') {
+    return AI_ACTION_LIMITS['free'];
+  }
+  // Active trial for Pro
+  if (productId === 'pro-trial' && status === 'trialing') {
+    return AI_ACTION_LIMITS['pro-trial'];
+  }
+  return AI_ACTION_LIMITS[productId] ?? AI_ACTION_LIMITS['free'];
+}
+
+/** Returns YYYY-MM string for the current month */
+function currentMonthYear(): string {
+  const now = new Date();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  return `${now.getUTCFullYear()}-${month}`;
+}
+
+const VALID_ACTION_TYPES = ['smart_import', 'auto_name', 'auto_tag', 'chat_message'] as const;
+type ActionType = typeof VALID_ACTION_TYPES[number];
+
+Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req.headers.get('Origin'));
+
+  // CORS Preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  // Only accept POST
+  if (req.method !== 'POST') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    // Initialize Supabase client with service role to bypass RLS for usage counting
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Authenticate user from JWT
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'No authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Parse request body
+    const body = await req.json() as { actionType?: unknown; recordingId?: unknown; orgId?: unknown };
+    const { actionType, recordingId, orgId } = body;
+
+    // Validate action type
+    if (!actionType || !VALID_ACTION_TYPES.includes(actionType as ActionType)) {
+      return new Response(
+        JSON.stringify({
+          error: `actionType must be one of: ${VALID_ACTION_TYPES.join(', ')}`,
+        }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const monthYear = currentMonthYear();
+
+    // Fetch user subscription state
+    const { data: profile } = await supabase
+      .from('user_profiles')
+      .select('product_id, subscription_status, current_period_end')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    // Check if trial has expired (handle expired trial as free)
+    let effectiveProductId = profile?.product_id ?? null;
+    let effectiveStatus = profile?.subscription_status ?? null;
+
+    if (
+      effectiveProductId === 'pro-trial' &&
+      effectiveStatus === 'trialing' &&
+      profile?.current_period_end
+    ) {
+      const trialEnd = new Date(profile.current_period_end);
+      if (trialEnd < new Date()) {
+        // Trial expired — treat as free
+        effectiveProductId = null;
+        effectiveStatus = null;
+
+        // Revert trial fields in background (non-blocking)
+        supabase
+          .from('user_profiles')
+          .update({ subscription_status: null, product_id: null, current_period_end: null })
+          .eq('user_id', user.id)
+          .then(() => {
+            console.log(`Trial expired for user ${user.id} — reverted to free`);
+          });
+      }
+    }
+
+    const limit = getActionLimit(effectiveProductId, effectiveStatus);
+
+    // Count current month usage
+    // For team orgs, count at org level if orgId provided
+    let used: number;
+    if (orgId && typeof orgId === 'string') {
+      const { data: orgCount } = await supabase.rpc('get_monthly_org_ai_usage', {
+        p_org_id: orgId,
+        p_month_year: monthYear,
+      });
+      used = (orgCount as number | null) ?? 0;
+    } else {
+      const { data: userCount } = await supabase.rpc('get_monthly_ai_usage', {
+        p_user_id: user.id,
+        p_month_year: monthYear,
+      });
+      used = (userCount as number | null) ?? 0;
+    }
+
+    const remaining = Math.max(0, limit - used);
+    const allowed = used < limit;
+
+    if (!allowed) {
+      console.log(`AI action blocked for user ${user.id}: ${used}/${limit} ${actionType}`);
+      return new Response(
+        JSON.stringify({ allowed: false, used, limit, remaining: 0 }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Record the action
+    const { error: insertError } = await supabase
+      .from('ai_usage')
+      .insert({
+        user_id: user.id,
+        org_id: (typeof orgId === 'string' && orgId) ? orgId : null,
+        action_type: actionType as ActionType,
+        recording_id: (typeof recordingId === 'string' && recordingId) ? recordingId : null,
+        month_year: monthYear,
+      });
+
+    if (insertError) {
+      console.error('Error recording AI usage:', insertError);
+      // Don't block the action if tracking fails — still allow it
+    }
+
+    console.log(`AI action recorded for user ${user.id}: ${actionType} (${used + 1}/${limit})`);
+
+    return new Response(
+      JSON.stringify({
+        allowed: true,
+        used: used + 1,
+        limit,
+        remaining: remaining - 1,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('track-ai-usage error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(
+      JSON.stringify({ error: errorMessage }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -16,6 +16,15 @@
  *   limit: number
  *   remaining: number
  * }
+ *
+ * NOTE on concurrency: The check-then-insert pattern has a known soft TOCTOU race.
+ * Two simultaneous requests can both read `used < limit` and both insert, allowing
+ * a user to slightly exceed their monthly limit in burst scenarios (e.g., batch imports).
+ * This is intentional: limits are soft caps, not hard financial guarantees.
+ * The window is small (single-user burst) and the over-count is bounded by concurrency.
+ * If hard enforcement is needed in the future, replace with an atomic SQL INSERT
+ * conditional on a sub-select count — e.g.:
+ *   INSERT INTO ai_usage (...) SELECT ... WHERE (SELECT COUNT(*) ... < limit)
  */
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
@@ -44,7 +53,7 @@ function getActionLimit(productId: string | null, status: string | null): number
   return AI_ACTION_LIMITS[productId] ?? AI_ACTION_LIMITS['free'];
 }
 
-/** Returns YYYY-MM string for the current month */
+/** Returns YYYY-MM string for the current month in UTC */
 function currentMonthYear(): string {
   const now = new Date();
   const month = String(now.getUTCMonth() + 1).padStart(2, '0');
@@ -133,25 +142,48 @@ Deno.serve(async (req) => {
         effectiveProductId = null;
         effectiveStatus = null;
 
-        // Revert trial fields in background (non-blocking)
+        // Revert trial fields — log any failure so it's observable
         supabase
           .from('user_profiles')
           .update({ subscription_status: null, product_id: null, current_period_end: null })
           .eq('user_id', user.id)
-          .then(() => {
-            console.log(`Trial expired for user ${user.id} — reverted to free`);
+          .then(({ error: revertError }) => {
+            if (revertError) {
+              console.error(`Failed to revert expired trial for user ${user.id}:`, revertError);
+            } else {
+              console.log(`Trial expired for user ${user.id} — reverted to free`);
+            }
           });
       }
     }
 
     const limit = getActionLimit(effectiveProductId, effectiveStatus);
 
-    // Count current month usage
-    // For team orgs, count at org level if orgId provided
+    // Validate org membership before using orgId for pooled counting.
+    // Without this check, a user could pass any org's ID to consume their quota
+    // or benefit from a higher team limit they're not entitled to.
+    const resolvedOrgId = typeof orgId === 'string' && orgId ? orgId : null;
+    if (resolvedOrgId) {
+      const { data: membership } = await supabase
+        .from('organization_memberships')
+        .select('id')
+        .eq('organization_id', resolvedOrgId)
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (!membership) {
+        return new Response(
+          JSON.stringify({ error: 'Not a member of this organization' }),
+          { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    // Count current month usage (org-level for team pooling, user-level otherwise)
     let used: number;
-    if (orgId && typeof orgId === 'string') {
+    if (resolvedOrgId) {
       const { data: orgCount } = await supabase.rpc('get_monthly_org_ai_usage', {
-        p_org_id: orgId,
+        p_org_id: resolvedOrgId,
         p_month_year: monthYear,
       });
       used = (orgCount as number | null) ?? 0;
@@ -174,12 +206,14 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Record the action
+    // Record the action.
+    // Note: there is a soft TOCTOU race between the count check above and this
+    // insert — see the file-level comment for details and the chosen trade-off.
     const { error: insertError } = await supabase
       .from('ai_usage')
       .insert({
         user_id: user.id,
-        org_id: (typeof orgId === 'string' && orgId) ? orgId : null,
+        org_id: resolvedOrgId,
         action_type: actionType as ActionType,
         recording_id: (typeof recordingId === 'string' && recordingId) ? recordingId : null,
         month_year: monthYear,

--- a/supabase/migrations/20260309000001_ai_credits_system.sql
+++ b/supabase/migrations/20260309000001_ai_credits_system.sql
@@ -1,0 +1,174 @@
+-- Migration: AI Credits System
+-- Purpose: Track AI actions per user/org for usage limiting (Free/Pro/Team tiers)
+-- Implements: Issue #156 - AI credits system and Polar.sh pricing tiers
+-- Date: 2026-03-09
+
+-- ============================================================================
+-- TABLE: ai_usage
+-- ============================================================================
+-- Tracks each AI action consumed by a user. Used for monthly limit enforcement.
+-- action_type maps to: smart_import, auto_name, auto_tag, chat_message
+-- month_year (YYYY-MM) is denormalized for efficient monthly aggregation queries.
+
+CREATE TABLE IF NOT EXISTS public.ai_usage (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  org_id      UUID        REFERENCES public.organizations(id) ON DELETE SET NULL,
+  action_type TEXT        NOT NULL,
+  recording_id UUID       REFERENCES public.recordings(id) ON DELETE SET NULL,
+  month_year  TEXT        NOT NULL, -- 'YYYY-MM' e.g. '2026-03'
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT ai_usage_action_type_check CHECK (
+    action_type IN ('smart_import', 'auto_name', 'auto_tag', 'chat_message')
+  )
+);
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_ai_usage_user_month
+  ON ai_usage(user_id, month_year);
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_org_month
+  ON ai_usage(org_id, month_year)
+  WHERE org_id IS NOT NULL;
+
+-- ============================================================================
+-- ROW LEVEL SECURITY (RLS)
+-- ============================================================================
+ALTER TABLE ai_usage ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own AI usage"
+  ON ai_usage FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own AI usage"
+  ON ai_usage FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================================
+-- FUNCTION: get_monthly_ai_usage
+-- ============================================================================
+-- Returns the count of AI actions for a given user in a given month.
+-- Called by the track-ai-usage edge function (which runs as service role).
+
+CREATE OR REPLACE FUNCTION public.get_monthly_ai_usage(
+  p_user_id   UUID,
+  p_month_year TEXT
+)
+RETURNS INTEGER
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COUNT(*)::INTEGER
+  FROM ai_usage
+  WHERE user_id = p_user_id
+    AND month_year = p_month_year;
+$$;
+
+-- ============================================================================
+-- FUNCTION: get_monthly_org_ai_usage
+-- ============================================================================
+-- Returns the pooled count for a team org (Team tier: 5,000 shared actions).
+
+CREATE OR REPLACE FUNCTION public.get_monthly_org_ai_usage(
+  p_org_id     UUID,
+  p_month_year TEXT
+)
+RETURNS INTEGER
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COUNT(*)::INTEGER
+  FROM ai_usage
+  WHERE org_id = p_org_id
+    AND month_year = p_month_year;
+$$;
+
+-- ============================================================================
+-- UPDATE SIGNUP TRIGGER: Add 14-day Pro trial for new users
+-- ============================================================================
+-- New users start with a 14-day Pro trial (product_id = 'pro-trial',
+-- subscription_status = 'trialing', current_period_end = NOW() + 14 days).
+-- When the trial ends, product_id reverts to NULL (Free tier).
+-- This replaces the function defined in 20260301000001_rename_vaults_to_workspaces.sql.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_organization_id UUID;
+  v_workspace_id    UUID;
+  v_trial_end       TIMESTAMPTZ;
+BEGIN
+  v_trial_end := NOW() + INTERVAL '14 days';
+
+  -- Insert profile with 14-day Pro trial
+  INSERT INTO public.user_profiles (
+    user_id,
+    email,
+    display_name,
+    onboarding_completed,
+    subscription_status,
+    product_id,
+    current_period_end
+  )
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'display_name', NEW.email),
+    false,
+    'trialing',
+    'pro-trial',
+    v_trial_end
+  );
+
+  -- Assign default FREE role
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (NEW.id, 'FREE')
+  ON CONFLICT (user_id, role) DO NOTHING;
+
+  -- Create personal organization
+  INSERT INTO organizations (name, type)
+  VALUES ('Personal', 'personal')
+  RETURNING id INTO v_organization_id;
+
+  -- Create org membership as owner
+  INSERT INTO organization_memberships (organization_id, user_id, role)
+  VALUES (v_organization_id, NEW.id, 'organization_owner');
+
+  -- Create default personal workspace
+  INSERT INTO workspaces (organization_id, name, workspace_type, is_default, is_home)
+  VALUES (v_organization_id, 'My Calls', 'personal', TRUE, TRUE)
+  RETURNING id INTO v_workspace_id;
+
+  -- Create workspace membership as owner
+  INSERT INTO workspace_memberships (workspace_id, user_id, role)
+  VALUES (v_workspace_id, NEW.id, 'workspace_owner');
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_new_user() IS
+  'Creates user profile (with 14-day Pro trial), FREE role, personal organization, and personal workspace on signup';
+
+-- ============================================================================
+-- COMMENTS
+-- ============================================================================
+COMMENT ON TABLE ai_usage IS 'Tracks AI actions per user/org for monthly limit enforcement';
+COMMENT ON COLUMN ai_usage.action_type IS 'Type: smart_import | auto_name | auto_tag | chat_message';
+COMMENT ON COLUMN ai_usage.month_year IS 'YYYY-MM format for efficient monthly aggregation';
+COMMENT ON COLUMN ai_usage.org_id IS 'Set for team accounts to enable pooled org-level counting';
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================

--- a/supabase/migrations/20260309000001_ai_credits_system.sql
+++ b/supabase/migrations/20260309000001_ai_credits_system.sql
@@ -51,6 +51,8 @@ CREATE POLICY "Users can insert their own AI usage"
 -- FUNCTION: get_monthly_ai_usage
 -- ============================================================================
 -- Returns the count of AI actions for a given user in a given month.
+-- Only counts personal actions (org_id IS NULL) so that org-context actions
+-- are not double-counted against the user's personal limit.
 -- Called by the track-ai-usage edge function (which runs as service role).
 
 CREATE OR REPLACE FUNCTION public.get_monthly_ai_usage(
@@ -66,7 +68,8 @@ AS $$
   SELECT COUNT(*)::INTEGER
   FROM ai_usage
   WHERE user_id = p_user_id
-    AND month_year = p_month_year;
+    AND month_year = p_month_year
+    AND org_id IS NULL;
 $$;
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

- **New pricing tiers**: Free ($0) / Pro ($29/mo, $278/yr) / Team ($79/mo, $758/yr) replacing the old Solo/Team/Business structure
- **AI usage tracking**: New `ai_usage` table + `track-ai-usage` edge function that records AI actions and enforces monthly limits (Free: 25, Pro: 1,000, Team: 5,000 pooled)
- **14-day Pro trial**: `handle_new_user()` trigger updated — new signups start with `subscription_status=trialing`, `product_id=pro-trial`, `current_period_end=NOW()+14days`
- **Usage bar**: `AiUsageBar` component shows used/limit with colour-coded progress and inline upgrade CTA when limit is reached
- **Enforcement**: `useAiUsage.trackAction()` calls the edge function before any AI action — returns `allowed: false` when limit exceeded

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260309000001_ai_credits_system.sql` | `ai_usage` table, RLS, helper functions, updated signup trigger |
| `supabase/functions/track-ai-usage/index.ts` | New edge function — checks + records AI actions |
| `src/hooks/useSubscription.ts` | New tiers, `aiActionsLimit`, `importLimit`, `isTrialing` |
| `src/hooks/useAiUsage.ts` | New hook — fetches month count, exposes `trackAction()` |
| `src/components/billing/AiUsageBar.tsx` | New — progress bar with upgrade CTA |
| `src/components/billing/PlanCards.tsx` | Updated pricing, trial banner, Free card |
| `src/components/settings/BillingTab.tsx` | Uses new tiers, adds AiUsageBar usage section |

## Test plan

- [ ] New user signup → `user_profiles` has `subscription_status=trialing`, `product_id=pro-trial`, `current_period_end=14 days from now`
- [ ] Pro trial: AI action limit = 1,000; Free: limit = 25
- [ ] `track-ai-usage` returns `allowed: false` when monthly count ≥ limit
- [ ] `AiUsageBar` shows correct used/limit; turns red at 100%; shows upgrade CTA
- [ ] `PlanCards` renders Free/Pro/Team with correct prices; trial badge on Pro card for trialing users
- [ ] After trial expires, `deriveTier()` returns `'free'`, edge function reverts DB fields

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)