### PR TITLE
Fix ReferenceError: openPanel not defined in WorkspaceListItem

### DIFF
--- a/src/components/panes/WorkspaceSidebarPane.tsx
+++ b/src/components/panes/WorkspaceSidebarPane.tsx
@@ -189,7 +189,8 @@ function WorkspaceListItem({
   const { data: assignments = {} } = useFolderAssignments(isOpen ? workspace.id : null);
   const { mutate: deleteFolder } = useDeleteFolder();
   const { mutate: archiveFolder } = useArchiveFolder();
-  
+  const { openPanel } = usePanelStore();
+
   const canManage = workspace.user_role === 'workspace_owner' || workspace.user_role === 'workspace_admin';
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

- `WorkspaceListItem` in `src/components/panes/WorkspaceSidebarPane.tsx` called `openPanel` in its context menu click handler without ever destructuring it from `usePanelStore`
- `usePanelStore()` was only called in the parent `WorkspaceSidebarPane` component; `WorkspaceListItem` is a separate function component with no closure access to that variable — causing a `ReferenceError: Can't find variable: openPanel` at runtime whenever a user right-clicked a workspace
- Fix: add `const { openPanel } = usePanelStore();` inside `WorkspaceListItem`'s hook initialization block

Fixes Sentry #103323848

## Test plan

- [ ] Open the app and right-click a workspace in the sidebar — confirm "Manage Members" context menu item opens the panel without throwing a ReferenceError
- [ ] Verify TypeScript passes: `npm run type-check` returns no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)