### PR TITLE
codex: additional comments on the prs to check out, and an error: ⎯⎯⎯⎯⎯⎯ Failed Suit...

### DIFF
--- a/src/test/rls-regression.test.ts
+++ b/src/test/rls-regression.test.ts
@@ -121,7 +121,7 @@ describe.skipIf(!integrationDbReachable)(
         .from('organizations')
         .insert({
           name: `${SUITE_TAG} Org A ${stamp}`,
-          owner_user_id: userAId,
+          type: 'business',
         })
         .select('id')
         .single()
@@ -136,7 +136,7 @@ describe.skipIf(!integrationDbReachable)(
         .from('organizations')
         .insert({
           name: `${SUITE_TAG} Org B ${stamp}`,
-          owner_user_id: userBId,
+          type: 'business',
         })
         .select('id')
         .single()
@@ -150,10 +150,18 @@ describe.skipIf(!integrationDbReachable)(
       // 3. Membership rows (owner role) so each user can see their own org.
       await admin
         .from('organization_memberships')
-        .insert({ organization_id: orgAId, user_id: userAId, role: 'owner' })
+        .insert({
+          organization_id: orgAId,
+          user_id: userAId,
+          role: 'organization_owner',
+        })
       await admin
         .from('organization_memberships')
-        .insert({ organization_id: orgBId, user_id: userBId, role: 'owner' })
+        .insert({
+          organization_id: orgBId,
+          user_id: userBId,
+          role: 'organization_owner',
+        })
 
       // 4. Workspace + folder per org.
       const wsA = await admin
@@ -161,7 +169,7 @@ describe.skipIf(!integrationDbReachable)(
         .insert({
           organization_id: orgAId,
           name: 'Home A',
-          is_home: true,
+          workspace_type: 'team',
         })
         .select('id')
         .single()
@@ -177,7 +185,7 @@ describe.skipIf(!integrationDbReachable)(
         .insert({
           organization_id: orgBId,
           name: 'Home B',
-          is_home: true,
+          workspace_type: 'team',
         })
         .select('id')
         .single()
@@ -190,7 +198,12 @@ describe.skipIf(!integrationDbReachable)(
 
       const folderA = await admin
         .from('folders')
-        .insert({ workspace_id: workspaceAId, name: 'Folder A' })
+        .insert({
+          organization_id: orgAId,
+          user_id: userAId,
+          workspace_id: workspaceAId,
+          name: 'Folder A',
+        })
         .select('id')
         .single()
       if (folderA.error || !folderA.data) {
@@ -202,7 +215,12 @@ describe.skipIf(!integrationDbReachable)(
 
       const folderB = await admin
         .from('folders')
-        .insert({ workspace_id: workspaceBId, name: 'Folder B' })
+        .insert({
+          organization_id: orgBId,
+          user_id: userBId,
+          workspace_id: workspaceBId,
+          name: 'Folder B',
+        })
         .select('id')
         .single()
       if (folderB.error || !folderB.data) {


### PR DESCRIPTION
Auto-generated by agent-mesh.

**Model:** codex
**Task ID:** mpe5gvque23z34
**Requested by:** Telegram chat 1474739896 (user 0)

**Prompt:**
> additional comments on the prs to check out, and an error: ⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯ FAIL src/test/rls-regression.test.ts > [phase-38-01 rls-regression] cross-org RLS isolation Error: [phase-38-01 rls-regression] insert org A failed: Could not find the 'owner_user_id' column of 'organizations' in the schema cache ❯ src/test/rls-regression.test.ts:129:15 127| .single() 128| if (orgA.error || !orgA.data) { 129| throw new Error( | ^ 130| ${SUITE_TAG} insert org A failed: ${orgA.error?.message} 131| ) ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯ Test Files 1 failed (1) Tests 22 skipped (22) Start at 14:17:02 Duration 1.96s (transform 68ms, setup 148ms, import 81ms, tests 1.07s, environment 524ms) Error: Process completed with exit code 1.

Review the diff and merge or close.