### PR TITLE
AI usage gating, attribution & dead code cleanup

### DIFF
--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -17,6 +17,7 @@ import { useCallDetailQueries } from "@/hooks/useCallDetailQueries";
 import { useCallDetailMutations } from "@/hooks/useCallDetailMutations";
 import { useRawCallData } from "@/hooks/useRawCallData";
 import { useAiGate } from "@/hooks/useAiGate";
+import { useOrgContext } from "@/hooks/useOrgContext";
 import { RiCheckboxCircleLine, RiRefreshLine } from "@remixicon/react";
 import { CallStatsFooter } from "@/components/call-detail/CallStatsFooter";
 import { CallInviteesTab } from "@/components/call-detail/CallInviteesTab";
@@ -46,13 +47,15 @@ function SplitSummaryRow({
   recordingId: string | number | null | undefined;
 }) {
   const { trackAction } = useAiGate();
+  const { activeOrgId } = useOrgContext();
 
   const handleRegenerate = async () => {
     if (!recordingId) return;
 
     // PAY-05: Enforce AI monthly limit
     const { allowed } = await trackAction('summarize_call', {
-      recordingId: typeof recordingId === 'string' ? recordingId : undefined
+      recordingId: typeof recordingId === 'string' ? recordingId : undefined,
+      orgId: activeOrgId || undefined
     });
     if (!allowed) return;
 

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -16,6 +16,7 @@ import { useTranscriptExport } from "@/hooks/useTranscriptExport";
 import { useCallDetailQueries } from "@/hooks/useCallDetailQueries";
 import { useCallDetailMutations } from "@/hooks/useCallDetailMutations";
 import { useRawCallData } from "@/hooks/useRawCallData";
+import { useAiGate } from "@/hooks/useAiGate";
 import { RiCheckboxCircleLine, RiRefreshLine } from "@remixicon/react";
 import { CallStatsFooter } from "@/components/call-detail/CallStatsFooter";
 import { CallInviteesTab } from "@/components/call-detail/CallInviteesTab";
@@ -44,8 +45,17 @@ function SplitSummaryRow({
   title: string;
   recordingId: string | number | null | undefined;
 }) {
+  const { trackAction } = useAiGate();
+
   const handleRegenerate = async () => {
     if (!recordingId) return;
+
+    // PAY-05: Enforce AI monthly limit
+    const { allowed } = await trackAction('summarize_call', {
+      recordingId: typeof recordingId === 'string' ? recordingId : undefined
+    });
+    if (!allowed) return;
+
     const toastId = toast.loading(`Regenerating summary for "${title}"…`);
     try {
       const { error } = await supabase.functions.invoke('summarize-call', {

--- a/src/components/CallDetailDialog.tsx
+++ b/src/components/CallDetailDialog.tsx
@@ -17,7 +17,7 @@ import { useCallDetailQueries } from "@/hooks/useCallDetailQueries";
 import { useCallDetailMutations } from "@/hooks/useCallDetailMutations";
 import { useRawCallData } from "@/hooks/useRawCallData";
 import { useAiGate } from "@/hooks/useAiGate";
-import { useOrgContext } from "@/hooks/useOrgContext";
+
 import { RiCheckboxCircleLine, RiRefreshLine } from "@remixicon/react";
 import { CallStatsFooter } from "@/components/call-detail/CallStatsFooter";
 import { CallInviteesTab } from "@/components/call-detail/CallInviteesTab";
@@ -47,7 +47,6 @@ function SplitSummaryRow({
   recordingId: string | number | null | undefined;
 }) {
   const { trackAction } = useAiGate();
-  const { activeOrgId } = useOrgContext();
 
   const handleRegenerate = async () => {
     if (!recordingId) return;
@@ -55,7 +54,6 @@ function SplitSummaryRow({
     // PAY-05: Enforce AI monthly limit
     const { allowed } = await trackAction('summarize_call', {
       recordingId: typeof recordingId === 'string' ? recordingId : undefined,
-      orgId: activeOrgId || undefined
     });
     if (!allowed) return;
 

--- a/src/components/SmartExportDialog.tsx
+++ b/src/components/SmartExportDialog.tsx
@@ -44,6 +44,7 @@ import { exportAsLLMContext, estimateTokens } from "@/lib/export-utils-advanced"
 import type { ExportableCall } from "@/lib/export-utils";
 import { generateMetaSummary } from "@/lib/api-client";
 import { useAiGate } from "@/hooks/useAiGate";
+import { useOrgContext } from "@/hooks/useOrgContext";
 import { supabase } from "@/integrations/supabase/client";
 import { saveAs } from "file-saver";
 
@@ -82,6 +83,7 @@ export default function SmartExportDialog({
   const [isExporting, setIsExporting] = useState(false);
   const [isGeneratingAiSummary, setIsGeneratingAiSummary] = useState(false);
   const { trackAction } = useAiGate();
+  const { activeOrgId } = useOrgContext();
 
   // Calculate stats
   const stats = useMemo(() => {
@@ -215,7 +217,7 @@ export default function SmartExportDialog({
         toast.loading("Generating AI meta-summary...", { id: loadingToast });
 
         // Gate: check AI usage limit before generating summary
-        const gate = await trackAction('smart_import');
+        const gate = await trackAction('smart_import', { orgId: activeOrgId || undefined });
         if (!gate.allowed) {
           setIsGeneratingAiSummary(false);
           return;

--- a/src/components/SmartExportDialog.tsx
+++ b/src/components/SmartExportDialog.tsx
@@ -44,7 +44,7 @@ import { exportAsLLMContext, estimateTokens } from "@/lib/export-utils-advanced"
 import type { ExportableCall } from "@/lib/export-utils";
 import { generateMetaSummary } from "@/lib/api-client";
 import { useAiGate } from "@/hooks/useAiGate";
-import { useOrgContext } from "@/hooks/useOrgContext";
+
 import { supabase } from "@/integrations/supabase/client";
 import { saveAs } from "file-saver";
 
@@ -83,7 +83,6 @@ export default function SmartExportDialog({
   const [isExporting, setIsExporting] = useState(false);
   const [isGeneratingAiSummary, setIsGeneratingAiSummary] = useState(false);
   const { trackAction } = useAiGate();
-  const { activeOrgId } = useOrgContext();
 
   // Calculate stats
   const stats = useMemo(() => {
@@ -217,7 +216,7 @@ export default function SmartExportDialog({
         toast.loading("Generating AI meta-summary...", { id: loadingToast });
 
         // Gate: check AI usage limit before generating summary
-        const gate = await trackAction('smart_import', { orgId: activeOrgId || undefined });
+        const gate = await trackAction('smart_import');
         if (!gate.allowed) {
           setIsGeneratingAiSummary(false);
           return;

--- a/src/components/contacts/ReengagementEmailModal.tsx
+++ b/src/components/contacts/ReengagementEmailModal.tsx
@@ -34,7 +34,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { useHealthAlerts, DEFAULT_REENGAGEMENT_PROMPT } from "@/hooks/useHealthAlerts";
 import { useAiGate } from "@/hooks/useAiGate";
-import { useOrgContext } from "@/hooks/useOrgContext";
+
 import type { ContactWithCallCount } from "@/types/contacts";
 
 export interface ReengagementEmailModalProps {
@@ -50,7 +50,6 @@ export function ReengagementEmailModal({
 }: ReengagementEmailModalProps) {
   const { generateReengagementEmail, isGenerating } = useHealthAlerts();
   const { trackAction } = useAiGate();
-  const { activeOrgId } = useOrgContext();
 
   // Form state
   const [prompt, setPrompt] = React.useState(DEFAULT_REENGAGEMENT_PROMPT);
@@ -74,7 +73,6 @@ export function ReengagementEmailModal({
     // PAY-05: Enforce AI monthly limit
     const { allowed } = await trackAction('generate_content', {
       recordingId: contact.last_call_recording_id ? String(contact.last_call_recording_id) : undefined,
-      orgId: activeOrgId || undefined
     });
     if (!allowed) return;
 

--- a/src/components/contacts/ReengagementEmailModal.tsx
+++ b/src/components/contacts/ReengagementEmailModal.tsx
@@ -33,6 +33,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { useHealthAlerts, DEFAULT_REENGAGEMENT_PROMPT } from "@/hooks/useHealthAlerts";
+import { useAiGate } from "@/hooks/useAiGate";
 import type { ContactWithCallCount } from "@/types/contacts";
 
 export interface ReengagementEmailModalProps {
@@ -47,6 +48,7 @@ export function ReengagementEmailModal({
   contact,
 }: ReengagementEmailModalProps) {
   const { generateReengagementEmail, isGenerating } = useHealthAlerts();
+  const { trackAction } = useAiGate();
 
   // Form state
   const [prompt, setPrompt] = React.useState(DEFAULT_REENGAGEMENT_PROMPT);
@@ -66,6 +68,12 @@ export function ReengagementEmailModal({
 
   const handleGenerate = async () => {
     if (!contact) return;
+
+    // PAY-05: Enforce AI monthly limit
+    const { allowed } = await trackAction('generate_content', {
+      recordingId: contact.last_call_recording_id ? String(contact.last_call_recording_id) : undefined
+    });
+    if (!allowed) return;
 
     const result = await generateReengagementEmail(contact, prompt);
     if (result) {

--- a/src/components/contacts/ReengagementEmailModal.tsx
+++ b/src/components/contacts/ReengagementEmailModal.tsx
@@ -71,9 +71,9 @@ export function ReengagementEmailModal({
     if (!contact) return;
 
     // PAY-05: Enforce AI monthly limit
-    const { allowed } = await trackAction('generate_content', {
-      recordingId: contact.last_call_recording_id ? String(contact.last_call_recording_id) : undefined,
-    });
+    // Note: recordingId intentionally omitted — generate_content is not tied to a specific recording,
+    // and last_call_recording_id is a numeric ID, not a UUID matching ai_usage.recording_id FK.
+    const { allowed } = await trackAction('generate_content');
     if (!allowed) return;
 
     const result = await generateReengagementEmail(contact, prompt);

--- a/src/components/contacts/ReengagementEmailModal.tsx
+++ b/src/components/contacts/ReengagementEmailModal.tsx
@@ -34,6 +34,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { useHealthAlerts, DEFAULT_REENGAGEMENT_PROMPT } from "@/hooks/useHealthAlerts";
 import { useAiGate } from "@/hooks/useAiGate";
+import { useOrgContext } from "@/hooks/useOrgContext";
 import type { ContactWithCallCount } from "@/types/contacts";
 
 export interface ReengagementEmailModalProps {
@@ -49,6 +50,7 @@ export function ReengagementEmailModal({
 }: ReengagementEmailModalProps) {
   const { generateReengagementEmail, isGenerating } = useHealthAlerts();
   const { trackAction } = useAiGate();
+  const { activeOrgId } = useOrgContext();
 
   // Form state
   const [prompt, setPrompt] = React.useState(DEFAULT_REENGAGEMENT_PROMPT);
@@ -71,7 +73,8 @@ export function ReengagementEmailModal({
 
     // PAY-05: Enforce AI monthly limit
     const { allowed } = await trackAction('generate_content', {
-      recordingId: contact.last_call_recording_id ? String(contact.last_call_recording_id) : undefined
+      recordingId: contact.last_call_recording_id ? String(contact.last_call_recording_id) : undefined,
+      orgId: activeOrgId || undefined
     });
     if (!allowed) return;
 

--- a/src/components/transcript-library/BulkActionToolbarEnhanced.tsx
+++ b/src/components/transcript-library/BulkActionToolbarEnhanced.tsx
@@ -36,6 +36,7 @@ import { CopyToOrganizationDialog } from "@/components/dialogs/CopyToOrganizatio
 import { exportToPDF, exportToDOCX, exportToTXT, exportToJSON, exportToZIP } from "@/lib/export-utils";
 import { autoTagCalls, generateAiTitles } from "@/lib/api-client";
 import { useAiGate } from "@/hooks/useAiGate";
+import { useOrgContext } from "@/hooks/useOrgContext";
 import { supabase } from "@/integrations/supabase/client";
 import { logger } from "@/lib/logger";
 import type { Meeting } from "@/types";
@@ -113,6 +114,7 @@ export function BulkActionToolbarEnhanced({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { trackAction } = useAiGate();
+  const { activeOrgId } = useOrgContext();
   const [showSmartExport, setShowSmartExport] = useState(false);
   const [showManualTagDialog, setShowManualTagDialog] = useState(false);
   const [showMoveToWsDialog, setShowMoveToWsDialog] = useState(false);
@@ -193,7 +195,7 @@ export function BulkActionToolbarEnhanced({
       }
 
       // Gate: check AI usage limit before proceeding
-      const gate = await trackAction('auto_name');
+      const gate = await trackAction('auto_name', { orgId: activeOrgId || undefined });
       if (!gate.allowed) return; // toast shown by useAiGate
 
       const { data, error } = await generateAiTitles(recordingIds);
@@ -256,7 +258,7 @@ export function BulkActionToolbarEnhanced({
       }
 
       // Gate: check AI usage limit before proceeding
-      const gate = await trackAction('auto_tag');
+      const gate = await trackAction('auto_tag', { orgId: activeOrgId || undefined });
       if (!gate.allowed) return; // toast shown by useAiGate
 
       const { data, error } = await autoTagCalls(recordingIds);

--- a/src/components/transcript-library/BulkActionToolbarEnhanced.tsx
+++ b/src/components/transcript-library/BulkActionToolbarEnhanced.tsx
@@ -36,7 +36,7 @@ import { CopyToOrganizationDialog } from "@/components/dialogs/CopyToOrganizatio
 import { exportToPDF, exportToDOCX, exportToTXT, exportToJSON, exportToZIP } from "@/lib/export-utils";
 import { autoTagCalls, generateAiTitles } from "@/lib/api-client";
 import { useAiGate } from "@/hooks/useAiGate";
-import { useOrgContext } from "@/hooks/useOrgContext";
+
 import { supabase } from "@/integrations/supabase/client";
 import { logger } from "@/lib/logger";
 import type { Meeting } from "@/types";
@@ -114,7 +114,6 @@ export function BulkActionToolbarEnhanced({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { trackAction } = useAiGate();
-  const { activeOrgId } = useOrgContext();
   const [showSmartExport, setShowSmartExport] = useState(false);
   const [showManualTagDialog, setShowManualTagDialog] = useState(false);
   const [showMoveToWsDialog, setShowMoveToWsDialog] = useState(false);
@@ -195,7 +194,7 @@ export function BulkActionToolbarEnhanced({
       }
 
       // Gate: check AI usage limit before proceeding
-      const gate = await trackAction('auto_name', { orgId: activeOrgId || undefined });
+      const gate = await trackAction('auto_name');
       if (!gate.allowed) return; // toast shown by useAiGate
 
       const { data, error } = await generateAiTitles(recordingIds);
@@ -258,7 +257,7 @@ export function BulkActionToolbarEnhanced({
       }
 
       // Gate: check AI usage limit before proceeding
-      const gate = await trackAction('auto_tag', { orgId: activeOrgId || undefined });
+      const gate = await trackAction('auto_tag');
       if (!gate.allowed) return; // toast shown by useAiGate
 
       const { data, error } = await autoTagCalls(recordingIds);

--- a/src/hooks/__tests__/useAiGate.test.ts
+++ b/src/hooks/__tests__/useAiGate.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+
+// Mock Supabase client
+vi.mock('@/integrations/supabase/client', () => {
+  const mockSupabase = {
+    auth: { getSession: vi.fn() },
+    functions: { invoke: vi.fn() },
+  };
+  return { supabase: mockSupabase };
+});
+
+// Mock useSubscription
+vi.mock('@/hooks/useSubscription', () => ({
+  useSubscription: () => ({
+    tier: 'pro' as const,
+    aiActionsLimit: 1000,
+    isLoading: false,
+  }),
+}));
+
+// Mock useOrgContext
+const mockActiveOrgId = vi.fn(() => 'org-abc-123');
+vi.mock('@/hooks/useOrgContext', () => ({
+  useOrgContext: () => ({
+    activeOrgId: mockActiveOrgId(),
+    activeOrg: null,
+    organizations: [],
+    activeWorkspaceId: null,
+    activeFolderId: null,
+    isPersonalOrg: false,
+    isReady: true,
+    switchOrg: vi.fn(),
+    switchWorkspace: vi.fn(),
+    switchFolder: vi.fn(),
+  }),
+}));
+
+// Import after mocking
+import { supabase } from '@/integrations/supabase/client';
+import { useAiGate } from '../useAiGate';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useAiGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveOrgId.mockReturnValue('org-abc-123');
+  });
+
+  function mockSession(token = 'test-token') {
+    (supabase.auth.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { session: { access_token: token } },
+    });
+  }
+
+  function mockInvokeSuccess(data = { success: true, usage: 1, limit: 1000, remaining: 999 }) {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data,
+      error: null,
+    });
+  }
+
+  it('should auto-inject activeOrgId when no orgId provided', async () => {
+    mockSession();
+    mockInvokeSuccess();
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.trackAction('summarize_call', { recordingId: 'rec-1' });
+    });
+
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('track-ai-usage', {
+      headers: { Authorization: 'Bearer test-token' },
+      body: {
+        actionType: 'summarize_call',
+        recordingId: 'rec-1',
+        orgId: 'org-abc-123',
+      },
+    });
+  });
+
+  it('should prefer explicit orgId over activeOrgId', async () => {
+    mockSession();
+    mockInvokeSuccess();
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.trackAction('auto_tag', { orgId: 'explicit-org' });
+    });
+
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('track-ai-usage', expect.objectContaining({
+      body: expect.objectContaining({ orgId: 'explicit-org' }),
+    }));
+  });
+
+  it('should send undefined orgId when activeOrgId is undefined and no explicit orgId', async () => {
+    mockActiveOrgId.mockReturnValue(undefined);
+    mockSession();
+    mockInvokeSuccess();
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.trackAction('chat_message');
+    });
+
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('track-ai-usage', expect.objectContaining({
+      body: expect.objectContaining({ orgId: undefined }),
+    }));
+  });
+
+  it('should return allowed: true on success', async () => {
+    mockSession();
+    mockInvokeSuccess({ success: true, usage: 5, limit: 1000, remaining: 995 });
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    let trackResult: Awaited<ReturnType<typeof result.current.trackAction>>;
+    await act(async () => {
+      trackResult = await result.current.trackAction('summarize_call');
+    });
+
+    expect(trackResult!.allowed).toBe(true);
+    expect(trackResult!.usage).toBe(5);
+    expect(trackResult!.remaining).toBe(995);
+  });
+
+  it('should fail open when no session exists', async () => {
+    (supabase.auth.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { session: null },
+    });
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    let trackResult: Awaited<ReturnType<typeof result.current.trackAction>>;
+    await act(async () => {
+      trackResult = await result.current.trackAction('summarize_call');
+    });
+
+    expect(trackResult!.allowed).toBe(true);
+    expect(supabase.functions.invoke).not.toHaveBeenCalled();
+  });
+
+  it('should return allowed: false on 429 limit-reached', async () => {
+    mockSession();
+
+    const mockContext = {
+      status: 429,
+      json: vi.fn().mockResolvedValue({
+        error: 'Monthly AI action limit reached',
+        usage: 1000,
+        limit: 1000,
+        tier: 'pro',
+      }),
+    };
+
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { context: mockContext },
+    });
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    let trackResult: Awaited<ReturnType<typeof result.current.trackAction>>;
+    await act(async () => {
+      trackResult = await result.current.trackAction('summarize_call');
+    });
+
+    expect(trackResult!.allowed).toBe(false);
+    expect(trackResult!.usage).toBe(1000);
+    expect(trackResult!.remaining).toBe(0);
+  });
+
+  it('should fail open on non-429 errors', async () => {
+    mockSession();
+
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { message: 'Internal server error' },
+    });
+
+    const { result } = renderHook(() => useAiGate(), { wrapper: createWrapper() });
+
+    let trackResult: Awaited<ReturnType<typeof result.current.trackAction>>;
+    await act(async () => {
+      trackResult = await result.current.trackAction('summarize_call');
+    });
+
+    expect(trackResult!.allowed).toBe(true);
+  });
+});

--- a/src/hooks/useAiGate.ts
+++ b/src/hooks/useAiGate.ts
@@ -7,7 +7,7 @@ import { useSubscription, type SubscriptionTier } from '@/hooks/useSubscription'
  * AI action types that are tracked against monthly limits.
  * Must match action_type CHECK constraint in ai_usage table.
  */
-export type AiActionType = 'smart_import' | 'auto_name' | 'auto_tag' | 'chat_message';
+export type AiActionType = 'smart_import' | 'auto_name' | 'auto_tag' | 'chat_message' | 'summarize_call' | 'generate_content';
 
 /**
  * Result returned by trackAction after calling track-ai-usage.

--- a/src/hooks/useAiGate.ts
+++ b/src/hooks/useAiGate.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 import { useSubscription, type SubscriptionTier } from '@/hooks/useSubscription';
+import { useOrgContext } from '@/hooks/useOrgContext';
 
 /**
  * AI action types that are tracked against monthly limits.
@@ -70,6 +71,7 @@ export interface AiGateResult {
  */
 export function useAiGate(): AiGateResult {
   const { tier, aiActionsLimit: limit, isLoading } = useSubscription();
+  const { activeOrgId } = useOrgContext();
   const queryClient = useQueryClient();
 
   async function trackAction(
@@ -91,7 +93,7 @@ export function useAiGate(): AiGateResult {
         body: {
           actionType: type,
           recordingId: opts?.recordingId,
-          orgId: opts?.orgId,
+          orgId: opts?.orgId ?? activeOrgId,
         },
       });
 

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -19,6 +19,9 @@ const AI_ACTION_LIMITS: Record<string, number> = {
   team: 5000,
 };
 
+// Simple UUID v4 regex for input validation
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const VALID_ACTION_TYPES = [
   'smart_import',
   'auto_name',
@@ -113,12 +116,34 @@ Deno.serve(async (req) => {
       );
     }
 
+    // Validate recordingId is a valid UUID if provided
+    if (recordingId && !UUID_REGEX.test(recordingId)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid recordingId — must be a valid UUID' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
     // Step 1: Get organization context and type
     let effectiveOrgId = orgId;
     let isPersonal = false;
 
-    // Verify user belongs to the specified organization
     if (effectiveOrgId) {
+      // Validate org exists
+      const { data: org } = await supabase
+        .from('organizations')
+        .select('id, type')
+        .eq('id', effectiveOrgId)
+        .maybeSingle();
+
+      if (!org) {
+        return new Response(
+          JSON.stringify({ error: 'Organization not found' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
+
+      // Verify user belongs to the specified organization
       const { data: membership } = await supabase
         .from('organization_memberships')
         .select('id')
@@ -128,26 +153,12 @@ Deno.serve(async (req) => {
 
       if (!membership) {
         return new Response(
-          JSON.stringify({ error: 'Not a member of the specified organization' }),
+          JSON.stringify({ error: 'Not a member of this organization' }),
           { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
         );
       }
 
-      const { data: org, error: orgError } = await supabase
-        .from('organizations')
-        .select('type')
-        .eq('id', effectiveOrgId)
-        .maybeSingle();
-
-      if (orgError) {
-        console.error('track-ai-usage: org type fetch error:', orgError);
-        return new Response(
-          JSON.stringify({ error: 'Failed to retrieve organization data' }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-        );
-      }
-
-      if (org?.type === 'personal') {
+      if (org.type === 'personal') {
         isPersonal = true;
       }
     }

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -117,13 +117,28 @@ Deno.serve(async (req) => {
     let effectiveOrgId = orgId;
     let isPersonal = false;
 
+    // Verify user belongs to the specified organization
     if (effectiveOrgId) {
+      const { data: membership } = await supabase
+        .from('organization_memberships')
+        .select('id')
+        .eq('organization_id', effectiveOrgId)
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (!membership) {
+        return new Response(
+          JSON.stringify({ error: 'Not a member of the specified organization' }),
+          { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
+
       const { data: org } = await supabase
         .from('organizations')
         .select('type')
         .eq('id', effectiveOrgId)
         .maybeSingle();
-      
+
       if (org?.type === 'personal') {
         isPersonal = true;
       }
@@ -161,7 +176,14 @@ Deno.serve(async (req) => {
         .eq('role', 'organization_owner')
         .maybeSingle();
 
-      const ownerUserId = ownerMembership?.user_id ?? user.id;
+      const ownerUserId = ownerMembership?.user_id;
+      if (!ownerUserId) {
+        console.error(`track-ai-usage: org ${effectiveOrgId} has no organization_owner`);
+        return new Response(
+          JSON.stringify({ error: 'Organization has no owner — cannot determine subscription tier' }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
       const { data: profile } = await supabase
         .from('user_profiles')
         .select('product_id, subscription_status, current_period_end')

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -113,51 +113,111 @@ Deno.serve(async (req) => {
       );
     }
 
+    // Step 1: Get organization context and type
+    let effectiveOrgId = orgId;
+    let isPersonal = false;
+
+    if (effectiveOrgId) {
+      const { data: org } = await supabase
+        .from('organizations')
+        .select('type')
+        .eq('id', effectiveOrgId)
+        .maybeSingle();
+      
+      if (org?.type === 'personal') {
+        isPersonal = true;
+      }
+    }
+
     // Compute month_year string (e.g., '2026-03')
     const monthYear = new Date().toISOString().slice(0, 7);
 
-    // Step 1: Get current monthly usage via RPC
-    const { data: currentUsage, error: usageError } = await supabase.rpc(
-      'get_monthly_ai_usage',
-      { p_user_id: user.id, p_month_year: monthYear },
-    );
+    // Step 2: Get current monthly usage and subscription tier
+    let usage = 0;
+    let limit = AI_ACTION_LIMITS.free;
+    let tier = 'free';
 
-    if (usageError) {
-      console.error('track-ai-usage: get_monthly_ai_usage RPC error:', usageError);
-      return new Response(
-        JSON.stringify({ error: 'Failed to retrieve usage data' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    if (effectiveOrgId && !isPersonal) {
+      // TEAM/BUSINESS USAGE: Pooled count for the organization
+      const { data: orgUsage, error: orgUsageError } = await supabase.rpc(
+        'get_monthly_org_ai_usage',
+        { p_org_id: effectiveOrgId, p_month_year: monthYear },
       );
+
+      if (orgUsageError) {
+        console.error('track-ai-usage: get_monthly_org_ai_usage RPC error:', orgUsageError);
+        return new Response(
+          JSON.stringify({ error: 'Failed to retrieve org usage data' }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
+      usage = orgUsage ?? 0;
+
+      // Find organization owner's subscription
+      const { data: ownerMembership } = await supabase
+        .from('organization_memberships')
+        .select('user_id')
+        .eq('organization_id', effectiveOrgId)
+        .eq('role', 'organization_owner')
+        .maybeSingle();
+
+      const ownerUserId = ownerMembership?.user_id ?? user.id;
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('product_id, subscription_status, current_period_end')
+        .eq('user_id', ownerUserId)
+        .maybeSingle();
+      
+      tier = deriveTier(
+        profile?.product_id ?? null,
+        profile?.subscription_status ?? null,
+        profile?.current_period_end ?? null,
+      );
+    } else {
+      // PERSONAL USAGE: Count for the user where org_id is NULL or personal org
+      // (Migration function get_monthly_ai_usage specifically filters org_id IS NULL)
+      const { data: userUsage, error: usageError } = await supabase.rpc(
+        'get_monthly_ai_usage',
+        { p_user_id: user.id, p_month_year: monthYear },
+      );
+
+      if (usageError) {
+        console.error('track-ai-usage: get_monthly_ai_usage RPC error:', usageError);
+        return new Response(
+          JSON.stringify({ error: 'Failed to retrieve usage data' }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
+      usage = userUsage ?? 0;
+
+      // Get user's subscription tier
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('product_id, subscription_status, current_period_end')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      tier = deriveTier(
+        profile?.product_id ?? null,
+        profile?.subscription_status ?? null,
+        profile?.current_period_end ?? null,
+      );
+      
+      // If it's a personal org, we'll store orgId but it won't be counted in get_monthly_ai_usage
+      // unless we update that function or decide NOT to store orgId for personal.
+      // THE FIX: If isPersonal is true, we force effectiveOrgId to null for the insert
+      // so it correctly attributes to the personal (NULL org_id) bucket.
+      if (isPersonal) {
+        effectiveOrgId = undefined;
+      }
     }
 
-    // Step 2: Get user's subscription tier from user_profiles
-    const { data: profile, error: profileError } = await supabase
-      .from('user_profiles')
-      .select('product_id, subscription_status, current_period_end')
-      .eq('user_id', user.id)
-      .maybeSingle();
-
-    if (profileError) {
-      console.error('track-ai-usage: profile fetch error:', profileError);
-      return new Response(
-        JSON.stringify({ error: 'Failed to retrieve subscription data' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-      );
-    }
-
-    // Step 3: Derive tier and get limit
-    const tier = deriveTier(
-      profile?.product_id ?? null,
-      profile?.subscription_status ?? null,
-      profile?.current_period_end ?? null,
-    );
-    const limit = AI_ACTION_LIMITS[tier] ?? AI_ACTION_LIMITS.free;
-    const usage = currentUsage ?? 0;
+    limit = AI_ACTION_LIMITS[tier] ?? AI_ACTION_LIMITS.free;
 
     // Step 4: Enforce limit — return 429 if at or over limit
     if (usage >= limit) {
       console.log(
-        `track-ai-usage: limit reached for user ${user.id} — usage=${usage} limit=${limit} tier=${tier}`,
+        `track-ai-usage: limit reached for ${effectiveOrgId ? 'org ' + effectiveOrgId : 'user ' + user.id} — usage=${usage} limit=${limit} tier=${tier}`,
       );
       return new Response(
         JSON.stringify({
@@ -173,7 +233,7 @@ Deno.serve(async (req) => {
     // Step 5: Insert usage record
     const { error: insertError } = await supabase.from('ai_usage').insert({
       user_id: user.id,
-      org_id: orgId ?? null,
+      org_id: effectiveOrgId ?? null,
       action_type: actionType as AiActionType,
       recording_id: recordingId ?? null,
       month_year: monthYear,
@@ -191,7 +251,7 @@ Deno.serve(async (req) => {
     // Step 6: Return success with updated usage counts
     const newUsage = usage + 1;
     console.log(
-      `track-ai-usage: recorded ${actionType} for user ${user.id} — usage=${newUsage}/${limit} tier=${tier}`,
+      `track-ai-usage: recorded ${actionType} for ${effectiveOrgId ? 'org ' + effectiveOrgId : 'user ' + user.id} — usage=${newUsage}/${limit} tier=${tier}`,
     );
 
     return new Response(

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -19,7 +19,14 @@ const AI_ACTION_LIMITS: Record<string, number> = {
   team: 5000,
 };
 
-const VALID_ACTION_TYPES = ['smart_import', 'auto_name', 'auto_tag', 'chat_message'] as const;
+const VALID_ACTION_TYPES = [
+  'smart_import',
+  'auto_name',
+  'auto_tag',
+  'chat_message',
+  'summarize_call',
+  'generate_content',
+] as const;
 type AiActionType = typeof VALID_ACTION_TYPES[number];
 
 /**

--- a/supabase/functions/track-ai-usage/index.ts
+++ b/supabase/functions/track-ai-usage/index.ts
@@ -133,11 +133,19 @@ Deno.serve(async (req) => {
         );
       }
 
-      const { data: org } = await supabase
+      const { data: org, error: orgError } = await supabase
         .from('organizations')
         .select('type')
         .eq('id', effectiveOrgId)
         .maybeSingle();
+
+      if (orgError) {
+        console.error('track-ai-usage: org type fetch error:', orgError);
+        return new Response(
+          JSON.stringify({ error: 'Failed to retrieve organization data' }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
 
       if (org?.type === 'personal') {
         isPersonal = true;
@@ -184,11 +192,19 @@ Deno.serve(async (req) => {
           { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
         );
       }
-      const { data: profile } = await supabase
+      const { data: profile, error: ownerProfileError } = await supabase
         .from('user_profiles')
         .select('product_id, subscription_status, current_period_end')
         .eq('user_id', ownerUserId)
         .maybeSingle();
+
+      if (ownerProfileError) {
+        console.error('track-ai-usage: owner profile fetch error:', ownerProfileError);
+        return new Response(
+          JSON.stringify({ error: 'Failed to retrieve owner subscription data' }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
       
       tier = deriveTier(
         profile?.product_id ?? null,
@@ -225,10 +241,7 @@ Deno.serve(async (req) => {
         profile?.current_period_end ?? null,
       );
       
-      // If it's a personal org, we'll store orgId but it won't be counted in get_monthly_ai_usage
-      // unless we update that function or decide NOT to store orgId for personal.
-      // THE FIX: If isPersonal is true, we force effectiveOrgId to null for the insert
-      // so it correctly attributes to the personal (NULL org_id) bucket.
+      // Personal orgs use the NULL org_id bucket to match get_monthly_ai_usage's filter
       if (isPersonal) {
         effectiveOrgId = undefined;
       }

--- a/supabase/migrations/20260405000000_add_ai_action_types.sql
+++ b/supabase/migrations/20260405000000_add_ai_action_types.sql
@@ -1,0 +1,13 @@
+-- Migration: Add new AI action types
+-- Purpose: Support summarize_call and generate_content in AI usage tracking
+-- Date: 2026-04-05
+
+ALTER TABLE public.ai_usage
+  DROP CONSTRAINT IF EXISTS ai_usage_action_type_check;
+
+ALTER TABLE public.ai_usage
+  ADD CONSTRAINT ai_usage_action_type_check CHECK (
+    action_type IN ('smart_import', 'auto_name', 'auto_tag', 'chat_message', 'summarize_call', 'generate_content')
+  );
+
+COMMENT ON COLUMN ai_usage.action_type IS 'Type: smart_import | auto_name | auto_tag | chat_message | summarize_call | generate_content';


### PR DESCRIPTION
## Summary
- Wire AI Gate into CallDetailDialog and ReengagementEmailModal for usage enforcement
- Implement org-level AI usage attribution with pooled token tracking
- Simplify MCP server, zoom sync, and contact hooks
- Remove dead planning docs, debug logs, polar webhook, and unused zoom OAuth code
- Net: -5,894 lines removed, +594 added across 69 files

## Branches consolidated
- `milestone/M001` (3 commits from Apr 5)

## Test plan
- [ ] Verify AI gate blocks actions when org usage is exhausted
- [ ] Verify `track-ai-usage` edge function records attribution correctly
- [ ] Verify MCP server still serves expected tools after simplification
- [ ] Verify zoom sync still pulls recordings after refactor
- [ ] Confirm no regressions in contacts table and import flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)