### PR TITLE
perf(import): make Fathom search feel instant

### DIFF
--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -109,4 +109,105 @@ Make Fathom search feel instant (~50ms) instead of slow and variable (1-7s with 
 
 ---
 
+## Fathom Share-Link Save — User-Paste Inbox
+
+**Priority:** High (unique product value, zero infra cost, clean legal posture)
+**Requested by:** Andrew (during research session, 2026-05-06)
+**Status:** Scoped, ready to plan
+
+**Goal:**
+
+Let any user save the contents of any Fathom share link into CallVault by pasting the URL + transcript themselves. CallVault becomes a permanent, searchable home for transcripts the user has been given access to — even ones recorded by other people, even after the original share is revoked.
+
+**Why this framing (legal + ethical):**
+
+Fathom ToS §2 prohibits automated tools accessing the Service AND storing/copying audiovisual works. CallVault therefore makes ZERO server-side requests to fathom.video. The user — Bob — does the copying himself, in his own browser, using Fathom's own "Copy transcript" button. CallVault is a notes app receiving user-generated content. Same legal posture as Notion, Evernote, Obsidian. We are not a Fathom client.
+
+**v1 scope (1 day, ships immediately):**
+
+One paste form. Three fields:
+
+1. **Share URL** (optional) — stored as text reference, never fetched
+2. **Transcript** (required) — pasted from Fathom's "Copy transcript" feature
+3. **Title / Date / Attendees** — auto-parsed from pasted transcript header (Fathom's copy format includes these), editable before save
+
+On save: parse transcript into structured segments (`[{start_ms, speaker, text}]`), insert/update `recordings` row in user's workspace, FTS-index automatically via existing `idx_recordings_transcript_fts`.
+
+**v2+ unlocks (do not build with v1):**
+
+- Bookmarklet — drag-to-bookmarks button that grabs transcript from Fathom DOM in user's session, posts to CallVault. Same legal posture (user clicked, user's browser).
+- Chrome extension — same as bookmarklet, native UX.
+- File upload — user drops MP4 they downloaded themselves via Fathom's owner-only download button. Stored in Supabase Storage.
+- Multi-source — same form accepts Otter, Zoom, Read.ai, Grain transcripts.
+
+**What's already built (don't redo):**
+
+- ✅ `recordings` table — `full_transcript`, `share_url`, `summary`, `source_metadata` JSONB, workspace-scoped via `bank_id` (`supabase/migrations/20260131000007_create_recordings_tables.sql:13-60`)
+- ✅ FTS GIN index `idx_recordings_transcript_fts` — search just works
+- ✅ Workspace RLS on `recordings`
+
+**What's missing (the actual work):**
+
+1. **Migration: ALTER `recordings`** (~10 min)
+   - Add `share_token TEXT` (parsed from URL — dedup key)
+   - Add `transcript_segments JSONB` (structured speaker+timestamp turns)
+   - Add `source_app TEXT` already exists (set to `'fathom-paste'`)
+   - Add unique index `(bank_id, share_token) WHERE share_token IS NOT NULL`
+
+2. **Edge function: `save-pasted-transcript`** (~2 hr)
+   - POST `{ share_url?, raw_transcript, title?, recorded_at?, attendees? }`
+   - Parse Fathom's copy-transcript format → structured segments
+   - Auto-extract title/date/attendees from transcript header if user didn't override
+   - Compute `share_token` from URL if provided
+   - Upsert `recordings` row keyed on `(bank_id, share_token)` (or new UUID if no token)
+   - Return recording_id
+
+3. **Frontend: paste modal** (~3 hr)
+   - New "Save Transcript" button on import page
+   - Modal: big textarea + URL field + auto-detected title/date/attendees preview
+   - Smart-detect Fathom format on paste, auto-fill metadata fields
+   - Submit → call edge function → redirect to recording detail
+   - Component path: `src/components/import/PasteTranscriptModal.tsx`
+
+4. **Transcript-format parser util** (~1 hr)
+   - Pure function: `parseFathomCopyFormat(text) → { title?, date?, attendees, segments }`
+   - Lives in `supabase/functions/_shared/` so edge fn + future client-side preview both use it
+   - Handle Fathom's known format: `Speaker Name (M:SS) text...`
+   - Graceful fallback: if format unrecognized, save raw text + flag `parse_status='raw'`
+
+5. **Recording detail rendering** (~1 hr)
+   - `recordings.source_app === 'fathom-paste'` → render with same UI as imported recordings, but no "play video" affordance (we don't have the file)
+   - Show "Source: Fathom share link" pill with optional outbound link to `share_url`
+
+**Total estimate: ~1 dev-day for v1.**
+
+**Acceptance criteria:**
+
+- User can paste a Fathom transcript + URL into a modal and have it appear in their library within 2 seconds
+- Pasted transcript is searchable via existing global search within 5 seconds of save
+- Repeat-paste of same share URL updates the existing record (no dup)
+- Recording detail page renders pasted recording cleanly (no broken video player)
+- Zero outbound HTTP requests to fathom.video from any CallVault server
+
+**Risks:**
+
+- Fathom changes their copy-transcript format — graceful fallback to raw text mitigates
+- User pastes garbage — parse_status flag surfaces it for cleanup
+- ToS reinterpretation — keep ALL fetching in user's browser, never server-side
+
+**Touches:**
+
+- New migration: `supabase/migrations/<ts>_recordings_paste_columns.sql`
+- New: `supabase/functions/save-pasted-transcript/index.ts`
+- New: `supabase/functions/_shared/fathom-transcript-parser.ts`
+- New: `src/components/import/PasteTranscriptModal.tsx`
+- Modified: `src/pages/import/*` — add "Save Transcript" CTA
+- Modified: `src/components/recordings/RecordingDetail.tsx` — handle missing video case
+
+**Related backlog:**
+
+- Fathom Mirror entry above — both are about Fathom data, but mirror is owner-only-via-API, this is anyone-via-paste. They coexist.
+
+---
+
 *Backlog created: 2026-04-03*

--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -43,4 +43,70 @@ When syncing calls from Fathom, if a call has been renamed or updated in Fathom,
 
 ---
 
+## Fathom Mirror — Read-from-Local for Fast Search
+
+**Priority:** High (UX impact for every user)
+**Requested by:** Andrew (during fetch-meetings perf debug, 2026-05-07)
+**Status:** Not yet scoped
+
+**Goal:**
+
+Make Fathom search feel instant (~50ms) instead of slow and variable (1-7s with 14× spike risk) by reading meeting metadata from our existing webhook-fed mirror table (`fathom_raw_calls`) instead of hitting Fathom's API on every search.
+
+**Why now:**
+
+- Measured Fathom API latency variance: 165ms to 2,277ms per page, same call. With 10/page default and no `limit` param, a 30-day search burns 3-15s.
+- Mirror table `fathom_raw_calls` already exists, indexed, and 99.5% populated (1,293 of 1,300 rows for the test account, going back to 2024-01-16).
+- Webhook handler at `supabase/functions/webhook/index.ts:347` already routes events to the right user via `user_settings.host_email`. Team-account fan-out also already supported.
+- The user-facing perf branch (`perf/fathom-fetch-improvements`) ships live pagination + Load More to mask the slowness — but this turns "masked" into "actually fast."
+
+**What's already built (don't redo):**
+
+- ✅ `webhook` edge function — handles Fathom event POSTs and writes to `fathom_raw_calls`
+- ✅ `create-fathom-webhook` edge function — auto-registers webhook with Fathom via OAuth (function deployed but file currently untracked in source — needs `supabase functions download` and commit)
+- ✅ `fathom_raw_calls` table — title, transcript, summary, recorded_by, calendar_invitees, etc., with `idx_calls_user_id` and `idx_calls_created_at DESC`
+- ✅ Composite PK `(recording_id, user_id)` enabling team-account fan-out
+
+**What's missing (the actual work):**
+
+1. **Backfill on signup (~2-3 hr)** — A new user has historical Fathom meetings the webhook never saw. Need a one-time bulk pull when they connect OAuth: paginate Fathom's `/external/v1/meetings`, write each into `fathom_raw_calls`. Could reuse logic from `sync-meetings`.
+2. **Reconciliation cron (~2 hr)** — Webhooks fail silently sometimes (the 7-row gap on the test account proves this). Daily job that diffs `fathom_raw_calls` vs Fathom's API for each user and backfills any missing rows.
+3. **Verify OAuth-callback auto-fires `create-fathom-webhook` (~30 min)** — If it's a manual button click, new users silently have no webhook firing. Confirm or wire it.
+4. **Multi-account-per-user routing (~1 hr)** — `import_sources` supports a user having N Fathom accounts (different emails), but `host_email` lives singularly on `user_settings`. Either move `host_email` to `import_sources` or store an array.
+5. **Switch `fetch-meetings` to read from the mirror (~1-2 hr)** — Replace the Fathom API loop with a Postgres SELECT on `fathom_raw_calls`. Keep the sync-status check against `recordings` (already fast). Optional: for "Today" date ranges, top up with one Fathom API call to catch meetings recorded in the last ~5 minutes that haven't webhooked yet.
+6. **Restore `create-fathom-webhook` to source control (~5 min)** — Currently deployed-but-untracked.
+
+**Total estimate:** ~1 dev-day if done together.
+
+**Touches:**
+
+- `supabase/functions/fetch-meetings/index.ts` — swap Fathom API loop for Postgres query
+- `supabase/functions/fathom-oauth-callback/index.ts` — verify/wire backfill kickoff + webhook registration
+- `supabase/functions/create-fathom-webhook/index.ts` — bring under source control
+- New: `supabase/functions/fathom-backfill/index.ts` — bulk pull for new users
+- New: cron job (Supabase scheduled function or external) — daily reconciliation
+- Migration: maybe move `host_email` from `user_settings` to `import_sources` for multi-account support
+- `src/components/import/FathomImportDetail.tsx` — once mirror is the source, can drop pagination Load More button (just show all)
+
+**Acceptance criteria:**
+
+- A 30-day Fathom search returns in <200ms p95 (vs current 1-7s)
+- A new user connecting Fathom sees their full history within 2 minutes of connecting (backfill complete)
+- The 7-row gap is closed and reconciliation runs nightly to prevent future drift
+- A user with 2+ Fathom accounts sees meetings from all of them routed to their library
+
+**Risks:**
+
+- Fathom webhook reliability — if events get dropped, mirror drifts. Mitigated by reconciliation cron.
+- "Just-recorded" gap — call recorded 30s ago may not be in mirror yet. Acceptable for date-range searches; mitigated for "Today" via top-up call.
+- Backfill API rate limit — Fathom is 60 req/min. A user with 1,000 meetings = ~17 minutes of backfill. Need to do this async with progress UI.
+
+**Related:**
+
+- `perf/fathom-fetch-improvements` branch — ships live pagination + 5min cache as a holdover until this lands
+- Webhook handler: `supabase/functions/webhook/index.ts`
+- Mirror schema: see `fathom_raw_calls` columns in DB
+
+---
+
 *Backlog created: 2026-04-03*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -47,6 +47,7 @@ Phases 7-10 were stub phases (Drag-to-Folder, YouTube Workspace UI, Global Searc
 - [ ] **Phase 21: Write CRUD Tools** - Note, tag, and folder organization tools
 - [ ] **Phase 22: AI Tools** - LLM-powered per-call analysis tools with DB caching
 - [ ] **Phase 23: Management UI** - Settings UI for connection details, token control, and capability toggles
+- [ ] **Phase 24: Fathom Share-Link Save** - Paste-driven save of any Fathom share-link transcript into the user's workspace (zero server-side fetch from fathom.video)
 
 ## Phase Details
 

--- a/src/components/dialogs/CreateWorkspaceDialog.tsx
+++ b/src/components/dialogs/CreateWorkspaceDialog.tsx
@@ -51,28 +51,23 @@ export function CreateWorkspaceDialog({
   const { organizations, activeOrgId } = useOrganizationContext()
   const createWorkspace = useCreateWorkspace()
 
-  const businessOrganizations = useMemo(
-    () => organizations.filter((org) => org.type === 'business'),
+  const availableOrganizations = useMemo(
+    () => organizations,
     [organizations]
   )
 
-  const showOrgSelect = businessOrganizations.length > 1
+  const showOrgSelect = availableOrganizations.length > 1
 
   useEffect(() => {
     if (!open) return
 
-    // Auto-select logic
-    const businessDefault =
-      businessOrganizations.find((org) => org.id === activeOrgId)?.id ||
-      businessOrganizations[0]?.id ||
-      ''
+    const activeMatch = availableOrganizations.find((org) => org.id === activeOrgId)?.id
+    const defaultOrg = activeMatch || availableOrganizations[0]?.id || ''
 
-    const fallbackOrg = showOrgSelect
-      ? businessDefault
-      : orgId || activeOrgId || businessDefault
+    const fallbackOrg = orgId || defaultOrg
 
     setSelectedOrgId(fallbackOrg)
-  }, [open, orgId, activeOrgId, businessOrganizations, showOrgSelect])
+  }, [open, orgId, activeOrgId, availableOrganizations])
 
   const trimmedName = name.trim()
   const isNameValid = trimmedName.length >= 3 && trimmedName.length <= 50
@@ -199,7 +194,7 @@ export function CreateWorkspaceDialog({
                   <SelectValue placeholder="Select an organization" />
                 </SelectTrigger>
                 <SelectContent>
-                  {businessOrganizations.map((org) => (
+                  {availableOrganizations.map((org) => (
                     <SelectItem key={org.id} value={org.id}>
                       {org.name}
                     </SelectItem>

--- a/src/components/import/FathomImportDetail.tsx
+++ b/src/components/import/FathomImportDetail.tsx
@@ -71,6 +71,16 @@ export interface FathomImportDetailProps {
   onDisconnect: (source: ImportSource) => void;
 }
 
+// ─── Search cache ─────────────────────────────────────────────────────────────
+// Module-scoped — survives re-renders and route swaps within the same SPA
+// session. Keyed by source + date range. Invalidated after a successful import
+// so the list reflects newly-synced meetings.
+const SEARCH_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+type CachedSearch = { meetings: FathomMeeting[]; fetchedAt: number };
+const searchCache = new Map<string, CachedSearch>();
+const cacheKeyFor = (sourceId: string | null, after: string, before: string) =>
+  `${sourceId ?? 'default'}|${after}|${before}`;
+
 // ─── Duration helper ──────────────────────────────────────────────────────────
 
 function formatDuration(start?: string, end?: string): string | null {
@@ -126,6 +136,8 @@ export function FathomImportDetail({
   const [meetings, setMeetings] = useState<FathomMeeting[]>([]);
   const [loading, setLoading] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
+  // Live progress while paginating Fathom: shown next to the spinner.
+  const [searchProgress, setSearchProgress] = useState<{ page: number; count: number } | null>(null);
 
   // Selection state — Fathom recording_id is numeric
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -266,6 +278,8 @@ export function FathomImportDetail({
     try {
       const createdAfter = toUTCStart(dateRange.from);
       const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
+      // Bust the cache for this range so the next manual search re-fetches.
+      searchCache.delete(cacheKeyFor(activeSourceId, createdAfter, createdBefore));
 
       const { data, error } = await supabase.functions.invoke('fetch-meetings', {
         body: { createdAfter, createdBefore, sourceId: activeSourceId },
@@ -274,6 +288,10 @@ export function FathomImportDetail({
 
       const fetched: FathomMeeting[] = data.meetings || [];
       setMeetings(fetched);
+      searchCache.set(cacheKeyFor(activeSourceId, createdAfter, createdBefore), {
+        meetings: fetched,
+        fetchedAt: Date.now(),
+      });
     } catch {
       // Best-effort refresh — already showed the success toast on import.
     }
@@ -285,29 +303,68 @@ export function FathomImportDetail({
     setHasFetched(false);
     setMeetings([]);
     setSelected(new Set());
+    setSearchProgress(null);
+
+    const createdAfter = toUTCStart(dateRange.from);
+    const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
+    const cacheKey = cacheKeyFor(activeSourceId, createdAfter, createdBefore);
+
+    // Cache hit: render instantly. Skip the Fathom round-trip entirely.
+    const cached = searchCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < SEARCH_CACHE_TTL_MS) {
+      setMeetings(cached.meetings);
+      setHasFetched(true);
+      setLoading(false);
+      const unsynced = cached.meetings.filter((m) => !m.synced).length;
+      toast.success(
+        `Found ${cached.meetings.length} call${cached.meetings.length !== 1 ? 's' : ''} — ${unsynced} available (cached)`
+      );
+      return;
+    }
 
     try {
-      const createdAfter = toUTCStart(dateRange.from);
-      const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
+      // Page-by-page so the user sees results stream in instead of a 14s freeze.
+      let cursor: string | null = null;
+      let page = 0;
+      const collected: FathomMeeting[] = [];
 
-      const { data, error } = await supabase.functions.invoke('fetch-meetings', {
-        body: { createdAfter, createdBefore, sourceId: activeSourceId },
-      });
+      do {
+        page++;
+        const { data, error } = await supabase.functions.invoke('fetch-meetings', {
+          body: {
+            createdAfter,
+            createdBefore,
+            sourceId: activeSourceId,
+            cursor: cursor ?? undefined,
+            pageMode: true,
+          },
+        });
+        if (error) throw error;
+        if (data?.error) throw new Error(data.error);
 
-      if (error) throw error;
-      if (data?.error) throw new Error(data.error);
+        const pageMeetings: FathomMeeting[] = data.meetings || [];
+        collected.push(...pageMeetings);
+        // Render meetings as they arrive — early results become clickable
+        // before the full search finishes.
+        setMeetings([...collected]);
+        setSearchProgress({ page, count: collected.length });
 
-      const fetched: FathomMeeting[] = data.meetings || [];
-      setMeetings(fetched);
+        cursor = (data.next_cursor as string | null) ?? null;
+      } while (cursor);
+
       setHasFetched(true);
+      searchCache.set(cacheKey, { meetings: collected, fetchedAt: Date.now() });
 
-      const unsyncedCount = fetched.filter((m) => !m.synced).length;
-      toast.success(`Found ${fetched.length} call${fetched.length !== 1 ? 's' : ''} — ${unsyncedCount} available to import`);
+      const unsynced = collected.filter((m) => !m.synced).length;
+      toast.success(
+        `Found ${collected.length} call${collected.length !== 1 ? 's' : ''} — ${unsynced} available to import`
+      );
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to fetch meetings';
       toast.error(msg);
     } finally {
       setLoading(false);
+      setSearchProgress(null);
     }
   }, [dateRange, activeSourceId]);
 
@@ -741,13 +798,17 @@ export function FathomImportDetail({
               className="gap-2 bg-vibe-orange hover:bg-vibe-orange/90 text-white"
             >
               <RiSearchLine className="h-3.5 w-3.5" />
-              {loading ? 'Searching…' : 'Search Fathom'}
+              {loading
+                ? searchProgress
+                  ? `Searching… (${searchProgress.count} found, page ${searchProgress.page})`
+                  : 'Searching…'
+                : 'Search Fathom'}
             </Button>
           </div>
         </div>
 
         {/* ── Results ── */}
-        {loading && (
+        {loading && meetings.length === 0 && (
           <div className="px-6 space-y-2 pb-4">
             {[0, 1, 2, 3].map((i) => (
               <div
@@ -758,7 +819,15 @@ export function FathomImportDetail({
           </div>
         )}
 
-        {!loading && hasFetched && (
+        {!loading && hasFetched && meetings.length === 0 && (
+          <div className="px-6 pb-4">
+            <p className="text-xs text-muted-foreground py-4 text-center">
+              No calls found in this date range.
+            </p>
+          </div>
+        )}
+
+        {(loading || hasFetched) && meetings.length > 0 && (
           <div className="px-6 pb-4">
             {/* Results header row */}
             <div className="flex items-center gap-3 py-2 mb-1">

--- a/src/components/import/FathomImportDetail.tsx
+++ b/src/components/import/FathomImportDetail.tsx
@@ -76,7 +76,12 @@ export interface FathomImportDetailProps {
 // session. Keyed by source + date range. Invalidated after a successful import
 // so the list reflects newly-synced meetings.
 const SEARCH_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-type CachedSearch = { meetings: FathomMeeting[]; fetchedAt: number };
+type CachedSearch = {
+  meetings: FathomMeeting[];
+  nextCursor: string | null;
+  pagesLoaded: number;
+  fetchedAt: number;
+};
 const searchCache = new Map<string, CachedSearch>();
 const cacheKeyFor = (sourceId: string | null, after: string, before: string) =>
   `${sourceId ?? 'default'}|${after}|${before}`;
@@ -135,9 +140,12 @@ export function FathomImportDetail({
   // Results state
   const [meetings, setMeetings] = useState<FathomMeeting[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
-  // Live progress while paginating Fathom: shown next to the spinner.
-  const [searchProgress, setSearchProgress] = useState<{ page: number; count: number } | null>(null);
+  // Cursor for the next Fathom page; null = no more pages.
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  // How many pages already pulled (used in the Load More button label).
+  const [pagesLoaded, setPagesLoaded] = useState(0);
 
   // Selection state — Fathom recording_id is numeric
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -288,14 +296,43 @@ export function FathomImportDetail({
 
       const fetched: FathomMeeting[] = data.meetings || [];
       setMeetings(fetched);
+      // refetchMeetingsSilently uses legacy mode (all pages), so the cached
+      // entry's nextCursor is null and pagesLoaded reflects "everything".
       searchCache.set(cacheKeyFor(activeSourceId, createdAfter, createdBefore), {
         meetings: fetched,
+        nextCursor: null,
+        pagesLoaded: 0,
         fetchedAt: Date.now(),
       });
+      setNextCursor(null);
     } catch {
       // Best-effort refresh — already showed the success toast on import.
     }
   }, [dateRange, activeSourceId]);
+
+  const fetchPage = useCallback(
+    async (cursor: string | null): Promise<{ meetings: FathomMeeting[]; nextCursor: string | null }> => {
+      if (!dateRange.from) return { meetings: [], nextCursor: null };
+      const createdAfter = toUTCStart(dateRange.from);
+      const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
+      const { data, error } = await supabase.functions.invoke('fetch-meetings', {
+        body: {
+          createdAfter,
+          createdBefore,
+          sourceId: activeSourceId,
+          cursor: cursor ?? undefined,
+          pageMode: true,
+        },
+      });
+      if (error) throw error;
+      if (data?.error) throw new Error(data.error);
+      return {
+        meetings: (data.meetings as FathomMeeting[]) || [],
+        nextCursor: (data.next_cursor as string | null) ?? null,
+      };
+    },
+    [dateRange, activeSourceId]
+  );
 
   const handleSearch = useCallback(async () => {
     if (!dateRange.from) return;
@@ -303,7 +340,8 @@ export function FathomImportDetail({
     setHasFetched(false);
     setMeetings([]);
     setSelected(new Set());
-    setSearchProgress(null);
+    setNextCursor(null);
+    setPagesLoaded(0);
 
     const createdAfter = toUTCStart(dateRange.from);
     const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
@@ -313,6 +351,8 @@ export function FathomImportDetail({
     const cached = searchCache.get(cacheKey);
     if (cached && Date.now() - cached.fetchedAt < SEARCH_CACHE_TTL_MS) {
       setMeetings(cached.meetings);
+      setNextCursor(cached.nextCursor);
+      setPagesLoaded(cached.pagesLoaded);
       setHasFetched(true);
       setLoading(false);
       const unsynced = cached.meetings.filter((m) => !m.synced).length;
@@ -323,50 +363,55 @@ export function FathomImportDetail({
     }
 
     try {
-      // Page-by-page so the user sees results stream in instead of a 14s freeze.
-      let cursor: string | null = null;
-      let page = 0;
-      const collected: FathomMeeting[] = [];
-
-      do {
-        page++;
-        const { data, error } = await supabase.functions.invoke('fetch-meetings', {
-          body: {
-            createdAfter,
-            createdBefore,
-            sourceId: activeSourceId,
-            cursor: cursor ?? undefined,
-            pageMode: true,
-          },
-        });
-        if (error) throw error;
-        if (data?.error) throw new Error(data.error);
-
-        const pageMeetings: FathomMeeting[] = data.meetings || [];
-        collected.push(...pageMeetings);
-        // Render meetings as they arrive — early results become clickable
-        // before the full search finishes.
-        setMeetings([...collected]);
-        setSearchProgress({ page, count: collected.length });
-
-        cursor = (data.next_cursor as string | null) ?? null;
-      } while (cursor);
-
+      // Fetch only the FIRST page so the user can start clicking right away.
+      // The Load More button pulls additional pages on demand.
+      const { meetings: firstPage, nextCursor: cursor } = await fetchPage(null);
+      setMeetings(firstPage);
+      setNextCursor(cursor);
+      setPagesLoaded(1);
       setHasFetched(true);
-      searchCache.set(cacheKey, { meetings: collected, fetchedAt: Date.now() });
+      searchCache.set(cacheKey, { meetings: firstPage, nextCursor: cursor, pagesLoaded: 1, fetchedAt: Date.now() });
 
-      const unsynced = collected.filter((m) => !m.synced).length;
+      const unsynced = firstPage.filter((m) => !m.synced).length;
+      const moreNote = cursor ? ' (more available)' : '';
       toast.success(
-        `Found ${collected.length} call${collected.length !== 1 ? 's' : ''} — ${unsynced} available to import`
+        `Loaded ${firstPage.length} call${firstPage.length !== 1 ? 's' : ''} — ${unsynced} available to import${moreNote}`
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to fetch meetings';
       toast.error(msg);
     } finally {
       setLoading(false);
-      setSearchProgress(null);
     }
-  }, [dateRange, activeSourceId]);
+  }, [dateRange, activeSourceId, fetchPage]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore || !dateRange.from) return;
+    setLoadingMore(true);
+    try {
+      const { meetings: nextPage, nextCursor: newCursor } = await fetchPage(nextCursor);
+      const merged = [...meetings, ...nextPage];
+      setMeetings(merged);
+      setNextCursor(newCursor);
+      setPagesLoaded((p) => p + 1);
+
+      // Extend the cache so a fresh search inside the TTL skips re-fetching
+      // already-loaded pages.
+      const createdAfter = toUTCStart(dateRange.from);
+      const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
+      searchCache.set(cacheKeyFor(activeSourceId, createdAfter, createdBefore), {
+        meetings: merged,
+        nextCursor: newCursor,
+        pagesLoaded: pagesLoaded + 1,
+        fetchedAt: Date.now(),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load more';
+      toast.error(msg);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [nextCursor, loadingMore, dateRange, activeSourceId, fetchPage, meetings, pagesLoaded]);
 
   // ── Selection helpers ─────────────────────────────────────────────────────
 
@@ -798,11 +843,7 @@ export function FathomImportDetail({
               className="gap-2 bg-vibe-orange hover:bg-vibe-orange/90 text-white"
             >
               <RiSearchLine className="h-3.5 w-3.5" />
-              {loading
-                ? searchProgress
-                  ? `Searching… (${searchProgress.count} found, page ${searchProgress.page})`
-                  : 'Searching…'
-                : 'Search Fathom'}
+              {loading ? 'Searching…' : 'Search Fathom'}
             </Button>
           </div>
         </div>
@@ -914,6 +955,23 @@ export function FathomImportDetail({
                     </div>
                   );
                 })}
+
+                {/* Load more — only when Fathom has additional pages. */}
+                {nextCursor && (
+                  <div className="pt-3 flex justify-center">
+                    <Button
+                      variant="hollow"
+                      size="sm"
+                      onClick={handleLoadMore}
+                      disabled={loadingMore || syncing}
+                      className="gap-2"
+                    >
+                      {loadingMore
+                        ? 'Loading…'
+                        : `Load more (${pagesLoaded * 10} loaded)`}
+                    </Button>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/supabase/functions/apply-routing-rules/index.ts
+++ b/supabase/functions/apply-routing-rules/index.ts
@@ -278,27 +278,29 @@ Deno.serve(async (req) => {
             return 'created';
           } else {
             // ----------------------------------------------------------------
-            // Same-org rule: MOVE to target workspace.
-            // Insert new entry first, then delete old entries from other workspaces.
-            // This moves the call — it won't appear in the old workspace anymore.
+            // Same-org rule: MOVE to target workspace + folder.
+            // "Already there" requires BOTH workspace_id AND folder_id to match —
+            // otherwise the rule's intended folder routing won't take effect on
+            // calls that already sit in the target workspace under the wrong folder
+            // (or no folder, e.g. calls put in the default workspace at import time).
             // ----------------------------------------------------------------
             const { data: existingEntry } = await supabase
               .from('workspace_entries')
-              .select('id')
+              .select('id, folder_id')
               .eq('workspace_id', match.target_workspace_id)
               .eq('recording_id', match.recording_id)
               .maybeSingle();
 
-            const wasAlreadyThere = !!existingEntry;
+            const targetFolderId = match.target_folder_id ?? null;
+            const existingFolderId = existingEntry?.folder_id ?? null;
+            const wasAlreadyThere = !!existingEntry && existingFolderId === targetFolderId;
 
-            if (wasAlreadyThere) {
-              // Already in target workspace — just stamp the routing trace below
-            } else {
-              // Insert into target workspace
+            if (!wasAlreadyThere) {
+              // Upsert: inserts when missing, updates folder_id when workspace already has the entry.
               const entryPayload: Record<string, unknown> = {
                 workspace_id: match.target_workspace_id,
                 recording_id: match.recording_id,
-                folder_id: match.target_folder_id ?? null,
+                folder_id: targetFolderId,
               };
 
               const { error: entryError } = await supabase
@@ -309,7 +311,8 @@ Deno.serve(async (req) => {
                 throw new Error(`workspace_entry upsert failed for ${match.recording_id}: ${entryError.message}`);
               }
 
-              // Remove from all OTHER workspaces (move semantics)
+              // Move semantics: recording lives ONLY in the target workspace.
+              // Idempotent — safe to run even when there are no other entries.
               const { error: deleteError } = await supabase
                 .from('workspace_entries')
                 .delete()

--- a/supabase/functions/create-fathom-webhook/index.ts
+++ b/supabase/functions/create-fathom-webhook/index.ts
@@ -1,0 +1,128 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/cors.ts';
+Deno.serve(async (req)=>{
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      headers: corsHeaders
+    });
+  }
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    // Get user ID from JWT
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({
+        error: 'No authorization header'
+      }), {
+        status: 401,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+    if (userError || !user) {
+      return new Response(JSON.stringify({
+        error: 'Unauthorized'
+      }), {
+        status: 401,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    // Get OAuth access token
+    const { data: settings } = await supabase.from('user_settings').select('oauth_access_token').eq('user_id', user.id).maybeSingle();
+    if (!settings?.oauth_access_token) {
+      return new Response(JSON.stringify({
+        error: 'OAuth not connected. Please connect with OAuth first.'
+      }), {
+        status: 400,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    const accessToken = settings.oauth_access_token;
+    const webhookUrl = `${supabaseUrl}/functions/v1/webhook`;
+    // Create webhook in Fathom using OAuth
+    const webhookResponse = await fetch('https://fathom.video/external/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        destination_url: webhookUrl,
+        triggered_for: [
+          'my_recordings'
+        ],
+        include_transcript: true,
+        include_summary: true,
+        include_action_items: true
+      })
+    });
+    if (!webhookResponse.ok) {
+      const errorText = await webhookResponse.text();
+      console.error('Webhook creation failed:', webhookResponse.status, errorText);
+      // Check if webhook already exists
+      if (webhookResponse.status === 409 || errorText.includes('already exists')) {
+        return new Response(JSON.stringify({
+          error: 'Webhook already exists for this URL. You\'re all set!',
+          alreadyExists: true
+        }), {
+          status: 409,
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'application/json'
+          }
+        });
+      }
+      throw new Error(`Failed to create webhook: ${errorText}`);
+    }
+    const webhookData = await webhookResponse.json();
+    console.log('Webhook created successfully:', webhookData);
+    // Store webhook secret in user_settings
+    if (webhookData.secret) {
+      const { error: updateError } = await supabase.from('user_settings').update({
+        webhook_secret: webhookData.secret
+      }).eq('user_id', user.id);
+      if (updateError) {
+        console.error('Error storing webhook secret:', updateError);
+        throw updateError;
+      }
+    }
+    console.log('Webhook auto-configured successfully for user:', user.id);
+    return new Response(JSON.stringify({
+      success: true,
+      message: 'Webhook created and configured automatically!',
+      webhookId: webhookData.id
+    }), {
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (error) {
+    console.error('Error creating webhook:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(JSON.stringify({
+      success: false,
+      error: errorMessage
+    }), {
+      status: 500,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+});

--- a/supabase/functions/fetch-meetings/index.ts
+++ b/supabase/functions/fetch-meetings/index.ts
@@ -158,7 +158,17 @@ Deno.serve(async (req) => {
     console.log('[fetch-meetings] Auth success for user:', user.id);
 
     // Parse request body first to get sourceId and date params
-    const { createdAfter, createdBefore, sourceId } = await req.json();
+    // pageMode: when true, fetch a single Fathom page and return its next_cursor
+    // so the frontend can paginate (and stream progress to the user). When false
+    // or omitted, the function fetches every page in a loop (legacy callers).
+    const { createdAfter, createdBefore, sourceId, cursor: initialCursor, pageMode } =
+      await req.json() as {
+        createdAfter?: string;
+        createdBefore?: string;
+        sourceId?: string;
+        cursor?: string;
+        pageMode?: boolean;
+      };
 
     // ── Resolve Fathom credentials ──────────────────────────────────────────
     // Priority: import_sources (per-account) → user_settings (legacy fallback)
@@ -309,10 +319,14 @@ Deno.serve(async (req) => {
     if (createdAfter) params.append('created_after', createdAfter);
     if (createdBefore) params.append('created_before', createdBefore);
 
-    // Fetch all meetings with pagination and rate limit handling
+    // Fetch meetings with pagination and rate limit handling.
+    // pageMode=true → fetch ONE page (starting from initialCursor if provided) so the
+    // frontend can paginate and show progress.
+    // pageMode=false → fetch every page in a loop (legacy callers like SyncTab).
     const allMeetings: FathomMeeting[] = [];
-    let cursor: string | null = null;
+    let cursor: string | null = initialCursor ?? null;
     let hasMore = true;
+    let nextCursor: string | null = null;
     const maxRetries = 3;
 
     while (hasMore) {
@@ -350,14 +364,15 @@ Deno.serve(async (req) => {
           }
 
           const data = await response.json();
-          
+
           if (data.items && data.items.length > 0) {
             allMeetings.push(...data.items);
             console.log(`Fetched ${data.items.length} meetings (total: ${allMeetings.length})`);
           }
 
           cursor = data.next_cursor;
-          hasMore = !!cursor;
+          nextCursor = data.next_cursor ?? null;
+          hasMore = pageMode ? false : !!cursor;
           success = true;
 
         } catch (error) {
@@ -455,6 +470,8 @@ Deno.serve(async (req) => {
     return new Response(
       JSON.stringify({
         meetings: meetingsWithSyncStatus,
+        // Only emitted in pageMode; legacy callers ignore it.
+        ...(pageMode ? { next_cursor: nextCursor } : {}),
       }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );

--- a/supabase/functions/fetch-meetings/index.ts
+++ b/supabase/functions/fetch-meetings/index.ts
@@ -304,11 +304,10 @@ Deno.serve(async (req) => {
 
     console.log('Fetching meetings from Fathom API', { createdAfter, createdBefore });
 
-    // Build query parameters - include calendar invitees for participant data
+    // calendar_invitees is part of the default response — no opt-in flag exists.
     const params = new URLSearchParams();
     if (createdAfter) params.append('created_after', createdAfter);
     if (createdBefore) params.append('created_before', createdBefore);
-    params.append('include_calendar_invitees', 'true');
 
     // Fetch all meetings with pagination and rate limit handling
     const allMeetings: FathomMeeting[] = [];

--- a/supabase/functions/fetch-single-meeting/index.ts
+++ b/supabase/functions/fetch-single-meeting/index.ts
@@ -212,7 +212,6 @@ serve(async (req) => {
 
       for (let page = 0; page < maxPages; page++) {
         const listUrl = new URL('https://api.fathom.ai/external/v1/meetings');
-        listUrl.searchParams.append('include_calendar_invitees', 'true');
 
         if (createdAfter) {
           listUrl.searchParams.append('created_after', createdAfter);

--- a/supabase/functions/sync-meetings/index.ts
+++ b/supabase/functions/sync-meetings/index.ts
@@ -496,7 +496,6 @@ Deno.serve(async (req) => {
 
       for (let pageCount = 0; pageCount < maxPages; pageCount++) {
         const url = new URL('https://api.fathom.ai/external/v1/meetings');
-        url.searchParams.append('include_calendar_invitees', 'true');
 
         // Add date filters if provided
         if (createdAfter) {


### PR DESCRIPTION
## Summary

Eliminates the 14s freeze on Fathom search reported in the debug panel and replaces it with sub-second perceived latency. Investigation confirmed the slowness is Fathom's API (165ms-2,277ms per page, 14× variance), not our code.

**Two-pronged improvement:**
- **Backend**: `fetch-meetings` accepts `pageMode: true` + `cursor` for page-by-page fetches. Backward-compatible — legacy callers unchanged.
- **Frontend**: search now fetches page 1 only (~850ms verified end-to-end), shows results immediately, and offers an explicit "Load more (10 loaded)" button for additional pages. 5-minute module-scoped cache keyed by `[sourceId, dateRange]` returns instantly on re-search.

**Cleanup along the way:**
- Stripped `include_calendar_invitees=true` from 3 edge functions — verified against Fathom's OpenAPI spec to be a silently-ignored, non-existent parameter (byte-identical responses with vs without).
- Restored `create-fathom-webhook` to source control (deployed but file orphaned in March cleanup).
- Added `.planning/BACKLOG.md` entry for the next big win — switching `fetch-meetings` to read from the existing `fathom_raw_calls` webhook mirror (~1 dev-day, would make searches truly instant).

## Verified

- ✅ Type-check clean (`npx tsc --noEmit`)
- ✅ Edge functions deployed via `--use-api`
- ✅ End-to-end via dev-browser at localhost: page 1 in 851ms, "Load more" appends page 2, button updates to "(20 loaded)"
- ✅ Backward compat: legacy `fetch-meetings` body (no `pageMode`) still returns all meetings in one shot — SyncTab and other callers unaffected
- ✅ Real Fathom API tests with the test account's OAuth token

## Test plan

- [ ] Click into Fathom import on production
- [ ] Pick "Last 30 Days", click Search Fathom
- [ ] Confirm first 10 meetings render in ≤2s (vs 7-14s before)
- [ ] Click "Load more" — verify next 10 append
- [ ] Search same range a second time within 5 min — verify instant cache hit (toast says "(cached)")
- [ ] Import a meeting — verify list refreshes correctly post-import (cache invalidates for current range)
- [ ] Open SyncTab — verify legacy fetch-all flow still works

## Heads-up

Branch contains 2 commits with messages already on main as different SHAs (`8eaee499` workspace fix, `b6377b31` rules folder_id fix). GitHub's merge will detect they're duplicate-by-content. Squash merge recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)