### PR TITLE
fix(28-03): OAuth encryption RPC param type — UUID, not BIGINT

### DIFF
--- a/supabase/functions/_shared/oauth-encrypt.ts
+++ b/supabase/functions/_shared/oauth-encrypt.ts
@@ -11,7 +11,7 @@
  * The encryption key is read from OAUTH_ENCRYPTION_KEY env var.
  */
 
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 /**
  * Read and decrypt OAuth tokens for an import source.
@@ -20,13 +20,17 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
  */
 export async function getDecryptedOAuthTokens(
   supabase: ReturnType<typeof createClient>,
-  sourceId: number,
+  sourceId: string,
   userId: string,
-): Promise<{ access_token: string | null; refresh_token: string | null; token_expires: number | null }> {
-  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+): Promise<{
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expires: number | null;
+}> {
+  const encryptionKey = Deno.env.get("OAUTH_ENCRYPTION_KEY");
 
   if (encryptionKey) {
-    const { data, error } = await supabase.rpc('get_decrypted_oauth_tokens', {
+    const { data, error } = await supabase.rpc("get_decrypted_oauth_tokens", {
       p_source_id: sourceId,
       p_user_id: userId,
       p_encryption_key: encryptionKey,
@@ -42,16 +46,19 @@ export async function getDecryptedOAuthTokens(
 
     // Fall through to plaintext read on error
     if (error) {
-      console.warn('Decryption RPC failed, falling back to plaintext:', error.message);
+      console.warn(
+        "Decryption RPC failed, falling back to plaintext:",
+        error.message,
+      );
     }
   }
 
   // Plaintext fallback
   const { data } = await supabase
-    .from('import_sources')
-    .select('oauth_access_token, oauth_refresh_token, oauth_token_expires')
-    .eq('id', sourceId)
-    .eq('user_id', userId)
+    .from("import_sources")
+    .select("oauth_access_token, oauth_refresh_token, oauth_token_expires")
+    .eq("id", sourceId)
+    .eq("user_id", userId)
     .maybeSingle();
 
   return {

--- a/supabase/migrations/20260522180000_fix_oauth_rpc_uuid_types.sql
+++ b/supabase/migrations/20260522180000_fix_oauth_rpc_uuid_types.sql
@@ -1,0 +1,84 @@
+-- Migration: Fix OAuth encryption RPC type mismatch (UUID vs BIGINT)
+-- Purpose:   Phase 28-03 / SEC-09 hotfix. The 2026-05-09 encryption helpers
+--            declared p_source_id as BIGINT, but import_sources.id is UUID
+--            (defined 2026-02-28). Every encrypted-path OAuth callback since
+--            2026-05-09 has thrown Postgres error 22P02 ("invalid input
+--            syntax for type bigint") before tokens could be stored, breaking
+--            all new Fathom OAuth connects.
+-- Evidence:  Direct RPC test 2026-05-22 returned
+--              {"code":"22P02","message":"invalid input syntax for type
+--               bigint: \"7927cb06-81e3-45e4-9fe5-93f365610d0d\""}
+--            Last successful OAuth: 2026-04-17. 9 stuck oauth_state rows in
+--            user_settings with no matching tokens since 2026-05-15.
+-- Safety:    Idempotent. Drops old signatures, re-creates with UUID.
+--            No data is read, written, or migrated. Existing plaintext tokens
+--            in import_sources/user_settings are not touched. The refresh
+--            path (which writes via direct UPDATE, not the RPC) is unaffected.
+-- Date:      2026-05-22
+
+-- ============================================================================
+-- Drop the broken BIGINT signatures (the body is preserved below with UUID).
+-- ============================================================================
+DROP FUNCTION IF EXISTS store_encrypted_oauth_tokens(BIGINT, UUID, TEXT, TEXT, BIGINT, TEXT, BOOLEAN);
+DROP FUNCTION IF EXISTS get_decrypted_oauth_tokens(BIGINT, UUID, TEXT);
+
+-- ============================================================================
+-- RPC: store_encrypted_oauth_tokens — fixed signature (UUID, not BIGINT)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION store_encrypted_oauth_tokens(
+  p_source_id     UUID,
+  p_user_id       UUID,
+  p_access_token  TEXT,
+  p_refresh_token TEXT,
+  p_token_expires BIGINT,
+  p_encryption_key TEXT,
+  p_is_active     BOOLEAN DEFAULT TRUE
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE import_sources
+  SET
+    oauth_access_token  = encrypt_token(p_access_token,  p_encryption_key),
+    oauth_refresh_token = encrypt_token(p_refresh_token, p_encryption_key),
+    oauth_token_expires = p_token_expires,
+    is_active           = p_is_active,
+    updated_at          = NOW()
+  WHERE id      = p_source_id
+    AND user_id = p_user_id;
+END;
+$$;
+
+COMMENT ON FUNCTION store_encrypted_oauth_tokens IS
+'Stores encrypted OAuth tokens in import_sources. Called from fathom-oauth-callback. p_source_id is UUID (fixed 2026-05-22 from BIGINT typo).';
+
+-- ============================================================================
+-- RPC: get_decrypted_oauth_tokens — fixed signature (UUID, not BIGINT)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION get_decrypted_oauth_tokens(
+  p_source_id     UUID,
+  p_user_id       UUID,
+  p_encryption_key TEXT
+)
+RETURNS TABLE(access_token TEXT, refresh_token TEXT, token_expires BIGINT)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    decrypt_token(s.oauth_access_token,  p_encryption_key) AS access_token,
+    decrypt_token(s.oauth_refresh_token, p_encryption_key) AS refresh_token,
+    s.oauth_token_expires                                  AS token_expires
+  FROM import_sources s
+  WHERE s.id      = p_source_id
+    AND s.user_id = p_user_id;
+END;
+$$;
+
+COMMENT ON FUNCTION get_decrypted_oauth_tokens IS
+'Returns decrypted OAuth tokens from import_sources. Falls back to plaintext for pre-encryption data via decrypt_token EXCEPTION clause. p_source_id is UUID (fixed 2026-05-22 from BIGINT typo).';
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================


### PR DESCRIPTION
## Summary

The 2026-05-09 encryption helpers declared `p_source_id` as **BIGINT** in both `store_encrypted_oauth_tokens` and `get_decrypted_oauth_tokens`, but `import_sources.id` is **UUID** (defined back on 2026-02-28). Every encrypted-path OAuth callback since 2026-05-09 has thrown Postgres `22P02` before tokens could be stored, breaking all new Fathom OAuth connects.

The refresh path uses direct `.update({...})` (not the RPC), which is why already-connected users kept refreshing successfully while new connects all silently failed.

## Evidence

Live RPC call against `vltmrnjsubfzrgrtdqey` before fix:

```json
{"code":"22P02","message":"invalid input syntax for type bigint: \"7927cb06-81e3-45e4-9fe5-93f365610d0d\""}
```

- **Last successful OAuth:** 2026-04-17
- **Stuck `oauth_state` rows:** 9 (across 7 users, including 3 of my own accounts + new prospect signups since 2026-05-15)
- **All 11 active production tokens are plaintext.** The 2026-05-12 batch `encrypt_existing_oauth_tokens(<key>)` op-step (per the runbook) never ran in production — so no existing token data is at risk.

## Changes

1. **`supabase/migrations/20260522180000_fix_oauth_rpc_uuid_types.sql`** — drops the two BIGINT-signature functions and re-creates them with `UUID`. Bodies preserved verbatim. No data is read, written, or migrated.
2. **`supabase/functions/_shared/oauth-encrypt.ts`** — retypes `sourceId: number` to `sourceId: string` to match the runtime UUID being passed.

## Production state

Migration was applied to `vltmrnjsubfzrgrtdqey` via `supabase db push --linked --yes` at 2026-05-22 ~14:30 ET. Smoke-tested live:

- `store_encrypted_oauth_tokens` with valid UUIDs → HTTP 204 ✓
- `get_decrypted_oauth_tokens` with valid UUIDs → HTTP 200 `[]` ✓
- Old BIGINT call path → now rejects with "invalid input syntax for type uuid" (correctly enforcing new type)

The edge function code itself wasn't redeployed because it was already passing UUIDs — the bug was 100% on the SQL contract side.

## Follow-ups (out of scope for this PR)

- Clear 9 stuck `oauth_state` rows in `user_settings` once a real OAuth connect has been end-to-end verified
- Andrew-specific webhook outage since 2026-04-21 is a separate bug (predates encryption rollout). Likely Fathom-side auto-disable, stale webhook URL, or webhook secret rotation. The Phase 39 background `create-fathom-webhook` task may incidentally heal it on next reconnect; if not, investigate.
- Add a regression test that exercises the encrypted-path RPC with a real UUID against a test schema, so the type signature stays correct under future schema changes

## Risk

Minimal. The migration is idempotent — drops the old signatures and re-creates with corrected types. No data is touched. The decrypt path's `EXCEPTION → RETURN raw value` clause continues to handle the still-plaintext production tokens transparently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Don