### PR TITLE
feat(154): YouTube transcript display — timestamps, paragraph breaks, readable formatting

### DIFF
--- a/src/components/call-detail/CallTranscriptTab.tsx
+++ b/src/components/call-detail/CallTranscriptTab.tsx
@@ -241,16 +241,39 @@ export const CallTranscriptTab = memo(function CallTranscriptTab({
                   <div className="space-y-6 py-4 px-4 bg-card">
                     {transcripts && transcripts.length > 0 ? (
                       (() => {
+                        // YouTube source: speaker-less paragraph view with timestamps
+                        const isYouTubeSource =
+                          call.source_platform === 'youtube' ||
+                          (transcripts.length > 0 && transcripts.every(t => t.speaker_name === ''));
+
+                        if (isYouTubeSource) {
+                          return (
+                            <div className="space-y-1">
+                              {transcripts.map((segment, idx) => (
+                                <div key={segment.id || idx} className="flex gap-3 py-2 border-b border-border/30 last:border-0">
+                                  <span className="shrink-0 w-11 text-right text-[11px] font-mono text-ink-muted mt-[3px] select-none">
+                                    {segment.timestamp}
+                                  </span>
+                                  <p className="flex-1 text-[15px] leading-[22px] text-ink">
+                                    {segment.display_text}
+                                  </p>
+                                </div>
+                              ))}
+                            </div>
+                          );
+                        }
+
+                        // Standard Fathom/Zoom source: chat bubble view
                         // Determine identifiers for the current user ("Andrew")
                         // 1. Current Auth User ID (strongest match if mapped in DB)
                         const currentUserId = user?.id || null;
-                        
+
                         // 2. Explicit host email from settings (A@VIBEOS.COM or ANDREW@AISIMPLE.CO)
                         const settingsHostEmail = userSettings?.host_email?.toLowerCase() || null;
-                        
+
                         // 3. Email from the call record
                         const callHostEmail = call.recorded_by_email?.toLowerCase() || null;
-                        
+
                         // 4. Name from the call record (Andrew Naegele -> Andrew)
                         const callHostName = call.recorded_by_name?.toLowerCase() || "";
                         const firstName = callHostName.split(' ')[0] || "";

--- a/src/components/youtube/YouTubeVideoDetailModal.tsx
+++ b/src/components/youtube/YouTubeVideoDetailModal.tsx
@@ -12,7 +12,7 @@
  * @brand-version v4.2
  */
 
-import { useState, useMemo, Fragment } from 'react'
+import { useState, useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import {
   Dialog,
@@ -231,16 +231,14 @@ export function YouTubeVideoDetailModal({
                     // Parsed YouTube format: timestamped paragraphs
                     <div className="space-y-0.5">
                       {transcriptSegments.map((seg, idx) => (
-                        <Fragment key={seg.id || idx}>
-                          <div className="flex gap-3 py-1.5 border-b border-border/20 last:border-0">
-                            <span className="shrink-0 w-10 text-right text-[11px] font-mono text-muted-foreground/70 mt-[2px] select-none">
-                              {seg.timestamp}
-                            </span>
-                            <p className="flex-1 text-sm text-foreground/85 leading-relaxed">
-                              {seg.text}
-                            </p>
-                          </div>
-                        </Fragment>
+                        <div key={seg.id || idx} className="flex gap-3 py-1.5 border-b border-border/20 last:border-0">
+                          <span className="shrink-0 w-10 text-right text-[11px] font-mono text-muted-foreground/70 mt-[2px] select-none">
+                            {seg.timestamp}
+                          </span>
+                          <p className="flex-1 text-sm text-foreground/85 leading-relaxed">
+                            {seg.text}
+                          </p>
+                        </div>
                       ))}
                     </div>
                   ) : (

--- a/src/components/youtube/YouTubeVideoDetailModal.tsx
+++ b/src/components/youtube/YouTubeVideoDetailModal.tsx
@@ -12,7 +12,7 @@
  * @brand-version v4.2
  */
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, Fragment } from 'react'
 import { cn } from '@/lib/utils'
 import {
   Dialog,
@@ -31,6 +31,7 @@ import {
 } from '@remixicon/react'
 import { getYouTubeMetadata } from '@/types/youtube'
 import { parseYouTubeDuration, formatCompactNumber, YOUTUBE_CATEGORIES } from '@/lib/youtube-utils'
+import { parseYouTubeTranscript, isYouTubeTranscriptFormat } from '@/lib/transcriptUtils'
 import type { WorkspaceRecording } from '@/hooks/useWorkspaces'
 
 export interface YouTubeVideoDetailModalProps {
@@ -95,6 +96,14 @@ export function YouTubeVideoDetailModal({
   const hasDescription = description.trim().length > 0
   const transcript = recording?.full_transcript || ''
   const hasTranscript = transcript.trim().length > 0
+
+  // Parse transcript into timestamped segments if in YouTube format
+  const transcriptSegments = useMemo(() => {
+    if (!hasTranscript) return null
+    if (!isYouTubeTranscriptFormat(transcript)) return null
+    const segments = parseYouTubeTranscript(transcript, recording?.id)
+    return segments.length > 0 ? segments : null
+  }, [transcript, hasTranscript, recording?.id])
 
   // Reset description expanded state when recording changes
   const handleOpenChange = (nextOpen: boolean) => {
@@ -218,9 +227,28 @@ export function YouTubeVideoDetailModal({
               </h4>
               {hasTranscript ? (
                 <div className="max-h-[300px] overflow-y-auto rounded-md border border-border/40 bg-muted/30 p-3">
-                  <p className="text-sm text-foreground/85 whitespace-pre-line leading-relaxed">
-                    {transcript}
-                  </p>
+                  {transcriptSegments ? (
+                    // Parsed YouTube format: timestamped paragraphs
+                    <div className="space-y-0.5">
+                      {transcriptSegments.map((seg, idx) => (
+                        <Fragment key={seg.id || idx}>
+                          <div className="flex gap-3 py-1.5 border-b border-border/20 last:border-0">
+                            <span className="shrink-0 w-10 text-right text-[11px] font-mono text-muted-foreground/70 mt-[2px] select-none">
+                              {seg.timestamp}
+                            </span>
+                            <p className="flex-1 text-sm text-foreground/85 leading-relaxed">
+                              {seg.text}
+                            </p>
+                          </div>
+                        </Fragment>
+                      ))}
+                    </div>
+                  ) : (
+                    // Fallback: raw text display
+                    <p className="text-sm text-foreground/85 whitespace-pre-line leading-relaxed">
+                      {transcript}
+                    </p>
+                  )}
                 </div>
               ) : (
                 <p className="text-sm text-muted-foreground italic">No transcript available</p>

--- a/src/hooks/useCallDetailQueries.ts
+++ b/src/hooks/useCallDetailQueries.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { groupTranscriptsBySpeaker } from "@/lib/transcriptUtils";
+import { groupTranscriptsBySpeaker, parseYouTubeTranscript, isYouTubeTranscriptFormat } from "@/lib/transcriptUtils";
 import { logger } from "@/lib/logger";
 import { queryKeys } from "@/lib/query-config";
 import { Meeting, TranscriptSegment, TranscriptSegmentDisplay, Speaker, Category } from "@/types";
@@ -148,6 +148,13 @@ export function useCallDetailQueries(options: UseCallDetailQueriesOptions): UseC
               segment.speaker_email = email;
             }
           });
+        }
+
+        // If the Fathom/Zoom regex found no segments, try YouTube format
+        if (segments.length === 0 && isYouTubeTranscriptFormat(fullTranscript)) {
+          const ytSegments = parseYouTubeTranscript(fullTranscript, call.recording_id);
+          logger.info(`Parsed ${ytSegments.length} YouTube transcript segments`);
+          return ytSegments;
         }
 
         logger.info(`Parsed ${segments.length} segments with ${speakerEmailMap.size} speaker email mappings`);

--- a/src/lib/__tests__/transcriptUtils.test.ts
+++ b/src/lib/__tests__/transcriptUtils.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { parseYouTubeTranscript, isYouTubeTranscriptFormat } from '../transcriptUtils';
+
+describe('isYouTubeTranscriptFormat', () => {
+  it('returns true for YouTube-format transcript', () => {
+    const transcript = `[0:00]
+Hello and welcome to this video
+more text here
+
+[0:30]
+next section text
+continues here`;
+    expect(isYouTubeTranscriptFormat(transcript)).toBe(true);
+  });
+
+  it('returns false for Fathom/Zoom format transcript', () => {
+    const transcript = `[00:00:08] Andrew Naegele: Hello this is a test
+[00:00:15] Other Person: Yes I agree with that`;
+    expect(isYouTubeTranscriptFormat(transcript)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isYouTubeTranscriptFormat('')).toBe(false);
+  });
+
+  it('handles hour-long YouTube videos', () => {
+    const transcript = `[1:00:00]
+text at one hour`;
+    expect(isYouTubeTranscriptFormat(transcript)).toBe(true);
+  });
+});
+
+describe('parseYouTubeTranscript', () => {
+  it('parses basic YouTube transcript into segments', () => {
+    const transcript = `[0:00]
+Hello and welcome to this video
+more text here
+
+[0:30]
+next section text
+continues here`;
+
+    const segments = parseYouTubeTranscript(transcript, 123);
+    expect(segments).toHaveLength(2);
+    expect(segments[0].timestamp).toBe('0:00');
+    expect(segments[0].text).toBe('Hello and welcome to this video more text here');
+    expect(segments[1].timestamp).toBe('0:30');
+    expect(segments[1].text).toBe('next section text continues here');
+  });
+
+  it('sets speaker_name to empty string for all segments', () => {
+    const transcript = `[0:00]
+some text`;
+    const segments = parseYouTubeTranscript(transcript, 'uuid-123');
+    expect(segments[0].speaker_name).toBe('');
+    expect(segments[0].speaker_email).toBeNull();
+  });
+
+  it('assigns unique ids to segments', () => {
+    const transcript = `[0:00]
+first
+[0:30]
+second`;
+    const segments = parseYouTubeTranscript(transcript, 1);
+    expect(segments[0].id).toBe('yt-0');
+    expect(segments[1].id).toBe('yt-1');
+  });
+
+  it('returns empty array for transcript with no timestamps', () => {
+    const transcript = 'just plain text with no timestamps';
+    expect(parseYouTubeTranscript(transcript, 1)).toHaveLength(0);
+  });
+
+  it('skips empty text blocks between timestamps', () => {
+    const transcript = `[0:00]
+
+[0:30]
+actual content here`;
+    const segments = parseYouTubeTranscript(transcript, 1);
+    expect(segments).toHaveLength(1);
+    expect(segments[0].timestamp).toBe('0:30');
+  });
+
+  it('handles hour-format timestamps', () => {
+    const transcript = `[1:00:00]
+text at one hour
+[1:00:30]
+more text`;
+    const segments = parseYouTubeTranscript(transcript, 1);
+    expect(segments).toHaveLength(2);
+    expect(segments[0].timestamp).toBe('1:00:00');
+    expect(segments[1].timestamp).toBe('1:00:30');
+  });
+
+  it('marks segments as not deleted and without edits', () => {
+    const transcript = `[0:00]
+some text`;
+    const segments = parseYouTubeTranscript(transcript, 1);
+    expect(segments[0].is_deleted).toBe(false);
+    expect(segments[0].edited_text).toBeNull();
+    expect(segments[0].edited_speaker_name).toBeNull();
+  });
+});

--- a/src/lib/__tests__/transcriptUtils.test.ts
+++ b/src/lib/__tests__/transcriptUtils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { parseYouTubeTranscript, isYouTubeTranscriptFormat } from '../transcriptUtils';
 
 describe('isYouTubeTranscriptFormat', () => {
-  it('returns true for YouTube-format transcript', () => {
+  it('returns true for YouTube 2-part [M:SS] format', () => {
     const transcript = `[0:00]
 Hello and welcome to this video
 more text here
@@ -13,20 +13,36 @@ continues here`;
     expect(isYouTubeTranscriptFormat(transcript)).toBe(true);
   });
 
-  it('returns false for Fathom/Zoom format transcript', () => {
+  it('returns false for Fathom/Zoom [HH:MM:SS] format with speakers', () => {
     const transcript = `[00:00:08] Andrew Naegele: Hello this is a test
 [00:00:15] Other Person: Yes I agree with that`;
     expect(isYouTubeTranscriptFormat(transcript)).toBe(false);
+  });
+
+  it('returns false for malformed Fathom transcript missing speaker labels', () => {
+    // Key regression case: [HH:MM:SS] format without speakers should NOT be detected
+    // as YouTube just because speakers are missing — the 3-part zero-padded format
+    // is structurally distinct from YouTube's 2-part [M:SS] format.
+    const malformedFathom = `[00:00:08]
+some transcript text without a speaker label
+[00:00:45]
+more text here`;
+    expect(isYouTubeTranscriptFormat(malformedFathom)).toBe(false);
   });
 
   it('returns false for empty string', () => {
     expect(isYouTubeTranscriptFormat('')).toBe(false);
   });
 
-  it('handles hour-long YouTube videos', () => {
+  it('returns true for YouTube over-1-hour format [H:MM:SS] with single-digit hour', () => {
     const transcript = `[1:00:00]
 text at one hour`;
     expect(isYouTubeTranscriptFormat(transcript)).toBe(true);
+  });
+
+  it('returns false for Fathom over-1-hour format [HH:MM:SS] with zero-padded hour', () => {
+    const transcript = `[01:00:00] Speaker: text at one hour`;
+    expect(isYouTubeTranscriptFormat(transcript)).toBe(false);
   });
 });
 

--- a/src/lib/transcriptUtils.ts
+++ b/src/lib/transcriptUtils.ts
@@ -9,6 +9,11 @@ export interface TranscriptSegment {
   speaker_email?: string | null;
   text?: string;
   timestamp?: string;
+  edited_text?: string | null;
+  edited_speaker_name?: string | null;
+  edited_speaker_email?: string | null;
+  is_deleted?: boolean;
+  created_at?: string;
   display_text?: string;
   display_speaker_name?: string;
   display_speaker_email?: string | null;
@@ -45,6 +50,84 @@ export function groupTranscriptsBySpeaker(transcripts: TranscriptSegment[]): Spe
   }
 
   return groups;
+}
+
+/**
+ * Parses a YouTube-format full_transcript into display segments.
+ *
+ * YouTube transcripts are stored as plain text with [M:SS] or [H:MM:SS]
+ * timestamp markers every ~30 seconds, followed by phrase lines:
+ *
+ *   [0:00]
+ *   first phrase here
+ *   second phrase here
+ *
+ *   [0:30]
+ *   next section text
+ *
+ * Returns one TranscriptSegment per timestamp block with text joined into a paragraph.
+ * Sets speaker_name to '' (empty) to signal no speaker attribution.
+ */
+export function parseYouTubeTranscript(
+  fullTranscript: string,
+  recordingId: number | string | undefined,
+): TranscriptSegment[] {
+  const segments: TranscriptSegment[] = [];
+  // Matches [M:SS] or [H:MM:SS] — YouTube timestamps don't zero-pad minutes
+  const timestampRe = /\[(\d{1,2}:\d{2}(?::\d{2})?)\]/g;
+  let lastTimestamp: string | null = null;
+  let lastIndex = 0;
+  let segIdx = 0;
+  let match: RegExpExecArray | null;
+
+  const pushSegment = (timestamp: string, rawText: string) => {
+    const text = rawText
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l.length > 0)
+      .join(' ')
+      .trim();
+    if (text) {
+      segments.push({
+        id: `yt-${segIdx++}`,
+        recording_id: recordingId as number,
+        timestamp,
+        speaker_name: '',
+        speaker_email: null,
+        text,
+        edited_text: null,
+        edited_speaker_name: null,
+        edited_speaker_email: null,
+        is_deleted: false,
+        created_at: new Date().toISOString(),
+      });
+    }
+  };
+
+  while ((match = timestampRe.exec(fullTranscript)) !== null) {
+    if (lastTimestamp !== null) {
+      pushSegment(lastTimestamp, fullTranscript.slice(lastIndex, match.index));
+    }
+    lastTimestamp = match[1];
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastTimestamp !== null) {
+    pushSegment(lastTimestamp, fullTranscript.slice(lastIndex));
+  }
+
+  return segments;
+}
+
+/**
+ * Returns true if the transcript string is in YouTube format.
+ * YouTube format has [M:SS] markers but no "Speaker Name: text" lines.
+ */
+export function isYouTubeTranscriptFormat(transcript: string): boolean {
+  const hasTimestampMarkers = /\[\d{1,2}:\d{2}(?::\d{2})?\]/.test(transcript);
+  // Standard Fathom/Zoom format has "Speaker: text" after an [HH:MM:SS] header
+  const hasStandardSpeakerFormat = /\[\d{2}:\d{2}:\d{2}\]\s+\S[^:\n]*:/.test(transcript);
+  return hasTimestampMarkers && !hasStandardSpeakerFormat;
 }
 
 /**

--- a/src/lib/transcriptUtils.ts
+++ b/src/lib/transcriptUtils.ts
@@ -90,7 +90,7 @@ export function parseYouTubeTranscript(
     if (text) {
       segments.push({
         id: `yt-${segIdx++}`,
-        recording_id: recordingId as number,
+        recording_id: recordingId,
         timestamp,
         speaker_name: '',
         speaker_email: null,
@@ -121,13 +121,25 @@ export function parseYouTubeTranscript(
 
 /**
  * Returns true if the transcript string is in YouTube format.
- * YouTube format has [M:SS] markers but no "Speaker Name: text" lines.
+ *
+ * YouTube and Fathom/Zoom use structurally different timestamp formats:
+ *   - YouTube (under 1 hour): [M:SS]  — 2-part, e.g. [0:30], [12:45]
+ *   - YouTube (over 1 hour):  [H:MM:SS] — 3-part, single-digit hour, e.g. [1:00:00]
+ *   - Fathom/Zoom:            [HH:MM:SS] — 3-part, always zero-padded, e.g. [00:00:08]
+ *
+ * The 2-part [M:SS] pattern is unambiguous — Fathom never produces it.
+ * The single-digit-hour [H:MM:SS] pattern is also unique to YouTube (Fathom
+ * would produce [01:00:00] not [1:00:00]).
+ * This avoids relying on the presence of speaker labels, which may be absent in
+ * malformed or partial Fathom transcripts.
  */
 export function isYouTubeTranscriptFormat(transcript: string): boolean {
-  const hasTimestampMarkers = /\[\d{1,2}:\d{2}(?::\d{2})?\]/.test(transcript);
-  // Standard Fathom/Zoom format has "Speaker: text" after an [HH:MM:SS] header
-  const hasStandardSpeakerFormat = /\[\d{2}:\d{2}:\d{2}\]\s+\S[^:\n]*:/.test(transcript);
-  return hasTimestampMarkers && !hasStandardSpeakerFormat;
+  // 2-part [M:SS]: uniquely YouTube — Fathom always uses 3-part [HH:MM:SS]
+  const hasTwoPart = /\[\d{1,2}:\d{2}\]/.test(transcript);
+  // 3-part [H:MM:SS] with a single-digit hour: YouTube over 1 hour
+  // (Fathom zero-pads to [HH:MM:SS], so single-digit hour can only be YouTube)
+  const hasThreePartSingleHour = /\[\d:\d{2}:\d{2}\]/.test(transcript);
+  return hasTwoPart || hasThreePartSingleHour;
 }
 
 /**


### PR DESCRIPTION
## Summary

- YouTube transcripts were showing "No conversation available" because the Fathom/Zoom regex (`[HH:MM:SS] Speaker: text`) found zero matches in YouTube's `[M:SS]` timestamp format
- Added `parseYouTubeTranscript()` and `isYouTubeTranscriptFormat()` to `transcriptUtils.ts` to detect and parse YouTube-format transcripts into clean, readable segments
- `CallTranscriptTab` now shows a timestamped paragraph view (no chat bubbles) for YouTube content
- `YouTubeVideoDetailModal` now displays the transcript as timestamped paragraphs instead of raw text with `[0:30]` markers visible in the prose

## Changes

- **`src/lib/transcriptUtils.ts`**: Add `parseYouTubeTranscript()` — splits on `[M:SS]`/`[H:MM:SS]` markers, joins phrase lines into readable paragraphs per block. Add `isYouTubeTranscriptFormat()` for format detection.
- **`src/hooks/useCallDetailQueries.ts`**: Fall back to YouTube parser when the Fathom/Zoom regex finds 0 segments and the transcript is in YouTube format.
- **`src/components/call-detail/CallTranscriptTab.tsx`**: Render a timeline-style view (timestamp + paragraph) instead of speaker chat bubbles when all segments have no speaker name (YouTube source).
- **`src/components/youtube/YouTubeVideoDetailModal.tsx`**: Parse and display transcript as timestamped paragraphs with a clean monospace timestamp column.
- **`src/lib/__tests__/transcriptUtils.test.ts`**: Unit tests for new utility functions.

## Test plan

- [ ] Import a YouTube video — transcript tab should show timestamped paragraphs, not "No conversation available"
- [ ] Verify `[0:00]`, `[0:30]` markers are shown as clean timestamp badges, not embedded in text
- [ ] Open a Fathom/Zoom call — speaker bubble layout should be unchanged
- [ ] Open `YouTubeVideoDetailModal` — transcript section shows timestamped paragraphs, not raw text
- [ ] Run `npm run type-check` — no errors

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)