### PR TITLE
Fix /rules page: bulk-apply calls non-existent edge function (Sentry #101708471)

### DIFF
--- a/src/components/import/RoutingRulesTab.tsx
+++ b/src/components/import/RoutingRulesTab.tsx
@@ -5,12 +5,11 @@
 import { useState } from 'react';
 import { RiRouteLine, RiFlashlightLine, RiLoader2Line } from '@remixicon/react';
 import { Button } from '@/components/ui/button';
-import { useRoutingRules, useRoutingDefault, useReorderRules, useToggleRule } from '@/hooks/useRoutingRules';
+import { useRoutingRules, useRoutingDefault, useReorderRules, useToggleRule, useBulkApplyRules } from '@/hooks/useRoutingRules';
 import { usePanelStore } from '@/stores/panelStore';
 import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { useOrgContextStore } from '@/stores/orgContextStore';
 import { useOrganizations } from '@/hooks/useOrganizations';
-import { useBulkApplyRules } from '@/hooks/useBulkApplyRules';
 import { DefaultDestinationBar } from './DefaultDestinationBar';
 import { RoutingRulesList } from './RoutingRulesList';
 
@@ -42,7 +41,7 @@ export function RoutingRulesTab() {
   const { workspaces = [] } = useWorkspaces(activeOrgId);
   const { data: allOrgs = [] } = useOrganizations();
   const bulkApply = useBulkApplyRules();
-  const [bulkDryRunResult, setBulkDryRunResult] = useState<{ matched: number; details: Array<{ matchedRuleName: string }> } | null>(null);
+  const [bulkDryRunResult, setBulkDryRunResult] = useState<{ matched: number; matches: Array<{ rule_name: string }> } | null>(null);
 
   const workspaceNames: Record<string, string> = {};
   for (const ws of workspaces) {
@@ -77,7 +76,7 @@ export function RoutingRulesTab() {
 
   async function handleBulkDryRun() {
     const result = await bulkApply.mutateAsync({ dryRun: true });
-    setBulkDryRunResult(result);
+    setBulkDryRunResult({ matched: result.matched, matches: result.matches });
   }
 
   async function handleBulkApply() {
@@ -181,13 +180,13 @@ export function RoutingRulesTab() {
                       Preview: {bulkDryRunResult.matched} call{bulkDryRunResult.matched !== 1 ? 's' : ''} would be routed
                     </p>
                     <div className="space-y-0.5 max-h-24 overflow-y-auto">
-                      {bulkDryRunResult.details.slice(0, 10).map((d, i) => (
+                      {bulkDryRunResult.matches.slice(0, 10).map((d, i) => (
                         <p key={i} className="text-[11px] text-muted-foreground truncate">
-                          <span className="text-foreground/60">Rule:</span> {d.matchedRuleName}
+                          <span className="text-foreground/60">Rule:</span> {d.rule_name}
                         </p>
                       ))}
-                      {bulkDryRunResult.details.length > 10 && (
-                        <p className="text-[11px] text-muted-foreground">+{bulkDryRunResult.details.length - 10} more...</p>
+                      {bulkDryRunResult.matches.length > 10 && (
+                        <p className="text-[11px] text-muted-foreground">+{bulkDryRunResult.matches.length - 10} more...</p>
                       )}
                     </div>
                     <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-1.5">

--- a/src/components/panes/WorkspaceSidebarPane.tsx
+++ b/src/components/panes/WorkspaceSidebarPane.tsx
@@ -189,7 +189,8 @@ function WorkspaceListItem({
   const { data: assignments = {} } = useFolderAssignments(isOpen ? workspace.id : null);
   const { mutate: deleteFolder } = useDeleteFolder();
   const { mutate: archiveFolder } = useArchiveFolder();
-  
+  const { openPanel } = usePanelStore();
+
   const canManage = workspace.user_role === 'workspace_owner' || workspace.user_role === 'workspace_admin';
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

- `RoutingRulesTab` was importing `useBulkApplyRules` from a stale standalone hook (`src/hooks/useBulkApplyRules.ts`) that called a non-existent Supabase Edge Function named `bulk-apply-routing-rules` — causing every bulk-apply and preview action on the `/rules` page to return a non-2xx response
- The broken hook also sent the wrong request body shape (camelCase `dryRun`/`ruleIds`/`limit`, no `organization_id`) and used raw `fetch` instead of `supabase.functions.invoke`
- Fixed by switching the import to the correct `useBulkApplyRules` already exported from `src/hooks/useRoutingRules.ts`, which calls the real `apply-routing-rules` edge function with `{ organization_id, dry_run }`
- Updated dry-run result state type and JSX field references (`details` → `matches`, `matchedRuleName` → `rule_name`) to match the actual `BulkApplyResult` shape from `src/types/routing.ts`

## Root cause

Two implementations of `useBulkApplyRules` existed — a correct one in `useRoutingRules.ts` and an outdated one in the standalone `useBulkApplyRules.ts`. The page component imported from the wrong file.

## Test plan

- [ ] Navigate to `/rules` page while authenticated
- [ ] Click "Preview" — should show a dry-run result without any toast error
- [ ] Click "Apply Now" — should route recordings and show success toast
- [ ] Confirm no `Edge Function returned a non-2xx status code` errors in Sentry
- [ ] `npm run type-check` passes (verified locally: no errors)

Fixes Sentry #101708471

🤖 Generated with [Claude Code](https://claude.com/claude-code)