### PR TITLE
fix(critical): auth deadlock regression + call detail into Pane 4

### DIFF
--- a/src/components/transcripts/TranscriptsTab.tsx
+++ b/src/components/transcripts/TranscriptsTab.tsx
@@ -98,7 +98,6 @@ export function TranscriptsTab({
 
   // Selection & interaction state
   const [selectedCalls, setSelectedCalls] = useState<(number | string)[]>([]);
-  const [selectedCall, setSelectedCall] = useState<Meeting | null>(null);
   // Use external search if provided, otherwise local state for backwards compatibility
   const [internalSearchQuery, setInternalSearchQuery] = useState("");
   const searchQuery = externalSearchQuery ?? internalSearchQuery;
@@ -1290,7 +1289,13 @@ export function TranscriptsTab({
                         setSelectedCalls(validCalls.map(c => c.recording_id));
                       }
                     }}
-                    onCallClick={(call) => setSelectedCall(call)}
+                    onCallClick={(call) => {
+                      usePanelStore.getState().openPanel('call-detail', {
+                        type: 'call-detail',
+                        recordingId: call.recording_id as number,
+                        title: call.title,
+                      });
+                    }}
                     tags={tags}
                     tagAssignments={tagAssignments}
                     folders={folders}
@@ -1318,17 +1323,7 @@ export function TranscriptsTab({
       </div>
 
       {/* Dialogs */}
-      {selectedCall && (
-        <CallDetailDialog
-          call={selectedCall}
-          open={!!selectedCall}
-          onOpenChange={(open) => {
-            if (!open) {
-              setSelectedCall(null);
-            }
-          }}
-        />
-      )}
+      {/* Call detail opens in Pane 4 via panelStore — see onCallClick handler above */}
 
       {taggingCallId && (
         <ManualTagDialog

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -38,8 +38,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           logger.debug('[AuthContext] User signed in');
           setSession(session);
           setUser(session?.user ?? null);
-          // Load user preferences after sign in
-          await usePreferencesStore.getState().loadPreferences();
+          // Load preferences fire-and-forget — do NOT await here.
+          // Awaiting inside onAuthStateChange causes a Supabase auth lock
+          // deadlock: the lock held by _notifyAllSubscribers is re-acquired
+          // by loadPreferences → supabase.auth.getUser(), hanging forever.
+          void usePreferencesStore.getState().loadPreferences();
         } else {
           // For other events (INITIAL_SESSION, etc.), update state
           setSession(session);
@@ -51,7 +54,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     );
 
     // THEN check for existing session
-    supabase.auth.getSession().then(async ({ data: { session }, error }) => {
+    supabase.auth.getSession().then(({ data: { session }, error }) => {
       if (error) {
         logger.error('[AuthContext] Error getting session:', error);
         setSession(null);
@@ -60,9 +63,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         logger.debug('[AuthContext] Initial session loaded:', session ? 'Valid' : 'None');
         setSession(session);
         setUser(session?.user ?? null);
-        // Load user preferences if session exists
+        // Load preferences fire-and-forget — do NOT await inside getSession().then().
+        // Same deadlock risk as onAuthStateChange: supabase.auth.getUser() inside
+        // loadPreferences re-acquires the auth lock that getSession() still holds.
         if (session) {
-          await usePreferencesStore.getState().loadPreferences();
+          void usePreferencesStore.getState().loadPreferences();
         }
       }
       setLoading(false);


### PR DESCRIPTION
## Two critical bugs found by live browser testing

### Bug 1: Auth deadlock on page reload (regression from earlier fix)

**Root cause**: The earlier fix made `loadPreferences()` awaited inside `onAuthStateChange`. This caused a Supabase auth lock deadlock:

```
onAuthStateChange holds _acquireLock
  → SIGNED_IN handler fires
    → await loadPreferences()
      → supabase.auth.getUser() tries to acquire _acquireLock
        → DEADLOCK: waits forever for lock that is already held
```

The app showed "Loading..." indefinitely on any page reload.

**Fix**: Reverted to `void loadPreferences()` (fire-and-forget) in both `onAuthStateChange` and `getSession().then()`. This matches the original intent — preferences load asynchronously after auth state is set, without blocking the auth lock.

---

### Bug 2: Call detail opened as centered modal overlay instead of Pane 4

**Root cause**: `onCallClick` in `TranscriptsTab` set local `selectedCall` state → rendered `<CallDetailDialog>` — a `fixed left-[50%] top-[50%] z-50` centered modal that covered the entire app and dimmed the background. The 4-pane layout was completely broken.

**Fix**: Replaced `setSelectedCall(call)` with `usePanelStore.getState().openPanel('call-detail', { recordingId, title })`. Call detail now slides into Pane 4 as designed — same plane, no overlay, other panes remain visible.

Removed `selectedCall` state and `<CallDetailDialog>` from `TranscriptsTab` entirely.

## Test
1. Reload the app → should load immediately without hanging
2. Click any call row → detail slides into Pane 4 (right side), all 4 panes visible simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)