### PR TITLE
fix(automation): strip unresolved template {{placeholders}} to empty string

### DIFF
--- a/supabase/functions/automation-engine/actions.ts
+++ b/supabase/functions/automation-engine/actions.ts
@@ -149,6 +149,9 @@ export function replaceTemplateVariables(
     }
   }
 
+  // Strip any remaining unresolved {{...}} placeholders (unknown fields → empty string)
+  result = result.replace(/\{\{[^}]+\}\}/g, '');
+
   return result;
 }
 


### PR DESCRIPTION
## Problem
`replaceTemplateVariables` in `actions.ts` only handled known fields via explicit `.replace()` calls. Any unknown variable like `{{call.missing}}` was left in the output string verbatim, causing the test `should handle missing context values gracefully` to fail.

## Fix
Added a catch-all at the end of the function:
```ts
result = result.replace(/\{\{[^}]+\}\}/g, '');
```
Any `{{placeholder}}` not matched by earlier rules is now replaced with an empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)