### PR TITLE
feat: use friendly Fireflies webhook URL

### DIFF
--- a/cloudflare/api-proxy/worker.ts
+++ b/cloudflare/api-proxy/worker.ts
@@ -7,6 +7,7 @@
  *   /.well-known/oauth-protected-resource   → mcp-oauth-metadata?doc=protected-resource
  *   /.well-known/oauth-authorization-server → mcp-oauth-metadata?doc=authorization-server
  *   /.well-known/openid-configuration       → mcp-oauth-metadata?doc=openid-configuration
+ *   /fireflies-webhook                      → fireflies-webhook edge function
  *   /auth/v1/*                              → Supabase Auth (transparent proxy)
  *   /logo.png                               → app.callvaultai.com/logo.png (proxy)
  *
@@ -177,6 +178,10 @@ function resolveTarget(url: URL): string | null {
   // so MCP clients never see the raw Supabase project ref.
   if (url.pathname.startsWith("/auth/v1/")) {
     return `${SUPABASE_BASE}${url.pathname}${url.search}`;
+  }
+  // /fireflies-webhook → fireflies-webhook edge function
+  if (url.pathname === "/fireflies-webhook") {
+    return `${SUPABASE_BASE}/functions/v1/fireflies-webhook${url.search}`;
   }
 
   // Logo — proxied from the Vercel-hosted public/ directory so op_logo_uri

--- a/docs/source-connector-gap-analysis.md
+++ b/docs/source-connector-gap-analysis.md
@@ -1,0 +1,309 @@
+# Source Connector Gap Analysis
+
+Status: Phase 0
+
+This document captures the gap between the **current codebase contract** and the **target contract** needed to make new recording-source vendors take hours instead of weeks.
+
+## Executive summary
+
+CallVault already has the beginnings of a shared connector model, but it is not yet the final abstraction.
+
+What exists today:
+
+- one shared insert path (`connector-pipeline.ts`)
+- one shared storage target (`recordings`)
+- one shared UI mapping layer (`mapRecordingToMeeting()`)
+- shared downstream AI consumers (`summarize-call`, `generate-ai-titles`, `auto-tag-calls`, MCP)
+
+What is still fragmented:
+
+- connector-required fields are not explicitly documented in-repo
+- media URLs are schema-level fields but not part of the shared connector pipeline
+- downstream parity depends on specific `source_metadata` keys that are implicit, not declared
+- source onboarding UI is still hardcoded per source in places
+
+## The target contract
+
+The desired steady-state is:
+
+```ts
+interface SourceConnector {
+  sourceApp: string;
+  listRecordings?(window: DateWindow): Promise<SourceRecordingStub[]>;
+  getRecording(id: string): Promise<CanonicalSourceConnectorRecord>;
+  verifyWebhook?(request: Request): Promise<VerifiedSourceEvent | null>;
+}
+```
+
+Where `CanonicalSourceConnectorRecord` is the single format every vendor emits.
+
+## Current gaps
+
+## Gap 1 — The hard insert contract is still hidden inside `connector-pipeline.ts`
+
+**Problem:** A new connector author still has to reverse-engineer which fields are truly mandatory.
+
+**Why it slows future vendors:** Every connector starts with archaeology.
+
+**Phase 1 fix:** Make `docs/source-connector-spec.md` the source-of-truth contract and keep a matching shared TypeScript type next to the pipeline.
+
+## Gap 2 — Media URLs are in schema, but not in the shared connector abstraction
+
+**Current state:**
+
+- `recordings` schema has `audio_url` and `video_url`
+- `connector-pipeline.ts` does not accept or write either field
+- connectors instead stuff source/share/media links into `source_metadata`
+
+**Impact:** The product cannot honestly claim a single canonical media contract yet.
+
+**Phase 1 fix:** Extend the shared connector record + insert path to support:
+
+- `audio_url?: string | null`
+- `video_url?: string | null`
+
+Then update `mapRecordingToMeeting()` to prefer first-class columns before metadata fallbacks.
+
+## Gap 3 — Downstream parity still depends on implicit `source_metadata` conventions
+
+Today, Fathom-like behavior depends on metadata keys such as:
+
+- `share_url`
+- `recorded_by_name`
+- `recorded_by_email`
+- `calendar_invitees`
+- `participant_emails`
+- optionally `action_items`
+
+These are real requirements, but they are not centrally declared.
+
+**Phase 1 fix:** Treat these as the explicit **parity contract** in shared types and tests.
+
+## Gap 4 — Summary ownership is ambiguous
+
+Today:
+
+- source summaries are accepted and cached if present
+- `summarize-call` generates one if absent
+- downstream tools happily read either form
+
+**Impact:** New connector authors do not know whether they should map source summaries or discard them.
+
+**Phase 1 fix:** Decide one of these and document it clearly:
+
+1. **Accept source summaries** (current behavior), or
+2. **System-owned summaries only** (future stricter behavior)
+
+Until that decision is made, connectors should treat source summary as **optional and safe to persist**.
+
+## Gap 5 — We are mixing up **source acquisition** with **canonical ingestion**
+
+The deepest mismatch is not just "some UI is hardcoded." It is that the codebase does not yet separate:
+
+1. **Source acquisition** — how CallVault discovers recordings from a vendor
+2. **Canonical ingestion** — how one discovered recording becomes a normalized `recordings` row
+
+Those are different contracts.
+
+### What the wrong shape looks like
+
+A Fireflies screen that asks the operator to paste transcript IDs and import them manually is **not** the target architecture.
+
+Why it is wrong:
+
+- it assumes the user already knows vendor record IDs
+- it bypasses the real connector problem of listing/discovering new recordings
+- it proves only "we can ingest a known ID", not "we have a recording source integration"
+- it does not generalize to the normal user flow for Fireflies, Grain, Otter, or Riverside
+
+### What the right shape looks like
+
+A recording-source vendor should integrate at the **acquisition** layer first:
+
+```ts
+interface SourceAcquisitionAdapter {
+  sourceApp: string;
+  listRecordings(window: DateWindow, account: ConnectedSource): Promise<SourceRecordingStub[]>;
+  getRecording(id: string, account: ConnectedSource): Promise<CanonicalSourceConnectorRecord>;
+  verifyWebhook?(request: Request): Promise<VerifiedSourceEvent | null>;
+}
+```
+
+And only then feed canonical ingestion.
+
+The user flow should be:
+
+1. connect source account / provide credentials
+2. backfill historical recordings in bulk from the provider
+3. keep ingesting future provider recordings automatically (webhook, poller, or both)
+4. optionally choose one or many recordings from fetched provider inventory
+5. normalize each fetched recording into canonical shape
+6. insert through the shared pipeline
+
+### Current codebase evidence
+
+Today the import/onboarding layer is still source-specific:
+
+- `ImportPage.tsx` switches explicitly on source IDs
+- `useIntegrationSync.ts` hardcodes supported platforms
+- `AddImportSourceDialog.tsx` and `ImportSourcePane.tsx` are static lists
+
+So the real missing abstraction is not just a better `CanonicalSourceConnectorRecord`. It is a **source acquisition registry**.
+
+### Reference model: how Fathom already works
+
+The connector pattern we should replicate is the existing Fathom/Zoom shape:
+
+- **Connection state** — account credentials are stored once and reused
+- **Search/list step** — user can fetch provider-native recording inventory for a date window (`fetch-meetings` / `zoom-fetch-meetings`)
+- **Bulk selection** — user selects many recordings, not one transcript ID
+- **Bulk import** — selected IDs are handed to `sync-meetings` / `zoom-sync-meetings`
+- **Future ingestion** — provider webhooks and/or repeatable fetch jobs keep new recordings flowing in
+- **Canonical insertion** — each fetched recording goes through the shared insert path into `recordings`
+
+For Fathom specifically, the working pattern is:
+
+1. connect account
+2. search recordings by date range
+3. select many recordings
+4. import them into a chosen workspace
+5. remain connected so future recordings can continue to arrive through the same account context
+
+That is the baseline Fireflies should match. The target is **not** “paste transcript IDs into a textarea.”
+
+### Fathom reference endpoints and phases
+
+The current Fathom connector already spans the whole lifecycle:
+
+- **Connect account**
+  - `fathom-oauth-url`
+  - `fathom-oauth-callback`
+- **Search/list source recordings**
+  - `fetch-meetings`
+- **Bulk import selected recordings**
+  - `sync-meetings`
+- **Stay connected / future ingestion**
+  - `create-fathom-webhook`
+  - `webhook`
+  - `fathom-oauth-refresh` when tokens expire
+
+That is the model to copy:
+
+```ts
+connectAccount() -> searchSourceRecordings() -> importSelectedRecordings() -> keepReceivingFutureRecordings()
+```
+
+So Fireflies should not ship as a one-off import utility. It should ship as the same four-phase connector lifecycle with Fireflies-specific acquisition underneath and the same canonical insertion underneath that.
+
+### Credential-surface mismatch
+
+The current persistence model is still biased toward older source implementations:
+
+- `import_sources` has generic OAuth token columns
+- but also a Fathom-specific `fathom_api_key`
+- `user_settings` still carries Fathom-specific `webhook_secret`
+- there is no generic place for a source-level signing secret or API-key auth bundle
+
+That means the data model still thinks in terms of "special source fields" instead of "connected source account."
+
+What we actually need is something like:
+
+```ts
+interface ConnectedSourceAccount {
+  id: string;
+  userId: string;
+  sourceApp: string;
+  accountLabel: string | null;
+  authMode: 'oauth' | 'api-key';
+  isActive: boolean;
+  lastSyncAt: string | null;
+  errorMessage: string | null;
+
+  // encrypted provider credentials
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  tokenExpiresAt?: number | null;
+  apiKey?: string | null;
+  signingSecret?: string | null;
+}
+```
+
+Fireflies then becomes a normal account-level connector:
+
+- **connect account**: validate API key against Fireflies API, store encrypted API key, optionally store webhook signing secret
+- **search/list**: query Fireflies transcripts by date range using stored API key
+- **bulk import**: selected transcript IDs are imported from fetched inventory, not typed by hand
+- **future ingestion**: verify `X-Hub-Signature` and ingest `meeting.transcribed` / `meeting.summarized` events, or fall back to scheduled polling if webhooks are unavailable
+
+That keeps Fireflies different only in **auth mode**, not in lifecycle.
+**Phase 1 fix:** introduce a registry that defines both acquisition and ingestion entrypoints per vendor.
+
+## Proposed registry for Phase 1
+
+## Gap 6 — Transcript normalization is still connector-local
+
+Fireflies and Grain can emit turn objects; Riverside may force file-format normalization; other vendors may vary.
+
+**Impact:** Each connector risks re-implementing transcript formatting rules.
+
+**Phase 1 fix:** move turn/text normalization into a shared `transcript-normalizer` helper.
+
+That helper should own:
+
+- turn sorting
+- timestamp formatting
+- speaker-name fallback rules
+- SRT/VTT/TXT conversion where needed
+- final `full_transcript` formatting
+
+## Gap 7 — Vendor viability is uneven
+
+From the current matrix:
+
+- **Fireflies:** strong fit
+- **Grain:** strong fit
+- **Riverside:** needs transcript-file normalization
+- **Otter:** API access/doc visibility remains uncertain
+
+**Impact:** one abstraction may still need multiple acquisition modes:
+
+- rich transcript object sources
+- transcript-file sources
+- enterprise-only sources
+
+**Phase 1 fix:** keep the canonical contract stable, and vary only the acquisition/normalization layer.
+
+## Recommended Phase 1 implementation order
+
+1. **Lock the contract**
+   - keep `docs/source-connector-spec.md` current
+   - align shared TS types with the doc
+
+2. **Lift media URLs into the pipeline**
+   - support `audio_url` / `video_url` directly
+
+3. **Extract transcript normalization**
+   - one helper used by Fireflies, Grain, Riverside, etc.
+
+4. **Create source registry for import surfaces**
+   - reduce hardcoded UI branching
+
+5. **Use Fireflies and Grain as proof vendors**
+   - if both fit with little special casing, the abstraction is probably real
+
+6. **Treat Riverside as the transcript-file validator**
+   - proves the normalizer layer
+
+7. **Treat Otter as an access-gated vendor**
+   - prove contract only after enterprise API access is confirmed
+
+## Exit criteria for “hours, not weeks”
+
+We should only claim the problem is solved when a new connector mostly consists of:
+
+- one vendor client module
+- one mapping function into `CanonicalSourceConnectorRecord`
+- one test fixture file
+- one small registry entry
+
+If adding a source still requires touching multiple unrelated downstream consumers, the abstraction is not finished.

--- a/docs/source-connector-spec.md
+++ b/docs/source-connector-spec.md
@@ -1,0 +1,337 @@
+# Source Connector Spec
+
+Status: Phase 0 draft
+
+This document records the **actual current connector contract from the codebase**, not the desired future contract.
+
+## Executive summary
+
+CallVault already has one shared insertion path for imported recordings: `supabase/functions/_shared/connector-pipeline.ts`. A source connector does not write directly to UI-facing tables. It builds a normalized record, then `runPipeline()` inserts into `recordings` and creates `workspace_entries`.
+
+The important distinction is between:
+
+1. the **hard insert contract** required by `connector-pipeline.ts`, and
+2. the **parity contract** needed for Fireflies/Grain/Otter/Riverside recordings to behave like Fathom in the app.
+
+They are not identical today.
+
+## Code anchors
+
+- Pipeline insert path: `supabase/functions/_shared/connector-pipeline.ts:197-215`
+- Canonical draft wrapper: `supabase/functions/_shared/canonical-recording.ts`
+- Meeting mapping into UI: `src/hooks/useWorkspaces.ts:357-415`
+- Summary generation/caching: `supabase/functions/summarize-call/index.ts:175-344`
+- AI title generation: `supabase/functions/generate-ai-titles/index.ts`
+- Auto-tag generation: `supabase/functions/auto-tag-calls/index.ts`
+- MCP recording context/action items: `supabase/functions/mcp-server/index.ts`
+
+## 1) Hard insert contract: what `connector-pipeline.ts` actually requires
+
+`insertRecording()` writes these fields into `recordings` today:
+
+```ts
+interface PipelineInsertRecord {
+  // Required by current pipeline
+  external_id: string;           // becomes recordings.source_call_id
+  source_app: string;            // becomes recordings.source_app
+  title: string;                 // becomes recordings.title
+  full_transcript: string;       // becomes recordings.full_transcript
+  recording_start_time: string;  // becomes recordings.recording_start_time
+  source_metadata: Record<string, unknown>; // becomes recordings.source_metadata
+
+  // Optional in current pipeline
+  summary?: string | null;       // becomes recordings.summary
+  duration?: number;             // becomes recordings.duration
+  recording_end_time?: string;   // becomes recordings.recording_end_time
+  organization_id?: string;
+  workspace_id?: string;
+  folder_id?: string;
+}
+```
+
+### Mandatory today
+
+A connector **must** provide:
+
+| Field | Why it is mandatory | Code evidence |
+|---|---|---|
+| `external_id` | dedup + stored as `recordings.source_call_id` | `connector-pipeline.ts:205-207` |
+| `source_app` | source identity, filtering, UI labeling | `connector-pipeline.ts:205-207` |
+| `title` | `recordings.title` is inserted directly | `connector-pipeline.ts:202` |
+| `full_transcript` | primary search + summarize/title/tag inputs | `connector-pipeline.ts:203`; `summarize-call`; `generate-ai-titles`; `auto-tag-calls` |
+| `recording_start_time` | list ordering, call metadata, context rendering | `connector-pipeline.ts:209`; `mapRecordingToMeeting()` |
+| `source_metadata` | all source-specific fields are recovered from here downstream | `connector-pipeline.ts:207`; `mapRecordingToMeeting(): meta = source_metadata` |
+
+### Optional today
+
+A connector **may** omit these without breaking insertion:
+
+| Field | Current behavior if omitted |
+|---|---|
+| `recording_end_time` | stored as `null` |
+| `duration` | stored as `null` |
+| `summary` | system can generate later via `summarize-call` |
+| `organization_id` | pipeline resolves personal org |
+| `workspace_id` / `folder_id` | pipeline resolves/rules destination |
+
+## 2) Parity contract: what imported recordings need to behave like Fathom
+
+A recording can insert successfully with the six hard fields above and still feel degraded in the product.
+
+To behave like an existing Fathom/Zoom call in downstream surfaces, a connector **should** add these `source_metadata` keys:
+
+```ts
+interface SourceMetadataParityKeys {
+  external_id: string; // pipeline prepends this automatically
+
+  // strongly recommended for parity
+  share_url?: string | null;
+  source_url?: string | null;
+  recorded_by_name?: string | null;
+  recorded_by_email?: string | null;
+  calendar_invitees?: Array<{
+    name?: string;
+    email?: string;
+    is_external?: boolean;
+    matched_speaker_display_name?: string;
+  }> | null;
+  participant_emails?: string[];
+
+  // optional but useful
+  action_items?: string[];
+  topics_discussed?: string[];
+  synced_at?: string;
+  import_source?: string;
+}
+```
+
+### Why these parity keys matter
+
+| Key | Downstream surface |
+|---|---|
+| `share_url` | `CallDetailHeader`, `CallOverviewTab`, `CallTranscriptTab` show/view outbound links |
+| `recorded_by_name`, `recorded_by_email` | speaker matching, contact/host context, export metadata |
+| `calendar_invitees` | invitees pills, participant counts, contact import, transcript speaker/email matching |
+| `participant_emails` | import/search/host inference helpers |
+| `action_items` | MCP `get_action_items` fast-path avoids an extra LLM pass |
+
+## 3) Important mismatch: schema contract vs current connector contract
+
+The `recordings` schema itself supports more than `connector-pipeline.ts` currently writes.
+
+`20260131000007_create_recordings_tables.sql` includes:
+
+- `audio_url TEXT`
+- `video_url TEXT`
+- `full_transcript TEXT`
+- `summary TEXT`
+- `source_metadata JSONB`
+- `duration INTEGER`
+- `recording_start_time TIMESTAMPTZ`
+- `recording_end_time TIMESTAMPTZ`
+
+### Current gap
+
+The shared connector pipeline **does not write `audio_url` or `video_url` at all**. It only writes link/media-ish values if a connector places them inside `source_metadata`.
+
+That means the current codebase contract is:
+
+- **Schema-level capability:** `audio_url` and `video_url` exist.
+- **Connector-level reality:** connectors must currently preserve media URLs in `source_metadata`, because the shared insertion path does not accept/write media columns.
+
+If we want media URLs to be first-class mandatory connector outputs, Phase 1 needs to extend the shared pipeline, not just update docs.
+
+## 4) What the system already generates for you
+
+These are not required from a connector for the current system to work:
+
+| Field / feature | Current owner |
+|---|---|
+| `ai_generated_title` | `generate-ai-titles` Edge Function |
+| `global_tags` / auto-tags | `auto-tag-calls` Edge Function |
+| `action_items_cache` | MCP `extract_action_items` cache path |
+| LLM summary when no summary exists | `summarize-call` Edge Function |
+
+## 5) Important nuance: summaries are allowed today
+
+If a connector already has a trustworthy source summary, the current codebase **does allow and use it**.
+
+Evidence:
+
+- pipeline inserts `record.summary ?? null` into `recordings.summary`
+- `summarize-call` returns cached summary unless `force_refresh` is set
+- MCP recording context surfaces `recording.summary`
+- `auto-tag-calls` can analyze transcript **and** summary
+
+So the strict statement "connectors must not produce summary" is **not true for the current codebase**.
+
+The accurate statement is:
+
+- source summaries are **optional**,
+- accepted if present,
+- and system-generated summaries backfill when absent.
+
+## 6) Recommended canonical TypeScript model for Phase 1
+
+This is the practical target shape implied by the codebase:
+
+```ts
+interface CanonicalSourceConnectorRecord {
+  // hard insert contract
+  externalId: string;
+  sourceApp: string;
+  title: string;
+  fullTranscript: string;
+  recordingStartTime: string;
+  sourceMetadata: Record<string, unknown>;
+
+  // parity fields
+  recordingEndTime?: string | null;
+  durationSeconds?: number | null;
+  sourceUrl?: string | null;
+  shareUrl?: string | null;
+  audioUrl?: string | null; // phase-1 pipeline extension needed
+  videoUrl?: string | null; // phase-1 pipeline extension needed
+  recordedByName?: string | null;
+  recordedByEmail?: string | null;
+  calendarInvitees?: Array<{ name?: string; email?: string; is_external?: boolean }> | null;
+  participantEmails?: string[] | null;
+
+  // optional source enrichment
+  summary?: string | null;
+  actionItems?: string[] | null;
+  topicsDiscussed?: string[] | null;
+}
+```
+
+## 7) Conformance checklist for a new vendor connector
+
+A vendor connector passes conformance when it proves all of the following:
+
+### Insert contract
+
+- Can build `external_id`, `source_app`, `title`, `full_transcript`, `recording_start_time`, `source_metadata`
+- Uses a stable vendor identifier for `source_call_id`
+- Produces lowercase `source_app`
+- Inserts through the shared pipeline instead of custom SQL
+
+### Product parity
+
+- `mapRecordingToMeeting()` can recover share/view link and host/invitee data from `source_metadata`
+- call detail opens without null-reference regressions
+- MCP `list_calls`, `get_transcript`, `get_recording_context`, and `get_action_items` work with the imported row
+- `summarize-call` works when summary is absent
+- `generate-ai-titles` works because `full_transcript` exists
+- `auto-tag-calls` works because transcript (and optional summary) exist
+
+### Non-goals for the connector itself
+
+- It does not generate AI title text itself
+- It does not generate auto-tags itself
+- It does not need to precompute LLM action items if none are supplied
+
+## 8) Bottom line
+
+The current CallVault connector contract is **smaller and more source-metadata-driven** than the desired future contract.
+
+- Six fields are hard-required by the shared insert path.
+- Several additional metadata keys are required for Fathom-like UX parity.
+- `audio_url` / `video_url` are present in schema but not yet in the connector abstraction.
+- Source summaries are optional, but fully supported today.
+
+## 9) What we are **not** shooting for
+
+A connector surface that asks the user to paste one transcript ID at a time is **not** the target architecture for recording sources.
+
+That kind of screen can be useful as a debug harness, but it is not the real contract we need to solve.
+
+Why:
+
+- it proves only direct ingestion of a known vendor record
+- it does not solve source-native discovery of recordings
+- it does not represent the real user flow for connected accounts
+- it keeps acquisition logic outside the connector abstraction
+
+The target connector flow is:
+
+1. connect source account
+2. backfill historical recordings in bulk from the provider
+3. keep ingesting future provider recordings automatically (webhook, poller, or both)
+4. choose provider-native recordings from fetched inventory when user intervention is needed
+5. normalize each fetched recording into the canonical ingestion shape
+6. insert through the shared pipeline
+
+So the complete solution requires **two contracts**:
+
+- **Acquisition contract** — connect account, list/backfill recordings, fetch details, and optionally webhook-verify future events
+- **Canonical ingestion contract** — map one fetched source recording into `recordings`
+
+Both have to exist before “new vendors take hours, not weeks” is true.
+
+## 10) Connector lifecycle invariant
+
+This lifecycle must be the **same for every recording-source connector**.
+
+Not "works once."
+Not "supports an initial import."
+Not "special-cases Fireflies."
+
+The invariant is:
+
+```ts
+interface RecordingSourceConnector {
+  sourceApp: string;
+
+  // account-level connection state
+  connect(input: ConnectSourceInput): Promise<ConnectedSourceAccount>;
+  refreshConnection?(account: ConnectedSourceAccount): Promise<ConnectedSourceAccount>;
+  disconnect(account: ConnectedSourceAccount): Promise<void>;
+
+  // historical ingestion
+  listRecordings(window: DateWindow, account: ConnectedSourceAccount): Promise<SourceRecordingStub[]>;
+  getRecording(recordingId: string, account: ConnectedSourceAccount): Promise<CanonicalSourceConnectorRecord>;
+
+  // future ingestion
+  verifyWebhook?(request: Request, account: ConnectedSourceAccount): Promise<VerifiedSourceEvent | null>;
+  listNewRecordings?(since: Cursor, account: ConnectedSourceAccount): Promise<SourceRecordingStub[]>;
+}
+```
+
+A connector is only valid when it supports the same **perpetual** operational model as every other source:
+
+1. account is connected once
+2. historical recordings can be backfilled in bulk
+3. future recordings continue to arrive without manual per-recording setup
+4. every fetched recording normalizes into the same canonical ingestion contract
+5. downstream readers remain source-agnostic
+
+If a vendor can only import one known transcript ID at a time, that is a debug utility, not a finished connector.
+
+## 11) Auth mode varies; lifecycle does not
+
+Different vendors may authenticate differently:
+
+- Fathom: OAuth and/or API key
+- Zoom: OAuth
+- Fireflies: API key plus optional webhook signing secret
+- Grain: OAuth, PAT, or workspace token
+- Riverside: API key
+- Otter: likely enterprise API credentials
+
+That is acceptable.
+
+What is **not** acceptable is letting auth differences leak into the connector lifecycle.
+
+The stable rule is:
+
+- auth mode may vary
+- discovery/backfill/future-ingestion lifecycle may **not** vary
+- canonical ingestion contract may **not** vary
+- downstream readers may **not** vary
+
+So the connector abstraction has to normalize two different things:
+
+1. **provider auth surface** → one `ConnectedSourceAccount`
+2. **provider recording payload** → one canonical ingestion record
+
+If we do only the second normalization, we have not solved the recording-source problem.

--- a/src/components/import/AddImportSourceDialog.tsx
+++ b/src/components/import/AddImportSourceDialog.tsx
@@ -21,6 +21,7 @@ import { cn } from '@/lib/utils';
 export type AddImportSourceChoice =
   | 'fathom'
   | 'zoom'
+  | 'fireflies'
   | 'youtube'
   | 'file-upload'
   | 'paste-transcript';
@@ -35,6 +36,7 @@ interface SourceTile {
 const TILES: SourceTile[] = [
   { id: 'fathom', label: 'Fathom', subtitle: 'Connect your Fathom account via OAuth', icon: RiCloudLine },
   { id: 'zoom', label: 'Zoom', subtitle: 'Connect Zoom Cloud Recordings via OAuth', icon: RiVideoLine },
+  { id: 'fireflies', label: 'Fireflies', subtitle: 'Import Fireflies transcripts with an API key', icon: RiCloudLine },
   { id: 'youtube', label: 'YouTube', subtitle: 'Import calls from public YouTube URLs', icon: RiYoutubeLine },
   { id: 'file-upload', label: 'File Upload', subtitle: 'Upload audio or video files directly', icon: RiUploadCloud2Line },
   { id: 'paste-transcript', label: 'Paste Transcript', subtitle: 'Manually paste or upload a transcript', icon: RiClipboardLine },

--- a/src/components/import/FirefliesImportDetail.tsx
+++ b/src/components/import/FirefliesImportDetail.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import {
+  RiCloudLine,
+  RiDownloadCloud2Line,
+  RiKey2Line,
+  RiLinkM,
+  RiLoader4Line,
+  RiRefreshLine,
+  RiSearchLine,
+  RiShieldKeyholeLine,
+} from '@remixicon/react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DateRangePicker } from '@/components/ui/date-range-picker';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { PageHeader } from '@/components/ui/page-header';
+import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
+import { supabase } from '@/integrations/supabase/client';
+import { queryKeys } from '@/lib/query-config';
+import { cn } from '@/lib/utils';
+import type { ImportSource } from '@/services/import-sources.service';
+
+interface FirefliesMeeting {
+  recording_id: string;
+  title: string;
+  created_at: string;
+  recording_start_time: string | null;
+  recording_end_time: string | null;
+  duration: number | null;
+  synced: boolean;
+  calendar_invitees: Array<{ name: string | null; email: string | null }>;
+  source_url: string | null;
+  share_url: string | null;
+}
+
+interface SyncJobPoll {
+  id: string;
+  status: 'processing' | 'completed' | 'completed_with_errors' | 'failed';
+  progress_current: number;
+  progress_total: number;
+  synced_ids: string[] | null;
+  failed_ids: string[] | null;
+  skipped_count: number | null;
+  error_message: string | null;
+}
+
+export interface FirefliesImportDetailProps {
+  source: ImportSource | null;
+  onDisconnect?: () => void;
+}
+
+export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportDetailProps) {
+  const queryClient = useQueryClient();
+  const [apiKey, setApiKey] = useState('');
+  const [webhookSigningSecret, setWebhookSigningSecret] = useState('');
+  const [savingConnection, setSavingConnection] = useState(false);
+  const [dateRange, setDateRange] = useState<{ from?: Date; to?: Date }>({});
+  const [meetings, setMeetings] = useState<FirefliesMeeting[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasFetched, setHasFetched] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [workspaceId, setWorkspaceId] = useState<string | undefined>(undefined);
+  const [syncing, setSyncing] = useState(false);
+  const [syncProgress, setSyncProgress] = useState({ current: 0, total: 0 });
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const toUTCStart = (d: Date) =>
+    new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)).toISOString();
+  const toUTCEnd = (d: Date) =>
+    new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)).toISOString();
+
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    setSyncing(false);
+  };
+
+  const handleSaveConnection = useCallback(async () => {
+    if (!apiKey.trim()) {
+      toast.error('Fireflies API key is required');
+      return;
+    }
+
+    setSavingConnection(true);
+    try {
+      const { data, error } = await supabase.functions.invoke('fireflies-save-source', {
+        body: {
+          apiKey: apiKey.trim(),
+          webhookSigningSecret: webhookSigningSecret.trim() || null,
+        },
+      });
+      if (error) throw error;
+      if ((data as { error?: string } | null)?.error) {
+        throw new Error((data as { error: string }).error);
+      }
+
+      toast.success('Fireflies connected');
+      queryClient.invalidateQueries({ queryKey: queryKeys.imports.sources() });
+      setApiKey('');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to connect Fireflies');
+    } finally {
+      setSavingConnection(false);
+    }
+  }, [apiKey, queryClient, webhookSigningSecret]);
+
+  const handleSearch = useCallback(async () => {
+    if (!source?.id) {
+      toast.error('Connect Fireflies first');
+      return;
+    }
+    if (!dateRange.from) {
+      toast.error('Choose a date range');
+      return;
+    }
+
+    setLoading(true);
+    setHasFetched(false);
+    setMeetings([]);
+    setSelected(new Set());
+
+    try {
+      const createdAfter = toUTCStart(dateRange.from);
+      const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
+      const { data, error } = await supabase.functions.invoke('fireflies-fetch-meetings', {
+        body: {
+          sourceId: source.id,
+          createdAfter,
+          createdBefore,
+          limit: 50,
+          skip: 0,
+        },
+      });
+      if (error) throw error;
+      if ((data as { error?: string } | null)?.error) {
+        throw new Error((data as { error: string }).error);
+      }
+
+      const fetched = ((data as { meetings?: FirefliesMeeting[] } | null)?.meetings ?? []);
+      setMeetings(fetched);
+      setHasFetched(true);
+      toast.success(`Found ${fetched.length} Fireflies recording${fetched.length === 1 ? '' : 's'}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to fetch Fireflies recordings');
+    } finally {
+      setLoading(false);
+    }
+  }, [dateRange, source?.id]);
+
+  const unsyncedMeetings = meetings.filter((meeting) => !meeting.synced);
+  const allUnsyncedSelected = unsyncedMeetings.length > 0 && unsyncedMeetings.every((meeting) => selected.has(meeting.recording_id));
+
+  const toggleSelectAll = () => {
+    if (allUnsyncedSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(unsyncedMeetings.map((meeting) => meeting.recording_id)));
+    }
+  };
+
+  const toggleMeeting = (recordingId: string) => {
+    setSelected((previous) => {
+      const next = new Set(previous);
+      if (next.has(recordingId)) next.delete(recordingId);
+      else next.add(recordingId);
+      return next;
+    });
+  };
+
+  const handleImport = useCallback(async () => {
+    if (!source?.id) {
+      toast.error('Connect Fireflies first');
+      return;
+    }
+    if (!workspaceId) {
+      toast.error('Choose a workspace before importing');
+      return;
+    }
+    if (selected.size === 0) {
+      toast.error('Choose at least one Fireflies recording');
+      return;
+    }
+
+    setSyncing(true);
+    setSyncProgress({ current: 0, total: selected.size });
+
+    try {
+      const transcriptIds = Array.from(selected);
+      const { data, error } = await supabase.functions.invoke('fireflies-sync-meetings', {
+        body: {
+          sourceId: source.id,
+          transcriptIds,
+          workspace_id: workspaceId,
+        },
+      });
+      if (error) throw error;
+      const jobId = (data as { jobId?: string } | null)?.jobId;
+      if (!jobId) throw new Error('Fireflies sync started without a job ID');
+
+      pollRef.current = setInterval(async () => {
+        try {
+          const { data: jobData, error: jobError } = await supabase
+            .from('sync_jobs')
+            .select('*')
+            .eq('id', jobId)
+            .single();
+          if (jobError || !jobData) return;
+          const job = jobData as SyncJobPoll;
+          setSyncProgress({
+            current: job.progress_current ?? 0,
+            total: job.progress_total ?? transcriptIds.length,
+          });
+          if (job.status === 'processing') return;
+
+          stopPolling();
+          const syncedCount = job.synced_ids?.length ?? 0;
+          const failedCount = job.failed_ids?.length ?? 0;
+          const skippedCount = job.skipped_count ?? 0;
+
+          if (job.status === 'completed') {
+            toast.success(`Imported ${syncedCount} Fireflies recording${syncedCount === 1 ? '' : 's'}`);
+          } else if (job.status === 'completed_with_errors') {
+            toast.warning(`Fireflies import finished with ${syncedCount} imported, ${failedCount} failed, ${skippedCount} skipped`);
+          } else {
+            toast.error(job.error_message || 'Fireflies import failed');
+          }
+
+          queryClient.invalidateQueries({ queryKey: queryKeys.calls.all });
+          queryClient.invalidateQueries({ queryKey: ['workspace-entries'] });
+          await handleSearch();
+          setSelected(new Set());
+        } catch {
+          // Ignore transient poll failures.
+        }
+      }, 1000);
+    } catch (error) {
+      stopPolling();
+      toast.error(error instanceof Error ? error.message : 'Failed to start Fireflies import');
+    }
+  }, [handleSearch, queryClient, selected, source?.id, workspaceId]);
+
+  const progressPct = syncProgress.total > 0 ? Math.round((syncProgress.current / syncProgress.total) * 100) : 0;
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <PageHeader
+        title="Fireflies"
+        subtitle="Connect once, search recordings, bulk import, and keep future ingestion wired"
+        icon={RiDownloadCloud2Line}
+      />
+      <div className="px-6 py-4 max-w-3xl space-y-5">
+        <div className="rounded-xl border border-border bg-card p-4 space-y-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Fireflies account connection</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Fireflies uses an account-level API key instead of OAuth. Connect the account once,
+                then bulk backfill and continue ingesting future calls from the same source.
+              </p>
+              {source?.account_email && (
+                <p className="text-xs text-muted-foreground mt-2">Connected as {source.account_email}</p>
+              )}
+            </div>
+            {source && onDisconnect && (
+              <Button variant="hollow" onClick={onDisconnect}>Disconnect</Button>
+            )}
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="fireflies-api-key" className="text-xs flex items-center gap-2">
+                <RiKey2Line className="h-3.5 w-3.5 text-muted-foreground" />
+                API Key
+              </Label>
+              <Input
+                id="fireflies-api-key"
+                type="password"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                placeholder={source ? 'Enter a replacement API key to reconnect' : 'Your Fireflies API key'}
+                autoComplete="off"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="fireflies-webhook-secret" className="text-xs flex items-center gap-2">
+                <RiShieldKeyholeLine className="h-3.5 w-3.5 text-muted-foreground" />
+                Webhook signing secret (optional)
+              </Label>
+              <Input
+                id="fireflies-webhook-secret"
+                type="password"
+                value={webhookSigningSecret}
+                onChange={(event) => setWebhookSigningSecret(event.target.value)}
+                placeholder="Optional Fireflies webhook secret"
+                autoComplete="off"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button onClick={() => void handleSaveConnection()} disabled={savingConnection || !apiKey.trim()}>
+              {savingConnection ? 'Saving…' : source ? 'Reconnect Fireflies' : 'Connect Fireflies'}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              One Fireflies account only for now.
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-border bg-card p-4 space-y-4">
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Search and import recordings</h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              This follows the Fathom/Zoom model: fetch provider-native recordings for a time window,
+              select many, then import them into a workspace.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
+            <DateRangePicker value={dateRange} onChange={setDateRange} />
+            <Button onClick={() => void handleSearch()} disabled={!source || loading || syncing || !dateRange.from} className="gap-2">
+              {loading ? <RiLoader4Line className="h-4 w-4 animate-spin" /> : <RiSearchLine className="h-4 w-4" />}
+              Search Fireflies
+            </Button>
+          </div>
+
+          {hasFetched && meetings.length === 0 && (
+            <div className="rounded-lg border border-dashed border-border px-4 py-6 text-sm text-muted-foreground">
+              No Fireflies recordings found for that date range.
+            </div>
+          )}
+
+          {meetings.length > 0 && (
+            <>
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-2 text-sm text-foreground">
+                  <Checkbox checked={allUnsyncedSelected} onCheckedChange={toggleSelectAll} />
+                  <span>Select all unsynced ({unsyncedMeetings.length})</span>
+                </div>
+                <WorkspaceSelector
+                  integration="fireflies"
+                  value={workspaceId}
+                  onWorkspaceChange={setWorkspaceId}
+                  disabled={syncing}
+                  className="min-w-[280px]"
+                />
+              </div>
+
+              <div className="rounded-xl border border-border divide-y divide-border overflow-hidden">
+                {meetings.map((meeting) => (
+                  <div key={meeting.recording_id} className="flex items-start gap-3 p-4 bg-card">
+                    <Checkbox
+                      checked={selected.has(meeting.recording_id)}
+                      disabled={meeting.synced || syncing}
+                      onCheckedChange={() => toggleMeeting(meeting.recording_id)}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium text-foreground truncate">{meeting.title}</span>
+                        {meeting.synced && (
+                          <span className="text-[10px] uppercase tracking-wide rounded-full bg-emerald-500/10 text-emerald-600 px-2 py-0.5">
+                            Imported
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-x-3 gap-y-1">
+                        <span>{format(new Date(meeting.created_at), 'MMM d, yyyy')}</span>
+                        {meeting.duration != null && <span>{Math.max(1, Math.round(meeting.duration / 60))}m</span>}
+                        <span>{meeting.calendar_invitees.length} attendee{meeting.calendar_invitees.length === 1 ? '' : 's'}</span>
+                      </div>
+                      {meeting.share_url && (
+                        <button
+                          type="button"
+                          className={cn('mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground')}
+                          onClick={() => window.open(meeting.share_url || meeting.source_url || '', '_blank', 'noopener,noreferrer')}
+                        >
+                          <RiLinkM className="h-3.5 w-3.5" />
+                          View in Fireflies
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex items-center gap-3">
+                <Button onClick={() => void handleImport()} disabled={syncing || selected.size === 0 || !workspaceId} className="gap-2">
+                  {syncing ? <RiLoader4Line className="h-4 w-4 animate-spin" /> : <RiRefreshLine className="h-4 w-4" />}
+                  {syncing ? 'Importing…' : `Import ${selected.size || ''} Fireflies recording${selected.size === 1 ? '' : 's'}`.trim()}
+                </Button>
+                {syncing && (
+                  <span className="text-xs text-muted-foreground">
+                    {syncProgress.current}/{syncProgress.total} · {progressPct}%
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/import/FirefliesImportDetail.tsx
+++ b/src/components/import/FirefliesImportDetail.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import {
-  RiCloudLine,
+  RiCheckLine,
   RiDownloadCloud2Line,
+  RiFileCopyLine,
   RiKey2Line,
   RiLinkM,
   RiLoader4Line,
@@ -58,6 +59,7 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
   const [apiKey, setApiKey] = useState('');
   const [webhookSigningSecret, setWebhookSigningSecret] = useState('');
   const [savingConnection, setSavingConnection] = useState(false);
+  const [copiedWebhookUrl, setCopiedWebhookUrl] = useState(false);
   const [dateRange, setDateRange] = useState<{ from?: Date; to?: Date }>({});
   const [meetings, setMeetings] = useState<FirefliesMeeting[]>([]);
   const [loading, setLoading] = useState(false);
@@ -78,6 +80,7 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
     new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)).toISOString();
   const toUTCEnd = (d: Date) =>
     new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)).toISOString();
+  const webhookUrl = `https://api.callvaultai.com/fireflies-webhook`;
 
   const stopPolling = () => {
     if (pollRef.current) {
@@ -115,6 +118,17 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
       setSavingConnection(false);
     }
   }, [apiKey, queryClient, webhookSigningSecret]);
+
+  const handleCopyWebhookUrl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(webhookUrl);
+      setCopiedWebhookUrl(true);
+      setTimeout(() => setCopiedWebhookUrl(false), 2000);
+      toast.success('Webhook URL copied to clipboard');
+    } catch {
+      toast.error('Failed to copy webhook URL');
+    }
+  }, [webhookUrl]);
 
   const handleSearch = useCallback(async () => {
     if (!source?.id) {
@@ -315,6 +329,36 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
             </Button>
             <p className="text-xs text-muted-foreground">
               One Fireflies account only for now.
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-dashed border-border p-3 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-medium text-foreground">Webhook URL for Fireflies</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Use this friendly webhook URL in Fireflies. A single shared URL is enough for every CallVault user;
+                  the per-account signing secret is what routes each webhook to the correct connected Fireflies source.
+                </p>
+              </div>
+              <Button variant="hollow" size="sm" onClick={() => void handleCopyWebhookUrl()} className="shrink-0">
+                {copiedWebhookUrl ? (
+                  <>
+                    <RiCheckLine className="h-4 w-4 mr-2 text-emerald-500" />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <RiFileCopyLine className="h-4 w-4 mr-2" />
+                    Copy URL
+                  </>
+                )}
+              </Button>
+            </div>
+            <Input value={webhookUrl} readOnly className="font-mono text-xs" />
+            <p className="text-[11px] text-muted-foreground">
+              In Fireflies, set this URL as the webhook destination. Then save the matching signing secret here if you
+              want future calls to ingest automatically as they land.
             </p>
           </div>
         </div>

--- a/src/components/import/ImportOverviewDashboard.tsx
+++ b/src/components/import/ImportOverviewDashboard.tsx
@@ -31,6 +31,7 @@ interface SourceDef {
 const SOURCE_DEFS: SourceDef[] = [
   { id: 'fathom', label: 'Fathom', icon: RiCloudLine },
   { id: 'zoom', label: 'Zoom', icon: RiVideoLine },
+  { id: 'fireflies', label: 'Fireflies', icon: RiCloudLine },
   { id: 'youtube', label: 'YouTube', icon: RiYoutubeLine },
   { id: 'file-upload', label: 'File Upload', icon: RiUploadCloud2Line },
 ];

--- a/src/components/panes/ImportSourcePane.tsx
+++ b/src/components/panes/ImportSourcePane.tsx
@@ -27,6 +27,7 @@ import type { ImportSource } from '@/services/import-sources.service';
 export type ImportSourceId =
   | 'fathom'
   | 'zoom'
+  | 'fireflies'
   | 'youtube'
   | 'file-upload'
   | 'paste-transcript'
@@ -53,6 +54,7 @@ interface SourceDef {
 const PRIMARY_SOURCES: SourceDef[] = [
   { id: 'fathom', label: 'Fathom', subtitle: 'AI meeting recorder', icon: RiCloudLine },
   { id: 'zoom', label: 'Zoom', subtitle: 'Cloud recordings', icon: RiVideoLine },
+  { id: 'fireflies', label: 'Fireflies', subtitle: 'Transcript API import', icon: RiCloudLine },
   { id: 'youtube', label: 'YouTube', subtitle: 'Video imports', icon: RiYoutubeLine },
   { id: 'file-upload', label: 'File Upload', subtitle: 'Direct upload', icon: RiUploadCloud2Line },
   // Phase 36-06 BUG-05: expose Paste Transcript as a first-class source entry

--- a/src/components/workspace/WorkspaceSelector.tsx
+++ b/src/components/workspace/WorkspaceSelector.tsx
@@ -28,7 +28,7 @@ import type { WorkspaceWithMembership } from '@/types/workspace'
 
 type WorkspaceForSelector = WorkspaceWithMembership & { member_count?: number }
 
-type IntegrationKey = 'zoom' | 'fathom' | 'youtube' | 'file-upload'
+type IntegrationKey = 'zoom' | 'fathom' | 'fireflies' | 'youtube' | 'file-upload'
 
 export interface WorkspaceSelectorProps {
   /** Which integration this selector is for (used to remember default) */

