### PR TITLE
feat: Settings → Integrations tab with OAuth return routing

### DIFF
--- a/src/components/panes/SettingsCategoryPane.tsx
+++ b/src/components/panes/SettingsCategoryPane.tsx
@@ -26,12 +26,14 @@ import {
   RiSettings3Line,
   RiRobot2Line,
   RiBuilding4Line,
+  RiPlugLine,
 } from "@remixicon/react";
 
 export type SettingsCategory =
   | "account"
   | "billing"
   | "organizations"
+  | "integrations"
   | "mcp"
   | "admin";
 
@@ -62,6 +64,12 @@ export const SETTINGS_CATEGORIES: CategoryItem[] = [
     label: "Organizations",
     description: "Manage workspaces and teams",
     icon: RiBuilding4Line,
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    description: "Connect meeting platforms",
+    icon: RiPlugLine,
   },
   {
     id: "mcp",
@@ -104,7 +112,7 @@ export function SettingsCategoryPane({
 
   // Refs for category buttons to enable focus management
   const buttonRefs = React.useRef<Map<SettingsCategory, HTMLButtonElement>>(
-    new Map()
+    new Map(),
   );
 
   // Filter categories based on user role
@@ -130,19 +138,20 @@ export function SettingsCategoryPane({
     (index: number) => {
       const categoryIds = visibleCategories.map((c) => c.id);
       const wrappedIndex =
-        ((index % categoryIds.length) + categoryIds.length) % categoryIds.length;
+        ((index % categoryIds.length) + categoryIds.length) %
+        categoryIds.length;
       const categoryId = categoryIds[wrappedIndex];
       const button = buttonRefs.current.get(categoryId);
       button?.focus();
     },
-    [visibleCategories]
+    [visibleCategories],
   );
 
   // Keyboard navigation handler for individual items
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent, categoryId: SettingsCategory) => {
       const currentIndex = visibleCategories.findIndex(
-        (c) => c.id === categoryId
+        (c) => c.id === categoryId,
       );
 
       switch (event.key) {
@@ -169,7 +178,7 @@ export function SettingsCategoryPane({
           break;
       }
     },
-    [onCategorySelect, visibleCategories, focusCategoryByIndex]
+    [onCategorySelect, visibleCategories, focusCategoryByIndex],
   );
 
   return (
@@ -178,10 +187,8 @@ export function SettingsCategoryPane({
         "h-full flex flex-col",
         // Pane enter animation (slide + fade)
         "transition-all duration-500 ease-in-out",
-        isMounted
-          ? "opacity-100 translate-x-0"
-          : "opacity-0 -translate-x-2",
-        className
+        isMounted ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
+        className,
       )}
       role="navigation"
       aria-label="Settings categories"
@@ -200,7 +207,9 @@ export function SettingsCategoryPane({
               >
                 Settings
               </h2>
-              <p className="text-[9px] text-muted-foreground/60 uppercase">Preferences & Config</p>
+              <p className="text-[9px] text-muted-foreground/60 uppercase">
+                Preferences & Config
+              </p>
             </div>
           </div>
         </div>
@@ -217,19 +226,17 @@ export function SettingsCategoryPane({
           const IconComponent = category.icon;
 
           return (
-            <div
-              key={category.id}
-              role="listitem"
-              className="relative mb-1"
-            >
+            <div key={category.id} role="listitem" className="relative mb-1">
               <SelectionButton
-                ref={((el: HTMLButtonElement | null) => {
-                  if (el) {
-                    buttonRefs.current.set(category.id, el);
-                  } else {
-                    buttonRefs.current.delete(category.id);
-                  }
-                }) as unknown as React.Ref<HTMLElement>}
+                ref={
+                  ((el: HTMLButtonElement | null) => {
+                    if (el) {
+                      buttonRefs.current.set(category.id, el);
+                    } else {
+                      buttonRefs.current.delete(category.id);
+                    }
+                  }) as unknown as React.Ref<HTMLElement>
+                }
                 selected={isActive}
                 icon={
                   <IconComponent

--- a/src/components/panes/SettingsDetailPane.tsx
+++ b/src/components/panes/SettingsDetailPane.tsx
@@ -32,6 +32,7 @@ import {
   RiRobot2Line,
   RiShieldLine,
   RiBuilding4Line,
+  RiPlugLine,
 } from "@remixicon/react";
 
 import type { SettingsCategory } from "./SettingsCategoryPane";
@@ -42,9 +43,14 @@ const TRANSITION_DURATION = 250;
 // Lazy load settings tab components
 const AccountTab = React.lazy(() => import("@/components/settings/AccountTab"));
 const BillingTab = React.lazy(() => import("@/components/settings/BillingTab"));
-const OrganizationsTab = React.lazy(() => import("@/components/settings/OrganizationsTab"));
+const OrganizationsTab = React.lazy(
+  () => import("@/components/settings/OrganizationsTab"),
+);
 const AdminTab = React.lazy(() => import("@/components/settings/AdminTab"));
 const MCPTab = React.lazy(() => import("@/components/settings/MCPTab"));
+const IntegrationsTab = React.lazy(
+  () => import("@/components/settings/IntegrationsTab"),
+);
 
 /** Category metadata for display */
 const CATEGORY_META: Record<
@@ -69,6 +75,11 @@ const CATEGORY_META: Record<
     label: "Organizations",
     description: "Manage workspaces and teams",
     icon: RiBuilding4Line,
+  },
+  integrations: {
+    label: "Integrations",
+    description: "Connect meeting platforms",
+    icon: RiPlugLine,
   },
   admin: {
     label: "Admin",
@@ -212,6 +223,8 @@ export function SettingsDetailPane({
         return <AdminTab />;
       case "mcp":
         return <MCPTab />;
+      case "integrations":
+        return <IntegrationsTab />;
       default:
         return (
           <div className="p-6 text-center text-muted-foreground">
@@ -228,10 +241,8 @@ export function SettingsDetailPane({
         "h-full flex flex-col bg-background",
         // Pane enter animation (slide + fade)
         "transition-all duration-500 ease-in-out",
-        isMounted
-          ? "opacity-100 translate-x-0"
-          : "opacity-0 translate-x-2",
-        className
+        isMounted ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2",
+        className,
       )}
       role="region"
       aria-label={`${meta.label} settings`}
@@ -299,7 +310,7 @@ export function SettingsDetailPane({
             "transition-all duration-200 ease-in-out",
             isContentVisible
               ? "opacity-100 translate-y-0"
-              : "opacity-0 translate-y-1"
+              : "opacity-0 translate-y-1",
           )}
         >
           <React.Suspense fallback={<SettingsLoadingSkeleton />}>
@@ -334,7 +345,10 @@ class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    logger.error("Settings component error", { error, componentStack: errorInfo.componentStack });
+    logger.error("Settings component error", {
+      error,
+      componentStack: errorInfo.componentStack,
+    });
   }
 
   render() {

--- a/src/components/settings/IntegrationsTab.tsx
+++ b/src/components/settings/IntegrationsTab.tsx
@@ -29,14 +29,10 @@ export default function IntegrationsTab() {
   const [hasCredentialsLoaded, setHasCredentialsLoaded] = useState(false);
 
   // Derived connection states from shared hook
-  const fathomConnected = integrations.find((i) => i.platform === "fathom")?.connected ?? false;
-  const zoomConnected = integrations.find((i) => i.platform === "zoom")?.connected ?? false;
-
-  // Get connected platforms for modal
-  const connectedPlatforms = [
-    ...(fathomConnected ? ["fathom"] : []),
-    ...(zoomConnected ? ["zoom"] : []),
-  ];
+  const fathomConnected =
+    integrations.find((i) => i.platform === "fathom")?.connected ?? false;
+  const zoomConnected =
+    integrations.find((i) => i.platform === "zoom")?.connected ?? false;
 
   // Load credential settings (for Fathom credential management UI)
   useEffect(() => {
@@ -91,20 +87,23 @@ export default function IntegrationsTab() {
         return;
       }
 
-      if (!webhookSecret.startsWith('whsec_')) {
-        toast.error("Invalid webhook secret format. Should start with 'whsec_'");
+      if (!webhookSecret.startsWith("whsec_")) {
+        toast.error(
+          "Invalid webhook secret format. Should start with 'whsec_'",
+        );
         return;
       }
 
-      const { error } = await supabase
-        .from("user_settings")
-        .upsert({
+      const { error } = await supabase.from("user_settings").upsert(
+        {
           user_id: user.id,
           fathom_api_key: apiKey.trim(),
           webhook_secret: webhookSecret.trim(),
-        }, {
-          onConflict: "user_id"
-        });
+        },
+        {
+          onConflict: "user_id",
+        },
+      );
 
       if (error) {
         logger.error("Failed to save credentials", error);
@@ -128,7 +127,8 @@ export default function IntegrationsTab() {
       setOauthConnecting(true);
       const response = await getFathomOAuthUrl();
       if (response.data?.authUrl) {
-        window.open(response.data.authUrl, '_blank', 'noopener,noreferrer');
+        localStorage.setItem("oauthReturnTo", window.location.pathname);
+        window.open(response.data.authUrl, "_blank", "noopener,noreferrer");
       } else if (response.error) {
         throw new Error(response.error);
       } else {
@@ -137,6 +137,7 @@ export default function IntegrationsTab() {
     } catch (error) {
       logger.error("Failed to get OAuth URL", error);
       toast.error("Failed to connect to Fathom");
+    } finally {
       setOauthConnecting(false);
     }
   };
@@ -184,9 +185,13 @@ export default function IntegrationsTab() {
                 <div className="space-y-6">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="font-medium text-sm text-gray-900 dark:text-gray-50">API Credentials</p>
+                      <p className="font-medium text-sm text-gray-900 dark:text-gray-50">
+                        API Credentials
+                      </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        {apiKey ? "API key and webhook secret configured" : "Not configured"}
+                        {apiKey
+                          ? "API key and webhook secret configured"
+                          : "Not configured"}
                       </p>
                     </div>
                     <Button
@@ -200,9 +205,13 @@ export default function IntegrationsTab() {
 
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="font-medium text-sm text-gray-900 dark:text-gray-50">OAuth Connection</p>
+                      <p className="font-medium text-sm text-gray-900 dark:text-gray-50">
+                        OAuth Connection
+                      </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        {hasOAuth ? "Connected - auto-sync enabled" : "Not connected"}
+                        {hasOAuth
+                          ? "Connected - auto-sync enabled"
+                          : "Not connected"}
                       </p>
                     </div>
                     <Button
@@ -230,7 +239,9 @@ export default function IntegrationsTab() {
                       />
                     </div>
                     <div>
-                      <Label htmlFor="edit-webhook-secret">Webhook Secret *</Label>
+                      <Label htmlFor="edit-webhook-secret">
+                        Webhook Secret *
+                      </Label>
                       <div className="relative mt-2">
                         <Input
                           id="edit-webhook-secret"
@@ -242,7 +253,9 @@ export default function IntegrationsTab() {
                         />
                         <button
                           type="button"
-                          onClick={() => setShowWebhookSecret(!showWebhookSecret)}
+                          onClick={() =>
+                            setShowWebhookSecret(!showWebhookSecret)
+                          }
                           className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                         >
                           {showWebhookSecret ? (
@@ -278,7 +291,6 @@ export default function IntegrationsTab() {
           </div>
         </>
       )}
-
     </div>
   );
 }

--- a/src/components/settings/__tests__/IntegrationsTab.test.tsx
+++ b/src/components/settings/__tests__/IntegrationsTab.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * IntegrationsTab — Settings → Integrations tab wiring
+ *
+ * Verifies:
+ *   - Smoke test: tab renders without crashing
+ *   - Uses shared IntegrationManager (same code path as ImportPage)
+ *   - Credential section is gated on Fathom connection state
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+
+// ─── Mocks (must come before IntegrationsTab import) ─────────────────────────
+
+const mockUseIntegrationSync = vi.fn(() => ({
+  integrations: [] as Array<{
+    platform: string;
+    connected: boolean;
+    email?: string;
+  }>,
+  isLoading: false,
+  refreshIntegrations: vi.fn(),
+  triggerManualSync: vi.fn(),
+}));
+
+vi.mock("@/hooks/useIntegrationSync", () => ({
+  useIntegrationSync: () => mockUseIntegrationSync(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: null }),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+  getSafeUser: () =>
+    Promise.resolve({ user: { id: "test-user" }, error: null }),
+}));
+
+vi.mock("@/components/shared/IntegrationManager", () => ({
+  IntegrationManager: ({ variant }: { variant?: string }) => (
+    <div data-testid="integration-manager" data-variant={variant} />
+  ),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  getFathomOAuthUrl: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import IntegrationsTab from "../IntegrationsTab";
+
+beforeEach(() => {
+  mockUseIntegrationSync.mockReturnValue({
+    integrations: [],
+    isLoading: false,
+    refreshIntegrations: vi.fn(),
+    triggerManualSync: vi.fn(),
+  });
+});
+
+describe("IntegrationsTab", () => {
+  it("renders without crashing", () => {
+    render(<IntegrationsTab />);
+    // Smoke: header text exists
+    expect(screen.getByText("Integrations")).toBeInTheDocument();
+  });
+
+  it("renders IntegrationManager with full variant (shared code path)", () => {
+    render(<IntegrationsTab />);
+    const manager = screen.getByTestId("integration-manager");
+    expect(manager).toBeInTheDocument();
+    expect(manager.getAttribute("data-variant")).toBe("full");
+  });
+
+  it("hides Fathom credential section when Fathom is not connected", async () => {
+    render(<IntegrationsTab />);
+    // Flush microtask queue so the credential-loading useEffect settles
+    await new Promise((r) => setTimeout(r, 0));
+    expect(
+      screen.queryByText("Manage Fathom Connection"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Fathom credential section when Fathom is connected", async () => {
+    mockUseIntegrationSync.mockReturnValue({
+      integrations: [
+        { platform: "fathom", connected: true, email: "test@example.com" },
+      ],
+      isLoading: false,
+      refreshIntegrations: vi.fn(),
+      triggerManualSync: vi.fn(),
+    });
+    render(<IntegrationsTab />);
+    // loadCredentialSettings is async and toggles hasCredentialsLoaded; wait
+    await new Promise((r) => setTimeout(r, 10));
+    expect(screen.getByText("Manage Fathom Connection")).toBeInTheDocument();
+  });
+});

--- a/src/components/sync/InlineConnectionWizard.tsx
+++ b/src/components/sync/InlineConnectionWizard.tsx
@@ -10,7 +10,10 @@ import {
   RiRefreshLine,
   RiExternalLinkLine,
 } from "@remixicon/react";
-import { FathomIcon, ZoomIcon } from "@/components/transcript-library/SourcePlatformIcons";
+import {
+  FathomIcon,
+  ZoomIcon,
+} from "@/components/transcript-library/SourcePlatformIcons";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import { getFathomOAuthUrl, getZoomOAuthUrl } from "@/lib/api-client";
@@ -41,7 +44,9 @@ export function InlineConnectionWizard({
   onCancel,
   currentEmail,
 }: InlineConnectionWizardProps) {
-  const [connectionState, setConnectionState] = useState<ConnectionState>({ status: "idle" });
+  const [connectionState, setConnectionState] = useState<ConnectionState>({
+    status: "idle",
+  });
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -138,8 +143,12 @@ export function InlineConnectionWizard({
       if (response.data?.authUrl) {
         // Store a flag to indicate we're completing OAuth and should refresh
         sessionStorage.setItem("pendingOAuthPlatform", platform);
+        // Persist the originating route so OAuthCallback can return the user
+        // here after success. localStorage (not sessionStorage) survives the
+        // `noopener` cross-tab boundary on the same origin.
+        localStorage.setItem("oauthReturnTo", window.location.pathname);
         // Redirect to OAuth provider
-        window.open(response.data.authUrl, '_blank', 'noopener,noreferrer');
+        window.open(response.data.authUrl, "_blank", "noopener,noreferrer");
       } else if (response.error) {
         throw new Error(response.error);
       } else {
@@ -157,7 +166,8 @@ export function InlineConnectionWizard({
         return; // Already handled
       }
 
-      const errorMessage = error instanceof Error ? error.message : "Connection failed";
+      const errorMessage =
+        error instanceof Error ? error.message : "Connection failed";
       logger.error(`Failed to get ${platform} OAuth URL`, error);
 
       setConnectionState({ status: "error", message: errorMessage });
@@ -175,7 +185,8 @@ export function InlineConnectionWizard({
       warningContent: (
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">
-            Zoom cloud recording is required for importing recordings. This feature is available on:
+            Zoom cloud recording is required for importing recordings. This
+            feature is available on:
           </p>
           <ul className="text-sm text-muted-foreground list-disc pl-5 space-y-1">
             <li>Zoom Pro, Business, Education, or Enterprise plans</li>
@@ -209,7 +220,12 @@ export function InlineConnectionWizard({
               {hasTimeout ? "Connection Timed Out" : "Connection Failed"}
             </h3>
           </div>
-          <Button variant="ghost" size="sm" onClick={handleCancel} className="h-8 w-8 p-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCancel}
+            className="h-8 w-8 p-0"
+          >
             <RiCloseLine className="h-4 w-4" />
           </Button>
         </div>
@@ -222,7 +238,9 @@ export function InlineConnectionWizard({
             <RiAlertLine className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
             <div className="space-y-2">
               <p className="font-medium text-destructive">
-                {hasTimeout ? "The connection took too long" : "Unable to connect"}
+                {hasTimeout
+                  ? "The connection took too long"
+                  : "Unable to connect"}
               </p>
               <p className="text-sm text-muted-foreground">
                 {hasTimeout
@@ -271,7 +289,9 @@ export function InlineConnectionWizard({
           <div className={config.color}>{config.icon}</div>
           <div>
             <h3 className="font-medium text-sm">
-              {currentEmail ? `Reconnect ${config.name}` : `Connect ${config.name}`}
+              {currentEmail
+                ? `Reconnect ${config.name}`
+                : `Connect ${config.name}`}
             </h3>
             <p className="text-xs text-muted-foreground">
               Sync recordings and transcripts
@@ -295,15 +315,21 @@ export function InlineConnectionWizard({
           <div className="flex items-start gap-2">
             <RiCheckLine className="h-4 w-4 text-blue-500 shrink-0 mt-0.5" />
             <p className="text-xs text-muted-foreground">
-              <span className="font-medium text-blue-600 dark:text-blue-400">{currentEmail}</span>
-              {" "}will be replaced
+              <span className="font-medium text-blue-600 dark:text-blue-400">
+                {currentEmail}
+              </span>{" "}
+              will be replaced
             </p>
           </div>
         </div>
       )}
 
       {/* Primary CTA - Prominent */}
-      <Button onClick={handleOAuthConnect} disabled={isConnecting} className="w-full">
+      <Button
+        onClick={handleOAuthConnect}
+        disabled={isConnecting}
+        className="w-full"
+      >
         {isConnecting ? (
           <>
             <RiLoader4Line className="mr-2 h-4 w-4 animate-spin" />
@@ -327,12 +353,13 @@ export function InlineConnectionWizard({
         <div className="flex items-start gap-2">
           <RiAlertLine className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
           <div className="space-y-1">
-            <p className="font-medium text-amber-600 dark:text-amber-400 text-sm">{config.warningTitle}</p>
+            <p className="font-medium text-amber-600 dark:text-amber-400 text-sm">
+              {config.warningTitle}
+            </p>
             {config.warningContent}
           </div>
         </div>
       </div>
-
 
       {/* Help text */}
       <p className="text-xs text-muted-foreground text-center">
@@ -342,11 +369,7 @@ export function InlineConnectionWizard({
       </p>
 
       {/* Cancel button - always visible (PRD-020) */}
-      <Button
-        variant="link"
-        onClick={handleCancel}
-        className="w-full text-xs"
-      >
+      <Button variant="link" onClick={handleCancel} className="w-full text-xs">
         {isConnecting ? "Cancel Connection" : "Cancel"}
       </Button>
     </div>

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -94,9 +94,12 @@ export default function OAuthCallback() {
         // instead of forcing /import. Always clear after read.
         const oauthReturnTo = localStorage.getItem("oauthReturnTo");
         localStorage.removeItem("oauthReturnTo");
+        // Validate same-origin relative path (must start with / but not //)
+        const safeReturnTo =
+          oauthReturnTo && /^\/[^/]/.test(oauthReturnTo) ? oauthReturnTo : null;
         const queryString = `?source=${sourceParam}&connected=true${extraParams ? "&" + extraParams : ""}`;
-        let redirectTo = oauthReturnTo
-          ? `${oauthReturnTo}${queryString}`
+        let redirectTo = safeReturnTo
+          ? `${safeReturnTo}${queryString}`
           : `/import${queryString}`;
 
         try {

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -40,8 +40,13 @@ export default function OAuthCallback() {
 
         // Check for OAuth errors from provider
         if (error) {
-          logger.error("OAuth error from provider", { error, errorDescription });
-          throw new Error(errorDescription || error || "OAuth authorization failed");
+          logger.error("OAuth error from provider", {
+            error,
+            errorDescription,
+          });
+          throw new Error(
+            errorDescription || error || "OAuth authorization failed",
+          );
         }
 
         if (!code || !stateParam) {
@@ -77,12 +82,22 @@ export default function OAuthCallback() {
         const connectedEmail = response.data?.accountEmail;
 
         // Check if onboarding is incomplete — if so, route to setup wizard
-        const sourceParam = isZoomCallback ? 'zoom' : 'fathom';
+        const sourceParam = isZoomCallback ? "zoom" : "fathom";
         const extraParams = [
-          connectedSourceId ? `sourceId=${connectedSourceId}` : '',
-          connectedEmail ? `email=${encodeURIComponent(connectedEmail)}` : '',
-        ].filter(Boolean).join('&');
-        let redirectTo = `/import?source=${sourceParam}&connected=true${extraParams ? '&' + extraParams : ''}`;
+          connectedSourceId ? `sourceId=${connectedSourceId}` : "",
+          connectedEmail ? `email=${encodeURIComponent(connectedEmail)}` : "",
+        ]
+          .filter(Boolean)
+          .join("&");
+        // If OAuth was initiated from a non-Import surface (e.g. Settings),
+        // InlineConnectionWizard stored the originating pathname. Return there
+        // instead of forcing /import. Always clear after read.
+        const oauthReturnTo = localStorage.getItem("oauthReturnTo");
+        localStorage.removeItem("oauthReturnTo");
+        const queryString = `?source=${sourceParam}&connected=true${extraParams ? "&" + extraParams : ""}`;
+        let redirectTo = oauthReturnTo
+          ? `${oauthReturnTo}${queryString}`
+          : `/import${queryString}`;
 
         try {
           const { user } = await getSafeUser();
@@ -104,11 +119,11 @@ export default function OAuthCallback() {
         setTimeout(() => {
           navigate(redirectTo, { replace: true });
         }, 1500);
-
       } catch (error) {
         logger.error("OAuth callback error", error);
         setState("error");
-        const errorMessage = error instanceof Error ? error.message : "OAuth callback failed";
+        const errorMessage =
+          error instanceof Error ? error.message : "OAuth callback failed";
         setMessage(errorMessage);
         toast.error(errorMessage);
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,11 @@ import { usePanelStore } from "@/stores/panelStore";
 import FathomSetupWizard from "@/components/settings/FathomSetupWizard";
 import { type SettingHelpTopic } from "@/components/panels/SettingHelpPanel";
 import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
-import { SettingsCategoryPane, type SettingsCategory, SETTINGS_CATEGORIES } from "@/components/panes/SettingsCategoryPane";
+import {
+  SettingsCategoryPane,
+  type SettingsCategory,
+  SETTINGS_CATEGORIES,
+} from "@/components/panes/SettingsCategoryPane";
 import { SettingsDetailPane } from "@/components/panes/SettingsDetailPane";
 import { AppShell } from "@/components/layout/AppShell";
 
@@ -18,11 +22,16 @@ export default function Settings() {
   const { category: urlCategory } = useParams<{ category?: string }>();
   const navigate = useNavigate();
   const { loading: roleLoading, isAdmin, isTeam } = useUserRole();
-  const { wizardCompleted, loading: wizardLoading, markWizardComplete } = useSetupWizard();
+  const {
+    wizardCompleted,
+    loading: wizardLoading,
+    markWizardComplete,
+  } = useSetupWizard();
 
   // --- Pane System Logic ---
   // Selected category for the 2nd pane (category list) and 3rd pane (detail view)
-  const [selectedCategory, setSelectedCategory] = useState<SettingsCategory | null>(null);
+  const [selectedCategory, setSelectedCategory] =
+    useState<SettingsCategory | null>(null);
 
   // --- Deep Link Handling ---
   // On initial load, read category from URL and validate
@@ -31,15 +40,19 @@ export default function Settings() {
       // Validate the category from URL
       if (VALID_CATEGORY_IDS.includes(urlCategory as SettingsCategory)) {
         // Check role-based access for restricted categories
-        const categoryConfig = SETTINGS_CATEGORIES.find((c) => c.id === urlCategory);
-        const hasAccess = !categoryConfig?.requiredRoles?.length ||
+        const categoryConfig = SETTINGS_CATEGORIES.find(
+          (c) => c.id === urlCategory,
+        );
+        const hasAccess =
+          !categoryConfig?.requiredRoles?.length ||
           (categoryConfig.requiredRoles.includes("ADMIN") && isAdmin) ||
-          (categoryConfig.requiredRoles.includes("TEAM") && (isTeam || isAdmin));
+          (categoryConfig.requiredRoles.includes("TEAM") &&
+            (isTeam || isAdmin));
 
         if (hasAccess) {
           // Use functional setter to read current value without a stale closure
           setSelectedCategory((prev) =>
-            prev !== urlCategory ? (urlCategory as SettingsCategory) : prev
+            prev !== urlCategory ? (urlCategory as SettingsCategory) : prev,
           );
         } else {
           // Redirect to base settings if user doesn't have access
@@ -55,7 +68,7 @@ export default function Settings() {
       const firstCategory = SETTINGS_CATEGORIES[0];
       if (firstCategory) {
         setSelectedCategory((prev) =>
-          prev !== firstCategory.id ? firstCategory.id : prev
+          prev !== firstCategory.id ? firstCategory.id : prev,
         );
         navigate(`/settings/${firstCategory.id}`, { replace: true });
       }
@@ -75,8 +88,9 @@ export default function Settings() {
   }, [selectedCategory, urlCategory, navigate]);
 
   // --- Panel Store ---
-  const { isPanelOpen, panelType, panelData, openPanel, closePanel } = usePanelStore();
-  const showRightPanel = isPanelOpen && panelType === 'setting-help';
+  const { isPanelOpen, panelType, panelData, openPanel, closePanel } =
+    usePanelStore();
+  const showRightPanel = isPanelOpen && panelType === "setting-help";
 
   // Close Pane 4 when switching settings category tabs (unless pinned)
   useEffect(() => {
@@ -85,14 +99,18 @@ export default function Settings() {
 
   // Helper function to open help panel for a specific topic
   const openHelpPanel = (topic: SettingHelpTopic) => {
-    openPanel('setting-help', { type: 'setting-help', topic });
+    openPanel("setting-help", { type: "setting-help", topic });
   };
 
   // Get help topic based on current category
-  const getHelpTopicForCategory = (category: SettingsCategory): SettingHelpTopic => {
+  const getHelpTopicForCategory = (
+    category: SettingsCategory,
+  ): SettingHelpTopic => {
     const topicMap: Record<SettingsCategory, SettingHelpTopic> = {
       account: "profile",
       billing: "billing",
+      organizations: "users",
+      integrations: "integrations",
       mcp: "integrations", // MCP uses integrations help panel for now
       admin: "admin",
     };
@@ -117,12 +135,12 @@ export default function Settings() {
   }, [showRightPanel, closePanel, selectedCategory]);
 
   useKeyboardShortcut(handleEscapeShortcut, {
-    key: 'Escape',
+    key: "Escape",
     cmdOrCtrl: false,
-    enabled: showRightPanel
+    enabled: showRightPanel,
   });
 
-  useKeyboardShortcut(handleHelpShortcut, { key: '/' });
+  useKeyboardShortcut(handleHelpShortcut, { key: "/" });
 
   const handleWizardComplete = async () => {
     await markWizardComplete();
@@ -168,7 +186,7 @@ export default function Settings() {
             />
           ),
           showDetailPane: true, // Enable DetailPaneOutlet for SettingHelpPanel
-          onSettingsClick: handleSettingsNavClick
+          onSettingsClick: handleSettingsNavClick,
         }}
       >
         {/* Settings Detail Pane - shown when category is selected */}


### PR DESCRIPTION
## Summary

Wire the existing `IntegrationsTab` component into the Settings navigation, so users can manage third-party connections (Fathom, Zoom) from `/settings/integrations` instead of `/import`. Adds OAuth return routing so connecting from Settings sends users back to Settings after completion.

This satisfies Zoom's app review requirement that integration management be accessible from a Settings path.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/components/panes/SettingsCategoryPane.tsx` | UPDATE | Add `"integrations"` to `SettingsCategory` type; add Integrations entry (RiPlugLine icon) between Organizations and AI Integrations |
| `src/components/panes/SettingsDetailPane.tsx` | UPDATE | Lazy-import `IntegrationsTab`; add `integrations` to `CATEGORY_META` Record; add `case "integrations"` to `renderContent()` |
| `src/pages/Settings.tsx` | UPDATE | Add `organizations` and `integrations` entries to `topicMap` so the type is complete for all 6 `SettingsCategory` values |
| `src/components/sync/InlineConnectionWizard.tsx` | UPDATE | Write `localStorage.oauthReturnTo = window.location.pathname` before `window.open()` (localStorage is used because `noopener` blocks sessionStorage inheritance across the popup boundary) |
| `src/pages/OAuthCallback.tsx` | UPDATE | Read `localStorage.oauthReturnTo`, validate it is a same-origin relative path (prevents open redirect), remove after read, redirect to it or fall back to `/import` |
| `src/components/settings/IntegrationsTab.tsx` | UPDATE | Move `localStorage.setItem` into `handleFathomOAuth`; add `finally` block so `oauthConnecting` clears on error; prettier pass |
| `src/components/settings/__tests__/IntegrationsTab.test.tsx` | CREATE | 4 vitest tests: smoke render, IntegrationManager `variant="full"` (shared code path assertion), Fathom credential section gated off when not connected, gated on when connected |

## Tests

| File | Test Cases |
|------|------------|
| `src/components/settings/__tests__/IntegrationsTab.test.tsx` | `renders without crashing` · `renders IntegrationManager with full variant (shared code path)` · `hides Fathom credential section when Fathom is not connected` · `shows Fathom credential section when Fathom is connected` |

All 4 tests pass. Full suite: 54 files, 878 tests, 0 failures.

## Validation

- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 errors (215 pre-existing warnings, none introduced)
- [x] `npm test` — 878 passed, 92 skipped, 0 failed
- [x] `npm run build` — clean

## Implementation Notes

### How OAuth return routing works

`InlineConnectionWizard` (and `IntegrationsTab.handleFathomOAuth`) writes `localStorage.oauthReturnTo = window.location.pathname` before calling `window.open()`. When the OAuth popup completes, it redirects back to `OAuthCallback` in the same tab (or the user closes the popup and refreshes). `OAuthCallback` reads and removes the key, validates it is a safe relative path (`/^\/[^/]/`), and navigates there — otherwise falls back to `/import`.

Users starting OAuth from `ImportPage` are unaffected: `localStorage` has no `oauthReturnTo` key, so the fallback is used.

### Security note

The `oauthReturnTo` value is validated before use to prevent open redirect: it must start with `/` but not `//` (which browsers treat as protocol-relative). Any invalid value is discarded and the fallback `/import` is used.

---

**Workflow ID**: `05d4f7d7ad37fdfa469d8bb831e8adf4`
