### PR TITLE
fix(cors): add localhost:3001 to edge function CORS allowlist

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -3,6 +3,7 @@
 const DEFAULT_ORIGINS = [
   'https://callvault.vercel.app',
   'https://app.callvaultai.com',
+  'http://localhost:3001',
   'http://localhost:8080',
   'http://localhost:5173',
 ];


### PR DESCRIPTION
Add port 3001 to DEFAULT_ORIGINS in `_shared/cors.ts` — local dev server runs on 3001 but only 8080 and 5173 were allowlisted, causing all edge function calls to fail with 'Failed to fetch'.