--- a/src/lib/__tests__/fireflies-import.test.ts
+++ b/src/lib/__tests__/fireflies-import.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseFirefliesTranscriptIds } from '../fireflies-import';
+
+describe('parseFirefliesTranscriptIds', () => {
+  it('splits comma and newline separated ids, trimming whitespace', () => {
+    expect(parseFirefliesTranscriptIds('  abc123, def456\n ghi789  ')).toEqual([
+      'abc123',
+      'def456',
+      'ghi789',
+    ]);
+  });
+
+  it('drops blanks and preserves first occurrence order', () => {
+    expect(parseFirefliesTranscriptIds('\nabc123,,abc123\n\ndef456,  ')).toEqual([
+      'abc123',
+      'def456',
+    ]);
+  });
+});

--- a/src/lib/fireflies-import.ts
+++ b/src/lib/fireflies-import.ts
@@ -1,0 +1,13 @@
+export function parseFirefliesTranscriptIds(raw: string): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  for (const piece of raw.split(/[\n,]/)) {
+    const id = piece.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -19,6 +19,7 @@ import { RoutingRulesTab } from '@/components/import/RoutingRulesTab';
 import { YouTubeImportForm } from '@/components/import/YouTubeImportForm';
 import { FathomImportDetail } from '@/components/import/FathomImportDetail';
 import { ZoomImportDetail } from '@/components/import/ZoomImportDetail';
+import { FirefliesImportDetail } from '@/components/import/FirefliesImportDetail';
 import { PasteTranscriptModal } from '@/components/import/PasteTranscriptModal';
 import { AddImportSourceDialog, type AddImportSourceChoice } from '@/components/import/AddImportSourceDialog';
 import { ImportHistoryPanel } from '@/components/import/ImportHistoryPanel';
@@ -176,6 +177,16 @@ export default function ImportPage() {
         />
       );
     }
