### PR TITLE
fix(lint): resolve TypeScript and ESLint errors across 4 components

### DIFF
--- a/src/components/AssignFolderDialog.tsx
+++ b/src/components/AssignFolderDialog.tsx
@@ -18,10 +18,13 @@ import { cn } from "@/lib/utils";
 import { getIconComponent } from "@/lib/folder-icons";
 import type { FolderWithDepth } from "@/types/folders";
 
+// Extended folder type with is_personal flag used internally
+interface FolderWithPersonal extends FolderWithDepth {
+  is_personal: boolean;
+}
+
 // Extended folder type for tree structure
-interface FolderTreeNode extends FolderWithDepth {
-  icon?: string;
-  position?: number;
+interface FolderTreeNode extends FolderWithPersonal {
   children: FolderTreeNode[];
 }
 
@@ -42,7 +45,7 @@ export default function AssignFolderDialog({
   onFoldersUpdated,
   onCreateFolder,
 }: AssignFolderDialogProps) {
-  const { activeOrganizationId, activeWorkspaceId } = useOrganizationContext();
+  const { activeOrganizationId } = useOrganizationContext();
   const [folderTree, setFolderTree] = useState<FolderTreeNode[]>([]);
   const [selectedFolders, setSelectedFolders] = useState<Set<string>>(new Set());
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
@@ -50,7 +53,7 @@ export default function AssignFolderDialog({
   const [saving, setSaving] = useState(false);
 
   // Track all folders flat for saving operations
-  const [allFolders, setAllFolders] = useState<FolderWithDepth[]>([]);
+  const [allFolders, setAllFolders] = useState<FolderWithPersonal[]>([]);
 
   const isBulkMode = recordingIds && recordingIds.length > 1;
 
@@ -114,12 +117,12 @@ export default function AssignFolderDialog({
       if (legacyError) throw legacyError;
 
       // personal_folders table is pending migration — only legacy folders for now
-      const all = (legacyData || []).map(f => ({ ...f, is_personal: false }));
+      const all: FolderWithPersonal[] = (legacyData || []).map(f => ({ ...f, is_personal: false }));
 
-      setAllFolders(all as any);
+      setAllFolders(all);
 
       // Build tree structure
-      const tree = buildFolderTree(all as any);
+      const tree = buildFolderTree(all);
       setFolderTree(tree);
     } catch (error) {
       logger.error("Error loading folders", error);
@@ -163,7 +166,7 @@ export default function AssignFolderDialog({
   }, [selectedFolders, allFolders, autoExpandParents]);
 
   // Build a tree structure from flat folder list
-  const buildFolderTree = (folders: FolderWithDepth[]): FolderTreeNode[] => {
+  const buildFolderTree = (folders: FolderWithPersonal[]): FolderTreeNode[] => {
     const folderMap = new Map<string, FolderTreeNode>();
     const rootFolders: FolderTreeNode[] = [];
 
@@ -245,7 +248,7 @@ export default function AssignFolderDialog({
       const userId = user?.id || null;
 
       // 1. Handle Legacy Folders
-      const legacySelected = new Set(Array.from(selectedFolders).filter(id => allFolders.find(f => f.id === id && !(f as any).is_personal)));
+      const legacySelected = new Set(Array.from(selectedFolders).filter(id => allFolders.find(f => f.id === id && !f.is_personal)));
       
       const { data: existingLegacy } = await supabase
         .from("folder_assignments")
@@ -259,7 +262,7 @@ export default function AssignFolderDialog({
           .eq("call_recording_id", a.call_recording_id).eq("folder_id", a.folder_id).eq("user_id", userId);
       }
       // Insertions
-      const legacyToAdd: any[] = [];
+      const legacyToAdd: { call_recording_id: number; folder_id: string; assigned_by: string | null; user_id: string | null }[] = [];
       numericRecordingIds.forEach(rid => {
         legacySelected.forEach(fid => {
           if (!(existingLegacy || []).some(a => a.call_recording_id === rid && a.folder_id === fid)) {

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -15,7 +15,6 @@ import { SplitConfirmDialog } from "@/components/transcript-library/SplitConfirm
 import { useTranscriptExport } from "@/hooks/useTranscriptExport";
 import { useCallDetailQueries } from "@/hooks/useCallDetailQueries";
 import { useCallDetailMutations } from "@/hooks/useCallDetailMutations";
-import { Badge } from "@/components/ui/badge";
 import { RiCheckboxCircleLine, RiRefreshLine } from "@remixicon/react";
 import { CallStatsFooter } from "@/components/call-detail/CallStatsFooter";
 import { CallInviteesTab } from "@/components/call-detail/CallInviteesTab";
@@ -88,7 +87,7 @@ export function CallDetailDialog({
   onDataChange,
 }: CallDetailDialogProps) {
   const { user } = useAuth();
-  const navigate = useNavigate();
+  const _navigate = useNavigate();
   const queryClient = useQueryClient();
 
   // Local UI state

--- a/src/components/EditFolderDialog.tsx
+++ b/src/components/EditFolderDialog.tsx
@@ -37,6 +37,8 @@ interface Folder {
   icon?: string | null;
   parent_id?: string | null;
   depth?: number;
+  workspace_id?: string | null;
+  organization_id?: string | null;
 }
 
 interface EditFolderDialogProps {
@@ -91,19 +93,7 @@ export default function EditFolderDialog({
     }, 0);
   }, []);
 
-  // Initialize form with folder data when opened
-  useEffect(() => {
-    if (open && folder) {
-      setName(folder.name || "");
-      setDescription(folder.description || "");
-      setShowDescription(!!folder.description);
-      setIconId(folder.icon || "folder");
-      setSelectedParentId(folder.parent_id || undefined);
-      loadFolders();
-    }
-  }, [open, folder]);
-
-  const loadFolders = async () => {
+  const loadFolders = useCallback(async () => {
     setLoadingFolders(true);
     try {
       const { user, error: authError } = await getSafeUser();
@@ -136,9 +126,9 @@ export default function EditFolderDialog({
       const computeDepth = (folderId: string, visited = new Set<string>()): number => {
         if (visited.has(folderId)) return 0; // Prevent infinite loops from circular refs
         visited.add(folderId);
-        const folder = foldersMap.get(folderId);
-        if (!folder || !folder.parent_id) return 0;
-        return 1 + computeDepth(folder.parent_id, visited);
+        const folderEntry = foldersMap.get(folderId);
+        if (!folderEntry || !folderEntry.parent_id) return 0;
+        return 1 + computeDepth(folderEntry.parent_id, visited);
       };
 
       const foldersWithDepth: FolderOption[] = (data || []).map(f => ({
@@ -154,7 +144,19 @@ export default function EditFolderDialog({
     } finally {
       setLoadingFolders(false);
     }
-  };
+  }, [workspaceId, folder?.workspace_id, folder?.organization_id, activeWorkspaceId, organizationId, activeOrganizationId]);
+
+  // Initialize form with folder data when opened
+  useEffect(() => {
+    if (open && folder) {
+      setName(folder.name || "");
+      setDescription(folder.description || "");
+      setShowDescription(!!folder.description);
+      setIconId(folder.icon || "folder");
+      setSelectedParentId(folder.parent_id || undefined);
+      loadFolders();
+    }
+  }, [open, folder, loadFolders]);
 
   const handleUpdate = async () => {
     if (!folder) return;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,9 +30,9 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   // Register a global tour starter so OnboardingModal (or any other code) can
   // call `window.__startCallVaultTour()` without importing the module directly.
   useEffect(() => {
-    (window as any).__startCallVaultTour = startTour;
+    (window as Window & { __startCallVaultTour?: typeof startTour }).__startCallVaultTour = startTour;
     return () => {
-      delete (window as any).__startCallVaultTour;
+      delete (window as Window & { __startCallVaultTour?: typeof startTour }).__startCallVaultTour;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- **Layout.tsx**: Replace `(window as any)` with typed intersection cast
- **EditFolderDialog.tsx**: Wrap `loadFolders` in `useCallback`, add to `useEffect` deps
- **CallDetailDialog.tsx**: Remove unused `Badge` import, rename `navigate` → `_navigate`
- **AssignFolderDialog.tsx**: Add `FolderWithPersonal` interface, remove unused `activeWorkspaceId`, type `legacyToAdd` properly

`npm run type-check` and `npm run lint` both pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)