### PR TITLE
Rename Participants to Contacts in filter UI

### DIFF
--- a/src/components/transcript-library/ContactsFilterPopover.tsx
+++ b/src/components/transcript-library/ContactsFilterPopover.tsx
@@ -6,17 +6,17 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Checkbox } from "@/components/ui/checkbox";
 import { FilterButton } from "./FilterButton";
 
-interface ParticipantsFilterPopoverProps {
+interface ContactsFilterPopoverProps {
   selectedParticipants?: string[];
   allParticipants: string[];
   onParticipantsChange: (participants: string[]) => void;
 }
 
-export function ParticipantsFilterPopover({
+export function ContactsFilterPopover({
   selectedParticipants = [],
   allParticipants,
   onParticipantsChange,
-}: ParticipantsFilterPopoverProps) {
+}: ContactsFilterPopoverProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -46,7 +46,7 @@ export function ParticipantsFilterPopover({
       <PopoverTrigger asChild>
         <FilterButton
           icon={<RiUserLine className="h-3.5 w-3.5" />}
-          label="Participants"
+          label="Contacts"
           count={selectedParticipants.length}
           active={selectedParticipants.length > 0}
         />
@@ -55,7 +55,7 @@ export function ParticipantsFilterPopover({
         <div className="flex flex-col">
           <div className="p-3 border-b">
             <Input
-              placeholder="Search participants..."
+              placeholder="Search contacts..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="h-8 text-xs"
@@ -64,7 +64,7 @@ export function ParticipantsFilterPopover({
           <div className="max-h-[300px] overflow-y-auto p-2 space-y-1">
             {filteredParticipants.length === 0 ? (
               <div className="text-sm text-muted-foreground py-6 text-center">
-                {searchQuery ? "No matching participants" : "No participants found"}
+                {searchQuery ? "No matching contacts" : "No contacts found"}
               </div>
             ) : (
               filteredParticipants.map((participant) => (

--- a/src/components/transcript-library/FilterBar.tsx
+++ b/src/components/transcript-library/FilterBar.tsx
@@ -5,7 +5,7 @@ import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { FilterPill } from "./FilterPill";
 import { TagFilterPopover } from "./TagFilterPopover";
 import { FolderFilterPopover } from "./FolderFilterPopover";
-import { ParticipantsFilterPopover } from "./ParticipantsFilterPopover";
+import { ContactsFilterPopover } from "./ContactsFilterPopover";
 import { DurationFilterPopover } from "./DurationFilterPopover";
 import { SourceFilterPopover } from "./SourceFilterPopover";
 import { format } from "date-fns";
@@ -50,21 +50,21 @@ export function FilterBar({
   compact = false,
 }: FilterBarProps) {
   const isMobile = useIsMobile();
-  const [allParticipants, setAllParticipants] = useState<string[]>([]);
+  const [allContacts, setAllContacts] = useState<string[]>([]);
 
-  // Fetch all unique participants
+  // Fetch all unique contacts
   useEffect(() => {
     // Track if component is still mounted to prevent state updates after unmount
     let isMounted = true;
 
-    const fetchParticipants = async () => {
+    const fetchContacts = async () => {
       try {
         // Use safe destructuring to handle network errors
         const userResponse = await supabase.auth.getUser();
 
         // Check for errors in the response (network issues, etc.)
         if (userResponse.error) {
-          logger.warn("Error getting user for participants fetch", userResponse.error);
+          logger.warn("Error getting user for contacts fetch", userResponse.error);
           return;
         }
 
@@ -78,30 +78,30 @@ export function FilterBar({
 
         if (fetchError) {
           if (isMounted) {
-            logger.error("Error fetching participants data", fetchError);
+            logger.error("Error fetching contacts data", fetchError);
           }
           return;
         }
 
         if (isMounted && data) {
-          const participantsSet = new Set<string>();
+          const contactsSet = new Set<string>();
           data.forEach((call: { calendar_invitees?: CalendarInvitee[] | null }) => {
             if (call.calendar_invitees && Array.isArray(call.calendar_invitees)) {
               call.calendar_invitees.forEach((invitee) => {
-                if (invitee?.email) participantsSet.add(invitee.email);
+                if (invitee?.email) contactsSet.add(invitee.email);
               });
             }
           });
-          setAllParticipants(Array.from(participantsSet).sort());
+          setAllContacts(Array.from(contactsSet).sort());
         }
       } catch (error) {
         // Only log errors if component is still mounted
         if (isMounted) {
-          logger.error("Error fetching participants", error);
+          logger.error("Error fetching contacts", error);
         }
       }
     };
-    fetchParticipants();
+    fetchContacts();
 
     // Cleanup: mark as unmounted to prevent state updates
     return () => {
@@ -191,10 +191,10 @@ export function FilterBar({
           onCreateFolder={onCreateFolder}
         />
 
-        {/* Participants Filter */}
-        <ParticipantsFilterPopover
+        {/* Contacts Filter */}
+        <ContactsFilterPopover
           selectedParticipants={filters.participants}
-          allParticipants={allParticipants}
+          allParticipants={allContacts}
           onParticipantsChange={(participants) => onFiltersChange({ ...filters, participants })}
         />
 
@@ -264,8 +264,8 @@ export function FilterBar({
           )}
           {filters.participants && filters.participants.length > 0 && (
             <FilterPill
-              label="Participants"
-              value={`${filters.participants.length} participant${filters.participants.length > 1 ? "s" : ""}`}
+              label="Contacts"
+              value={`${filters.participants.length} contact${filters.participants.length > 1 ? "s" : ""}`}
               onRemove={() => onFiltersChange({ ...filters, participants: [] })}
             />
           )}

--- a/src/components/transcript-library/TranscriptTable.tsx
+++ b/src/components/transcript-library/TranscriptTable.tsx
@@ -40,7 +40,7 @@ import type { Folder } from "@/types/workspace";
 const workspaceColumnOptions = [
   { id: "date", label: "Date" },
   { id: "duration", label: "Duration" },
-  { id: "participants", label: "Invitees" },
+  { id: "participants", label: "Contacts" },
   { id: "tags", label: "Tags" },
   { id: "folders", label: "Folders" },
   { id: "workspaces", label: "Workspaces" },
@@ -224,7 +224,7 @@ export const TranscriptTable = React.memo(({
                 )}
                 {!isHome && visibleColumns.participants !== false && (
                   <TableHead className="hidden lg:table-cell text-center w-[85px] h-11 whitespace-nowrap py-2 text-xs md:text-sm">
-                    <SortButton field="participants">INVITEES</SortButton>
+                    <SortButton field="participants">CONTACTS</SortButton>
                   </TableHead>
                 )}
                 {!isHome && (

--- a/src/components/transcript-library/TranscriptTableRow.tsx
+++ b/src/components/transcript-library/TranscriptTableRow.tsx
@@ -178,7 +178,7 @@ export function TranscriptTableRow({
               {call.calendar_invitees && call.calendar_invitees.length > 0 ? (
                 <InviteesPopover invitees={call.calendar_invitees} hostEmail={hostEmail} />
               ) : (
-                <span className="text-muted-foreground text-2xs">No participants</span>
+                <span className="text-muted-foreground text-2xs">No contacts</span>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Renamed `ParticipantsFilterPopover` component and file to `ContactsFilterPopover`
- Updated all user-facing labels: filter button, filter pill, search placeholder, empty states
- Changed column header from "INVITEES" to "CONTACTS" and column toggle label to "Contacts"
- Updated `TranscriptTableRow` empty state from "No participants" to "No contacts"
- Internal `participants` field name preserved for URL param backward compatibility

Closes #165

## Test plan
- [ ] Verify "Contacts" label appears on the filter button in FilterBar
- [ ] Open the contacts filter popover and confirm "Search contacts..." placeholder
- [ ] Apply a contacts filter and verify the pill shows "Contacts: N contact(s)"
- [ ] Check the column header shows "CONTACTS" in workspace table mode
- [ ] Verify the column visibility toggle shows "Contacts" label
- [ ] Confirm empty state text reads "No contacts" in table rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)