+    if (selectedSource === 'fireflies') {
+      const firefliesRow = sources.find((s) => s.source_app === 'fireflies') ?? null;
+      return (
+        <FirefliesImportDetail
+          source={firefliesRow}
+          onDisconnect={firefliesRow ? () => setDisconnectTarget(firefliesRow) : undefined}
+        />
+      );
+    }
+
 
     if (selectedSource === 'youtube') {
       return (
@@ -274,6 +285,8 @@ export default function ImportPage() {
       void connectFathom();
     } else if (choice === 'zoom') {
       void connectZoom();
+    } else if (choice === 'fireflies') {
+      setSelectedSource('fireflies');
     } else if (choice === 'youtube') {
       setSelectedSource('youtube');
     } else if (choice === 'file-upload') {
@@ -308,7 +321,7 @@ export default function ImportPage() {
           <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
           <AlertDialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md rounded-xl bg-card p-6 shadow-lg border border-border">
             <AlertDialog.Title className="text-lg font-semibold text-foreground">
-              Disconnect {disconnectTarget?.source_app === 'fathom' ? 'Fathom' : 'Zoom'}?
+              Disconnect {disconnectTarget ? (disconnectTarget.source_app === 'fathom' ? 'Fathom' : disconnectTarget.source_app === 'zoom' ? 'Zoom' : getSourceName(disconnectTarget.source_app)) : 'source'}?
             </AlertDialog.Title>
             <AlertDialog.Description className="text-sm text-muted-foreground mt-2">
               Your imported calls will remain in CallVault. You can reconnect at any time.
@@ -345,4 +358,11 @@ export default function ImportPage() {
       />
     </>
   );
+}
+
+function getSourceName(sourceApp: string): string {
+  if (sourceApp === 'fireflies') return 'Fireflies';
+  if (sourceApp === 'youtube') return 'YouTube';
+  if (sourceApp === 'file-upload') return 'File Upload';
+  return sourceApp;
 }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1953,6 +1953,7 @@ export type Database = {
       import_sources: {
         Row: {
           account_email: string | null
+          api_key: string | null
           created_at: string
           error_message: string | null
           fathom_api_key: string | null
@@ -1965,9 +1966,11 @@ export type Database = {
           source_app: string
           updated_at: string
           user_id: string
+          webhook_signing_secret: string | null
         }
         Insert: {
           account_email?: string | null
+          api_key?: string | null
           created_at?: string
           error_message?: string | null
           fathom_api_key?: string | null
@@ -1980,9 +1983,11 @@ export type Database = {
           source_app: string
           updated_at?: string
           user_id: string
+          webhook_signing_secret?: string | null
         }
         Update: {
           account_email?: string | null
+          api_key?: string | null
           created_at?: string
           error_message?: string | null
           fathom_api_key?: string | null
@@ -1995,6 +2000,7 @@ export type Database = {
           source_app?: string
           updated_at?: string
           user_id?: string
+          webhook_signing_secret?: string | null
         }
         Relationships: []
       }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -33,6 +33,15 @@ verify_jwt = false
 
 [functions.zoom-sync-meetings]
 verify_jwt = false
+[functions.fireflies-save-source]
+verify_jwt = false
+
+[functions.fireflies-fetch-meetings]
+verify_jwt = false
+
+[functions.fireflies-sync-meetings]
+verify_jwt = false
+
 
 [functions.youtube-import]
 verify_jwt = false
@@ -129,6 +138,8 @@ verify_jwt = false
 
 [functions.zoom-webhook]
 # Receives external Zoom webhook callbacks — no user JWT available
+verify_jwt = false
+[functions.fireflies-webhook]
 verify_jwt = false
 
 [functions.polar-webhook]

--- a/supabase/functions/_shared/fireflies-connector.ts
+++ b/supabase/functions/_shared/fireflies-connector.ts
@@ -1,0 +1,368 @@
+import {
+  formatCanonicalTranscript,
+  normalizeEmailList,
+  type CanonicalRecording,
+  type CanonicalTranscriptTurn,
+} from './canonical-recording.ts';
+
+const FIREFLIES_GRAPHQL_URL = 'https://api.fireflies.ai/graphql';
+
+export const FIREFLIES_USER_QUERY = `
+  query CallVaultFirefliesUser {
+    user {
+      user_id
+      email
+      name
+      integrations
+    }
+  }
+`;
+
+export const FIREFLIES_TRANSCRIPTS_QUERY = `
+  query CallVaultFirefliesTranscripts(
+    $fromDate: DateTime
+    $toDate: DateTime
+    $limit: Int
+    $skip: Int
+  ) {
+    transcripts(fromDate: $fromDate, toDate: $toDate, limit: $limit, skip: $skip) {
+      id
+      title
+      dateString
+      date
+      duration
+      transcript_url
+      audio_url
+      video_url
+      meeting_link
+      host_email
+      organizer_email
+      participants
+      meeting_attendees {
+        displayName
+        email
+        name
+      }
+    }
+  }
+`;
+export const FIREFLIES_TRANSCRIPT_QUERY = `
+  query CallVaultFirefliesTranscript($transcriptId: String!) {
+    transcript(id: $transcriptId) {
+      id
+      title
+      dateString
+      date
+      transcript_url
+      audio_url
+      video_url
+      duration
+      host_email
+      organizer_email
+      participants
+      meeting_link
+      sentences {
+        index
+        speaker_name
+        text
+        start_time
+        end_time
+      }
+      meeting_attendees {
+        displayName
+        email
+        name
+      }
+      summary {
+        overview
+        short_summary
+        short_overview
+        gist
+        bullet_gist
+        action_items
+        topics_discussed
+      }
+    }
+  }
+`;
+
+export interface FirefliesTranscript {
+  id: string;
+  title?: string | null;
+  dateString?: string | null;
+  date?: number | string | null;
+  transcript_url?: string | null;
+  audio_url?: string | null;
+  video_url?: string | null;
+  duration?: number | null;
+  host_email?: string | null;
+  organizer_email?: string | null;
+  participants?: unknown;
+  meeting_link?: string | null;
+  sentences?: FirefliesSentence[] | null;
+  meeting_attendees?: FirefliesAttendee[] | null;
+  summary?: FirefliesSummary | null;
+}
+
+export interface FirefliesSentence {
+  index?: number | null;
+  speaker_name?: string | null;
+  text?: string | null;
+  start_time?: number | null;
+  end_time?: number | null;
+}
+
+export interface FirefliesAttendee {
+  displayName?: string | null;
+  email?: string | null;
+  name?: string | null;
+}
+
+export interface FirefliesSummary {
+  overview?: string | null;
+  short_summary?: string | null;
+  short_overview?: string | null;
+  gist?: string | null;
+  bullet_gist?: string | string[] | null;
+  action_items?: string | string[] | null;
+  topics_discussed?: string | string[] | null;
+}
+
+export interface FirefliesGraphQLResponse {
+  data?: { transcript?: FirefliesTranscript | null; transcripts?: FirefliesTranscript[] | null; user?: FirefliesUser | null };
+  errors?: Array<{ message?: string }>;
+}
+
+export interface FirefliesUser {
+  user_id?: string | null;
+  email?: string | null;
+  name?: string | null;
+  integrations?: unknown;
+}
+
+export async function fetchFirefliesTranscript(
+  apiKey: string,
+  transcriptId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FirefliesTranscript> {
+  if (!apiKey.trim()) throw new Error('Fireflies API key is required');
+  if (!transcriptId.trim()) throw new Error('Fireflies transcript ID is required');
+
+  const response = await fetchImpl(FIREFLIES_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      query: FIREFLIES_TRANSCRIPT_QUERY,
+      variables: { transcriptId },
+    }),
+  });
+
+  const payload = await response.json() as FirefliesGraphQLResponse;
+  if (!response.ok || payload.errors?.length) {
+    const message = payload.errors?.map((error) => error.message).filter(Boolean).join('; ')
+      || `Fireflies API request failed with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+
+  if (!payload.data?.transcript) {
+    throw new Error(`Fireflies transcript not found: ${transcriptId}`);
+  }
+
+  return payload.data.transcript;
+}
+
+export async function fetchFirefliesUser(
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FirefliesUser> {
+  const payload = await firefliesGraphqlRequest<{ user?: FirefliesUser | null }>(
+    apiKey,
+    FIREFLIES_USER_QUERY,
+    {},
+    fetchImpl,
+  );
+  if (!payload.user) {
+    throw new Error('Fireflies user lookup failed');
+  }
+  return payload.user;
+}
+
+export async function fetchFirefliesTranscripts(
+  apiKey: string,
+  params: {
+    fromDate?: string | null;
+    toDate?: string | null;
+    limit?: number;
+    skip?: number;
+  },
+  fetchImpl: typeof fetch = fetch,
+): Promise<FirefliesTranscript[]> {
+  const payload = await firefliesGraphqlRequest<{ transcripts?: FirefliesTranscript[] | null }>(
+    apiKey,
+    FIREFLIES_TRANSCRIPTS_QUERY,
+    {
+      fromDate: params.fromDate ?? null,
+      toDate: params.toDate ?? null,
+      limit: params.limit ?? 50,
+      skip: params.skip ?? 0,
+    },
+    fetchImpl,
+  );
+  return payload.transcripts ?? [];
+}
+
+export function firefliesTranscriptToCanonical(transcript: FirefliesTranscript): CanonicalRecording {
+  const turns = firefliesSentencesToTurns(transcript.sentences ?? []);
+  const fullTranscript = formatCanonicalTranscript(turns);
+  const recordingStartTime = coerceFirefliesDate(transcript.dateString ?? transcript.date);
+  const durationSeconds = normalizeDurationSeconds(transcript.duration);
+  const recordingEndTime = durationSeconds != null
+    ? new Date(new Date(recordingStartTime).getTime() + durationSeconds * 1000).toISOString()
+    : null;
+  const attendeeEmails = (transcript.meeting_attendees ?? [])
+    .map((attendee) => attendee.email)
+    .filter((email): email is string => typeof email === 'string');
+
+  return {
+    externalId: transcript.id,
+    sourceApp: 'fireflies',
+    title: transcript.title?.trim() || 'Untitled Fireflies Call',
+    fullTranscript,
+    summary: summarizeFirefliesSummary(transcript.summary),
+    recordingStartTime,
+    recordingEndTime,
+    durationSeconds,
+    sourceUrl: transcript.transcript_url ?? transcript.meeting_link ?? null,
+    shareUrl: transcript.transcript_url ?? transcript.meeting_link ?? null,
+    recordedByEmail: transcript.host_email ?? transcript.organizer_email ?? null,
+    participantEmails: normalizeEmailList([
+      transcript.host_email ?? '',
+      transcript.organizer_email ?? '',
+      ...attendeeEmails,
+      ...extractEmailsFromParticipants(transcript.participants),
+    ]),
+    calendarInvitees: transcript.meeting_attendees ?? [],
+    sourceMetadata: {
+      fireflies_transcript_id: transcript.id,
+      fireflies_transcript_url: transcript.transcript_url ?? null,
+      fireflies_audio_url: transcript.audio_url ?? null,
+      fireflies_video_url: transcript.video_url ?? null,
+      fireflies_meeting_link: transcript.meeting_link ?? null,
+      recorded_by_email: transcript.host_email ?? transcript.organizer_email ?? null,
+      recorded_by_name: findHostName(transcript),
+      action_items: normalizeSummaryList(transcript.summary?.action_items),
+      topics_discussed: normalizeSummaryList(transcript.summary?.topics_discussed),
+    },
+    rawPayload: transcript,
+  };
+}
+
+function firefliesSentencesToTurns(sentences: FirefliesSentence[]): CanonicalTranscriptTurn[] {
+  return [...sentences]
+    .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+    .map((sentence) => ({
+      speakerName: sentence.speaker_name ?? 'Unknown',
+      text: sentence.text ?? '',
+      startSeconds: sentence.start_time ?? 0,
+      endSeconds: sentence.end_time ?? null,
+    }));
+}
+
+function coerceFirefliesDate(value: number | string | null | undefined): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const millis = value > 10_000_000_000 ? value : value * 1000;
+    return new Date(millis).toISOString();
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+
+  throw new Error('Fireflies transcript is missing a valid date/dateString');
+}
+
+function normalizeDurationSeconds(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return Math.round(value);
+}
+
+function summarizeFirefliesSummary(summary: FirefliesSummary | null | undefined): string | null {
+  if (!summary) return null;
+  const sections = [
+    summary.short_summary,
+    summary.short_overview,
+    summary.overview,
+    summary.gist,
+    stringifyList('Topics discussed', summary.topics_discussed),
+    stringifyList('Action items', summary.action_items),
+    stringifyList('Highlights', summary.bullet_gist),
+  ].filter((section): section is string => typeof section === 'string' && section.trim().length > 0);
+
+  return sections.length > 0 ? sections.join('\n\n') : null;
+}
+
+function stringifyList(label: string, value: string | string[] | null | undefined): string | null {
+  if (Array.isArray(value)) {
+    const items = value.map((item) => item.trim()).filter(Boolean);
+    return items.length > 0 ? `${label}:\n${items.map((item) => `- ${item}`).join('\n')}` : null;
+  }
+  return typeof value === 'string' && value.trim() ? `${label}: ${value.trim()}` : null;
+}
+
+function normalizeSummaryList(value: string | string[] | null | undefined): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => item.trim()).filter(Boolean);
+  }
+  return typeof value === 'string' && value.trim() ? [value.trim()] : [];
+}
+
+function extractEmailsFromParticipants(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((participant) => {
+      if (typeof participant === 'string') return participant;
+      if (participant && typeof participant === 'object' && 'email' in participant) {
+        return String((participant as { email?: unknown }).email ?? '');
+      }
+      return '';
+    })
+    .filter(Boolean);
+}
+
+function findHostName(transcript: FirefliesTranscript): string | null {
+  const hostEmail = transcript.host_email ?? transcript.organizer_email;
+  if (!hostEmail) return null;
+  const attendee = (transcript.meeting_attendees ?? []).find((item) => item.email === hostEmail);
+  return attendee?.displayName ?? attendee?.name ?? null;
+}
+
+async function firefliesGraphqlRequest<T>(
+  apiKey: string,
+  query: string,
+  variables: Record<string, unknown>,
+  fetchImpl: typeof fetch,
+): Promise<T> {
+  if (!apiKey.trim()) throw new Error('Fireflies API key is required');
+
+  const response = await fetchImpl(FIREFLIES_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = await response.json() as FirefliesGraphQLResponse;
+  if (!response.ok || payload.errors?.length) {
+    const message = payload.errors?.map((error) => error.message).filter(Boolean).join('; ')
+      || `Fireflies API request failed with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+
+  return (payload.data ?? {}) as T;
+}

--- a/supabase/functions/fireflies-fetch-meetings/index.ts
+++ b/supabase/functions/fireflies-fetch-meetings/index.ts
@@ -1,0 +1,144 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { fetchFirefliesTranscripts, type FirefliesTranscript } from '../_shared/fireflies-connector.ts';
+
+interface FirefliesFetchMeetingsRequest {
+  createdAfter?: string | null;
+  createdBefore?: string | null;
+  sourceId?: string | null;
+  skip?: number;
+  limit?: number;
+}
+
+interface FirefliesListRow {
+  recording_id: string;
+  title: string;
+  created_at: string;
+  recording_start_time: string | null;
+  recording_end_time: string | null;
+  duration: number | null;
+  synced: boolean;
+  calendar_invitees: Array<{ name: string | null; email: string | null }>;
+  source_url: string | null;
+  share_url: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const authResult = await authenticateRequest(req, supabase, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json() as FirefliesFetchMeetingsRequest;
+    const limit = Math.min(Math.max(body.limit ?? 50, 1), 50);
+    const skip = Math.max(body.skip ?? 0, 0);
+
+    const { data: source, error: sourceError } = await supabase
+      .from('import_sources')
+      .select('id, api_key, webhook_signing_secret, account_email')
+      .eq('user_id', userId)
+      .eq('source_app', 'fireflies')
+      .eq('is_active', true)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (sourceError) throw sourceError;
+    if (!source?.api_key) {
+      return new Response(JSON.stringify({ error: 'Fireflies is not connected. Save an API key first.' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const transcripts = await fetchFirefliesTranscripts(source.api_key, {
+      fromDate: body.createdAfter ?? null,
+      toDate: body.createdBefore ?? null,
+      limit,
+      skip,
+    });
+
+    const ids = transcripts.map((item) => item.id).filter(Boolean);
+    const syncedIds = new Set<string>();
+    if (ids.length > 0) {
+      const { data: recordings, error: recordingsError } = await supabase
+        .from('recordings')
+        .select('source_call_id')
+        .eq('owner_user_id', userId)
+        .eq('source_app', 'fireflies')
+        .in('source_call_id', ids);
+      if (recordingsError) throw recordingsError;
+      for (const row of recordings ?? []) {
+        if (row.source_call_id) syncedIds.add(String(row.source_call_id));
+      }
+    }
+
+    const meetings: FirefliesListRow[] = transcripts.map((transcript) => mapTranscriptToListRow(transcript, syncedIds));
+
+    return new Response(JSON.stringify({
+      meetings,
+      nextSkip: transcripts.length === limit ? skip + transcripts.length : null,
+      sourceId: source.id,
+      accountEmail: source.account_email,
+    }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Error fetching Fireflies meetings:', error);
+    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});
+
+function mapTranscriptToListRow(transcript: FirefliesTranscript, syncedIds: Set<string>): FirefliesListRow {
+  const start = coerceDate(transcript.dateString ?? transcript.date);
+  const durationSeconds = normalizeDurationSeconds(transcript.duration);
+  const end = durationSeconds != null ? new Date(new Date(start).getTime() + durationSeconds * 1000).toISOString() : null;
+
+  return {
+    recording_id: transcript.id,
+    title: transcript.title?.trim() || 'Untitled Fireflies Call',
+    created_at: start,
+    recording_start_time: start,
+    recording_end_time: end,
+    duration: durationSeconds,
+    synced: syncedIds.has(transcript.id),
+    calendar_invitees: (transcript.meeting_attendees ?? []).map((attendee) => ({
+      name: attendee.displayName ?? attendee.name ?? null,
+      email: attendee.email ?? null,
+    })),
+    source_url: transcript.transcript_url ?? transcript.meeting_link ?? null,
+    share_url: transcript.transcript_url ?? transcript.meeting_link ?? null,
+  };
+}
+
+function normalizeDurationSeconds(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return Math.round(value);
+}
+
+function coerceDate(value: number | string | null | undefined): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const millis = value > 10_000_000_000 ? value : value * 1000;
+    return new Date(millis).toISOString();
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  throw new Error('Fireflies transcript is missing a valid date/dateString');
+}

--- a/supabase/functions/fireflies-save-source/index.ts
+++ b/supabase/functions/fireflies-save-source/index.ts
@@ -1,0 +1,93 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { fetchFirefliesUser } from '../_shared/fireflies-connector.ts';
+
+interface FirefliesSaveSourceRequest {
+  apiKey?: string;
+  webhookSigningSecret?: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const authResult = await authenticateRequest(req, supabase, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json() as FirefliesSaveSourceRequest;
+    const apiKey = body.apiKey?.trim() ?? '';
+    const webhookSigningSecret = body.webhookSigningSecret?.trim() || null;
+
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: 'Fireflies API key is required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const firefliesUser = await fetchFirefliesUser(apiKey);
+    const accountEmail = firefliesUser.email?.trim() || null;
+
+    const { data: existing } = await supabase
+      .from('import_sources')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('source_app', 'fireflies')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const payload = {
+      user_id: userId,
+      source_app: 'fireflies',
+      account_email: accountEmail,
+      is_active: true,
+      error_message: null,
+      api_key: apiKey,
+      webhook_signing_secret: webhookSigningSecret,
+      updated_at: new Date().toISOString(),
+    };
+
+    let sourceRow;
+    if (existing?.id) {
+      const { data, error } = await supabase
+        .from('import_sources')
+        .update(payload)
+        .eq('id', existing.id)
+        .eq('user_id', userId)
+        .select('id, source_app, account_email, is_active, last_sync_at, error_message, created_at, updated_at')
+        .single();
+      if (error) throw error;
+      sourceRow = data;
+    } else {
+      const { data, error } = await supabase
+        .from('import_sources')
+        .insert(payload)
+        .select('id, source_app, account_email, is_active, last_sync_at, error_message, created_at, updated_at')
+        .single();
+      if (error) throw error;
+      sourceRow = data;
+    }
+
+    return new Response(JSON.stringify({ success: true, source: sourceRow }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Error saving Fireflies source:', error);
+    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/fireflies-sync-meetings/index.ts
+++ b/supabase/functions/fireflies-sync-meetings/index.ts
@@ -1,0 +1,174 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { fetchFirefliesTranscript, firefliesTranscriptToCanonical } from '../_shared/fireflies-connector.ts';
+import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+
+interface FirefliesSyncRequest {
+  transcriptIds?: string[];
+  singleCallId?: string;
+  sourceId?: string | null;
+  workspace_id?: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const authResult = await authenticateRequest(req, supabase, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json() as FirefliesSyncRequest;
+    const transcriptIds = body.singleCallId ? [body.singleCallId] : body.transcriptIds ?? [];
+
+    if (!Array.isArray(transcriptIds) || transcriptIds.length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'transcriptIds must be an array or singleCallId must be provided' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const { data: source, error: sourceError } = await supabase
+      .from('import_sources')
+      .select('id, api_key')
+      .eq('user_id', userId)
+      .eq('source_app', 'fireflies')
+      .eq('is_active', true)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (sourceError) throw sourceError;
+    const sourceId = body.sourceId ?? source?.id ?? null;
+    const apiKey = source?.api_key?.trim() ?? '';
+
+    if (!sourceId || !apiKey) {
+      return new Response(
+        JSON.stringify({ error: 'Fireflies is not connected. Save an API key first.' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    let validatedWorkspaceId: string | null = null;
+    if (body.workspace_id) {
+      const { data: membership, error: membershipError } = await supabase
+        .from('workspace_memberships')
+        .select('id')
+        .eq('workspace_id', body.workspace_id)
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (membershipError) {
+        console.error('Error checking workspace membership:', membershipError);
+      } else if (membership) {
+        validatedWorkspaceId = body.workspace_id;
+      }
+    }
+
+    const { data: syncJob, error: jobError } = await supabase
+      .from('sync_jobs')
+      .insert({
+        user_id: userId,
+        recording_ids: transcriptIds,
+        status: 'processing',
+        progress_current: 0,
+        progress_total: transcriptIds.length,
+        type: 'fireflies',
+      })
+      .select()
+      .single();
+
+    if (jobError) throw jobError;
+    const jobId = syncJob.id;
+
+    const processSyncJob = async () => {
+      const synced: string[] = [];
+      const failed: string[] = [];
+      let skippedCount = 0;
+
+      for (const transcriptId of transcriptIds) {
+        try {
+          const transcript = await fetchFirefliesTranscript(apiKey, transcriptId);
+          const canonical = firefliesTranscriptToCanonical(transcript);
+          const result = await runCanonicalConnectorPipeline(supabase, userId, canonical, {
+            importSource: 'fireflies-sync-meetings',
+            workspaceId: validatedWorkspaceId,
+            includeRawPayload: true,
+          });
+
+          if (result.success) {
+            synced.push(transcriptId);
+          } else if (result.skipped) {
+            skippedCount++;
+          } else {
+            failed.push(transcriptId);
+            console.error(`Fireflies sync failed for ${transcriptId}:`, result.error);
+          }
+        } catch (error) {
+          failed.push(transcriptId);
+          console.error(`Fireflies sync failed for ${transcriptId}:`, error);
+        }
+
+        await supabase
+          .from('sync_jobs')
+          .update({
+            progress_current: synced.length + failed.length + skippedCount,
+            synced_ids: synced,
+            failed_ids: failed,
+            skipped_count: skippedCount,
+          })
+          .eq('id', jobId);
+      }
+
+      const finalStatus = failed.length === 0 ? 'completed'
+        : synced.length === 0 ? 'failed'
+        : 'completed_with_errors';
+
+      await supabase
+        .from('sync_jobs')
+        .update({
+          status: finalStatus,
+          completed_at: new Date().toISOString(),
+          skipped_count: skippedCount,
+        })
+        .eq('id', jobId);
+      await supabase
+        .from('import_sources')
+        .update({
+          last_sync_at: new Date().toISOString(),
+          error_message: failed.length > 0 ? `${failed.length} Fireflies recording${failed.length === 1 ? '' : 's'} failed to sync` : null,
+        })
+        .eq('id', sourceId)
+        .eq('user_id', userId);
+    };
+
+    // @ts-expect-error - EdgeRuntime is available in Deno Deploy
+    EdgeRuntime.waitUntil(processSyncJob());
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        jobId,
+        message: `Fireflies sync job started for ${transcriptIds.length} transcripts`,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (error) {
+    console.error('Error syncing Fireflies transcripts:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/functions/fireflies-webhook/index.ts
+++ b/supabase/functions/fireflies-webhook/index.ts
@@ -1,0 +1,116 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { fetchFirefliesTranscript, firefliesTranscriptToCanonical } from '../_shared/fireflies-connector.ts';
+import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+
+interface FirefliesWebhookEvent {
+  event?: string;
+  timestamp?: number;
+  meeting_id?: string;
+  client_reference_id?: string;
+}
+
+interface FirefliesSourceRow {
+  id: string;
+  user_id: string;
+  api_key: string | null;
+  webhook_signing_secret: string | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-hub-signature' } });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const rawBody = await req.text();
+    const signature = req.headers.get('X-Hub-Signature') || req.headers.get('x-hub-signature') || '';
+    if (!signature) {
+      return new Response(JSON.stringify({ error: 'Missing X-Hub-Signature header' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const { data: sources, error: sourceError } = await supabase
+      .from('import_sources')
+      .select('id, user_id, api_key, webhook_signing_secret')
+      .eq('source_app', 'fireflies')
+      .eq('is_active', true)
+      .not('webhook_signing_secret', 'is', null);
+
+    if (sourceError) throw sourceError;
+    const matchedSource = await findMatchingSource(rawBody, signature, (sources ?? []) as FirefliesSourceRow[]);
+    if (!matchedSource || !matchedSource.api_key) {
+      return new Response(JSON.stringify({ error: 'No matching Fireflies webhook secret configured' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const payload = JSON.parse(rawBody) as FirefliesWebhookEvent;
+    if (!payload.meeting_id) {
+      return new Response(JSON.stringify({ error: 'meeting_id is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (payload.event !== 'meeting.transcribed' && payload.event !== 'meeting.summarized') {
+      return new Response(JSON.stringify({ success: true, ignored: true, event: payload.event ?? null }), { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const transcript = await fetchFirefliesTranscript(matchedSource.api_key, payload.meeting_id);
+    const canonical = firefliesTranscriptToCanonical(transcript);
+    const result = await runCanonicalConnectorPipeline(supabase, matchedSource.user_id, canonical, {
+      importSource: 'fireflies-webhook',
+      includeRawPayload: true,
+    });
+
+    await supabase
+      .from('import_sources')
+      .update({
+        last_sync_at: new Date().toISOString(),
+        error_message: result.success || result.skipped ? null : result.error ?? 'Webhook import failed',
+      })
+      .eq('id', matchedSource.id)
+      .eq('user_id', matchedSource.user_id);
+
+    return new Response(JSON.stringify({ success: result.success, skipped: result.skipped ?? false, recordingId: result.recordingId ?? null }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Fireflies webhook error:', error);
+    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});
+
+async function findMatchingSource(rawBody: string, actualSignature: string, sources: FirefliesSourceRow[]): Promise<FirefliesSourceRow | null> {
+  for (const source of sources) {
+    if (!source.webhook_signing_secret) continue;
+    const expected = await computeSignature(rawBody, source.webhook_signing_secret);
+    if (timingSafeEqual(expected, actualSignature)) {
+      return source;
+    }
+  }
+  return null;
+}
+
+async function computeSignature(rawBody: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  const hex = Array.from(new Uint8Array(signature)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/supabase/migrations/20260523130000_add_generic_source_auth_fields.sql
+++ b/supabase/migrations/20260523130000_add_generic_source_auth_fields.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE import_sources
+  ADD COLUMN IF NOT EXISTS api_key TEXT,
+  ADD COLUMN IF NOT EXISTS webhook_signing_secret TEXT;
+
+COMMENT ON COLUMN import_sources.api_key IS 'Generic API key for source connectors that authenticate with a static bearer token instead of OAuth.';
+COMMENT ON COLUMN import_sources.webhook_signing_secret IS 'Generic signing secret used to verify incoming source webhooks for connectors like Fireflies.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- expose Fireflies webhook through the same api.callvaultai.com Cloudflare API proxy pattern used by MCP
- show the friendly webhook URL in the Fireflies import UI instead of the raw Supabase functions URL

## Verification
- npm run type-check
- deployed Cloudflare worker route for /fireflies-webhook
- curl POST to https://api.callvaultai.com/fireflies-webhook returns JSON from the Fireflies webhook function
- https://api.callvaultai.com/logo.png and /mcp still route correctly
