### PR TITLE
fix: workspace view shows recent calls first (#162)

### DIFF
--- a/src/components/transcripts/TranscriptsTab.tsx
+++ b/src/components/transcripts/TranscriptsTab.tsx
@@ -120,9 +120,11 @@ export function TranscriptsTab({
   const workspaceColumns = { date: true, duration: true, participants: true, tags: true, folders: true, workspaces: true, sharedWith: true };
   const [visibleColumns, setVisibleColumns] = useState<Record<string, boolean>>(isHomeView ? homeColumns : workspaceColumns);
 
-  // Reset column defaults when switching between home and workspace views
+  // Reset column defaults and filters when switching workspaces
   useEffect(() => {
     setVisibleColumns(isHomeView ? homeColumns : workspaceColumns);
+    setFilters({});
+    setSelectedCalls([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeWorkspaceId]);
 
@@ -376,6 +378,7 @@ export function TranscriptsTab({
         }
 
         const { data: entries, error: entryError, count } = await entryQuery
+          .order('created_at', { ascending: false })
           .order('created_at', { ascending: false, referencedTable: 'recordings' })
           .range(offset, offset + pageSize - 1);
 


### PR DESCRIPTION
## Summary
- **Root cause:** The workspace query in `TranscriptsTab.tsx` used `.order('created_at', { referencedTable: 'recordings' })` which only sorts nested recording data within each workspace_entry row — PostgREST does not use referenced table ordering for the parent row sort. The parent `workspace_entries` rows were returned in default insertion order (oldest first).
- **Fix:** Added `.order('created_at', { ascending: false })` on the parent `workspace_entries` table so the SQL ORDER BY applies to the actual result set pagination.
- **Bonus:** Reset filters and selection state when switching workspaces to prevent stale date filters from carrying over.

## Test plan
- [ ] Navigate to "My Calls" workspace — should show 2026 calls first, not 2024
- [ ] Switch between workspaces — filters should reset (no stale date range)
- [ ] Verify "All Calls" home view still works (unchanged code path)
- [ ] Page through results in a workspace — pagination should respect date desc order

🤖 Generated with [Claude Code](https://claude.com/claude-code)