### PR TITLE
fix: userId shadowing security bug + wire e2e-smoke secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CALLVAULTAI_LOGIN: ${{ secrets.CALLVAULTAI_LOGIN }}
+          CALLVAULTAI_LOGIN_PASSWORD: ${{ secrets.CALLVAULTAI_LOGIN_PASSWORD }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/supabase/functions/auto-tag-calls/index.ts
+++ b/supabase/functions/auto-tag-calls/index.ts
@@ -290,11 +290,10 @@ Deno.serve(async (req) => {
       console.log(`Internal service call for user: ${userId}`);
     } else {
       // External call - verify JWT authorization
-            // SEC-02A: Authenticate via shared helper (Phase 37 shared-auth migration)
+      // SEC-02A: Authenticate via shared helper (Phase 37 shared-auth migration)
       const authResult = await authenticateRequest(req, supabase, corsHeaders);
       if (authResult instanceof Response) return authResult;
-      const userId = authResult.userId;
-      userId = userId;
+      userId = authResult.userId;
     }
 
     // -----------------------------------------------------------------------

--- a/supabase/functions/generate-ai-titles/index.ts
+++ b/supabase/functions/generate-ai-titles/index.ts
@@ -351,11 +351,10 @@ Deno.serve(async (req) => {
     // Authorization token — this prevents unauthenticated clients from bypassing JWT
     // by simply including a user_id in the request body.
     if (internalUserId) {
-            // SEC-02A: Authenticate via shared helper (Phase 37 shared-auth migration)
+      // SEC-02A: Authenticate via shared helper (Phase 37 shared-auth migration)
       const authResult = await authenticateRequest(req, supabase, corsHeaders);
       if (authResult instanceof Response) return authResult;
-      const userId = authResult.userId;
-      userId = userId;
+      userId = authResult.userId;
     }
 
     // Check user preference when called from automated pipeline


### PR DESCRIPTION
**Narrowed from the original CI-restore PR** — most of that work landed in parallel via b2526c3b. This PR retains only the 2 fixes that are NOT on main:

## 1. Security: userId variable shadowing bug

`supabase/functions/auto-tag-calls/index.ts` and `.../generate-ai-titles/index.ts` had this anti-pattern inside the auth-helper if-block:

```typescript
let userId: string;  // outer

if (internalUserId) {
    const authResult = await authenticateRequest(...);
    if (authResult instanceof Response) return authResult;
    const userId = authResult.userId;  // SHADOWS outer
    userId = userId;                   // self-assign on the inner const
}
```

The outer `let userId` was never assigned on the auth path → all downstream Supabase queries (`.eq('user_id', userId)`) operated with `userId === undefined`. Also triggered Deno lint errors (`no-const-assign` + `no-self-assign`).

Fix: remove the inner const declaration so the assignment hits the outer let, and delete the self-assign.

## 2. CI: wire missing e2e-smoke secrets

`e2e-smoke` job's env block only passed `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` through. The Playwright suite (`e2e/mcp-server.spec.ts:88`) asserts `SUPABASE_SERVICE_ROLE_KEY`, `CALLVAULTAI_LOGIN`, `CALLVAULTAI_LOGIN_PASSWORD` are present before running. Added them.

(All 6 of those secrets are already configured in the GH Actions secrets store as of 2026-05-20.)