### PR TITLE
fix(fireflies): cleanup PR — encryption, hardening, tests, env-derived URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ APP_URL=https://app.callvaultai.com
 SITE_URL=https://app.callvaultai.com
 PUBLIC_SITE_URL=https://app.callvaultai.com
 
+# [optional] Public base URL for the edge-function API. Used by the frontend
+# to render the Fireflies webhook URL the user pastes into Fireflies. Defaults
+# to https://api.callvaultai.com when unset (production). Override in staging
+# or local dev (e.g., https://staging-api.callvaultai.com or
+# http://localhost:54321/functions/v1).
+VITE_API_BASE_URL=https://api.callvaultai.com
+
 
 # ============================================
 # FATHOM — Meeting Sync (OAuth)

--- a/src/components/import/FirefliesImportDetail.tsx
+++ b/src/components/import/FirefliesImportDetail.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
 import {
   RiCheckLine,
   RiDownloadCloud2Line,
@@ -11,19 +11,19 @@ import {
   RiRefreshLine,
   RiSearchLine,
   RiShieldKeyholeLine,
-} from '@remixicon/react';
-import { toast } from 'sonner';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import { DateRangePicker } from '@/components/ui/date-range-picker';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { PageHeader } from '@/components/ui/page-header';
-import { WorkspaceSelector } from '@/components/workspace/WorkspaceSelector';
-import { supabase } from '@/integrations/supabase/client';
-import { queryKeys } from '@/lib/query-config';
-import { cn } from '@/lib/utils';
-import type { ImportSource } from '@/services/import-sources.service';
+} from "@remixicon/react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DateRangePicker } from "@/components/ui/date-range-picker";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PageHeader } from "@/components/ui/page-header";
+import { WorkspaceSelector } from "@/components/workspace/WorkspaceSelector";
+import { supabase } from "@/integrations/supabase/client";
+import { queryKeys } from "@/lib/query-config";
+import { cn } from "@/lib/utils";
+import type { ImportSource } from "@/services/import-sources.service";
 
 interface FirefliesMeeting {
   recording_id: string;
@@ -40,7 +40,7 @@ interface FirefliesMeeting {
 
 interface SyncJobPoll {
   id: string;
-  status: 'processing' | 'completed' | 'completed_with_errors' | 'failed';
+  status: "processing" | "completed" | "completed_with_errors" | "failed";
   progress_current: number;
   progress_total: number;
   synced_ids: string[] | null;
@@ -54,11 +54,14 @@ export interface FirefliesImportDetailProps {
   onDisconnect?: () => void;
 }
 
-export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportDetailProps) {
+export function FirefliesImportDetail({
+  source,
+  onDisconnect,
+}: FirefliesImportDetailProps) {
   const queryClient = useQueryClient();
-  const [apiKey, setApiKey] = useState('');
-  const [webhookSigningSecret, setWebhookSigningSecret] = useState('');
-  const [webhookPathToken, setWebhookPathToken] = useState('');
+  const [apiKey, setApiKey] = useState("");
+  const [webhookSigningSecret, setWebhookSigningSecret] = useState("");
+  const [webhookPathToken, setWebhookPathToken] = useState("");
   const [savingConnection, setSavingConnection] = useState(false);
   const [copiedWebhookUrl, setCopiedWebhookUrl] = useState(false);
   const [dateRange, setDateRange] = useState<{ from?: Date; to?: Date }>({});
@@ -74,13 +77,17 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
   const generateWebhookSigningSecret = useCallback(() => {
     const bytes = new Uint8Array(16);
     crypto.getRandomValues(bytes);
-    return Array.from(bytes).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+    return Array.from(bytes)
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
   }, []);
 
   const generateWebhookPathToken = useCallback(() => {
     const bytes = new Uint8Array(16);
     crypto.getRandomValues(bytes);
-    return `ffwh_${Array.from(bytes).map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+    return `ffwh_${Array.from(bytes)
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")}`;
   }, []);
 
   useEffect(() => {
@@ -100,15 +107,31 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
     } else if (!source && !webhookPathToken) {
       setWebhookPathToken(generateWebhookPathToken());
     }
-  }, [generateWebhookPathToken, generateWebhookSigningSecret, source, webhookPathToken, webhookSigningSecret]);
+  }, [
+    generateWebhookPathToken,
+    generateWebhookSigningSecret,
+    source,
+    webhookPathToken,
+    webhookSigningSecret,
+  ]);
 
   const toUTCStart = (d: Date) =>
-    new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)).toISOString();
+    new Date(
+      Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0),
+    ).toISOString();
   const toUTCEnd = (d: Date) =>
-    new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)).toISOString();
+    new Date(
+      Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999),
+    ).toISOString();
+
+  const apiBaseUrl =
+    (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(
+      /\/+$/,
+      "",
+    ) || "https://api.callvaultai.com";
   const webhookUrl = webhookPathToken
-    ? `https://api.callvaultai.com/fireflies-webhook/${webhookPathToken}`
-    : `https://api.callvaultai.com/fireflies-webhook`;
+    ? `${apiBaseUrl}/fireflies-webhook/${webhookPathToken}`
+    : `${apiBaseUrl}/fireflies-webhook`;
 
   const stopPolling = () => {
     if (pollRef.current) {
@@ -120,37 +143,44 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
 
   const handleSaveConnection = useCallback(async () => {
     if (!apiKey.trim()) {
-      toast.error('Fireflies API key is required');
+      toast.error("Fireflies API key is required");
       return;
     }
     if (!source && !webhookSigningSecret.trim()) {
-      toast.error('Fireflies webhook signing secret is required');
+      toast.error("Fireflies webhook signing secret is required");
       return;
     }
 
     setSavingConnection(true);
     try {
-      const { data, error } = await supabase.functions.invoke('fireflies-save-source', {
-        body: {
-          apiKey: apiKey.trim(),
-          webhookSigningSecret: webhookSigningSecret.trim() || null,
-          webhookPathToken: webhookPathToken.trim() || null,
+      const { data, error } = await supabase.functions.invoke(
+        "fireflies-save-source",
+        {
+          body: {
+            apiKey: apiKey.trim(),
+            webhookSigningSecret: webhookSigningSecret.trim() || null,
+            webhookPathToken: webhookPathToken.trim() || null,
+          },
         },
-      });
+      );
       if (error) throw error;
       if ((data as { error?: string } | null)?.error) {
         throw new Error((data as { error: string }).error);
       }
-      const returnedSecret = (data as { webhookSigningSecret?: string } | null)?.webhookSigningSecret;
+      const returnedSecret = (data as { webhookSigningSecret?: string } | null)
+        ?.webhookSigningSecret;
       if (returnedSecret) setWebhookSigningSecret(returnedSecret);
-      const returnedToken = (data as { webhookPathToken?: string } | null)?.webhookPathToken;
+      const returnedToken = (data as { webhookPathToken?: string } | null)
+        ?.webhookPathToken;
       if (returnedToken) setWebhookPathToken(returnedToken);
 
-      toast.success('Fireflies connected');
+      toast.success("Fireflies connected");
       queryClient.invalidateQueries({ queryKey: queryKeys.imports.sources() });
-      setApiKey('');
+      setApiKey("");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to connect Fireflies');
+      toast.error(
+        error instanceof Error ? error.message : "Failed to connect Fireflies",
+      );
     } finally {
       setSavingConnection(false);
     }
@@ -161,19 +191,19 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
       await navigator.clipboard.writeText(webhookUrl);
       setCopiedWebhookUrl(true);
       setTimeout(() => setCopiedWebhookUrl(false), 2000);
-      toast.success('Webhook URL copied to clipboard');
+      toast.success("Webhook URL copied to clipboard");
     } catch {
-      toast.error('Failed to copy webhook URL');
+      toast.error("Failed to copy webhook URL");
     }
   }, [webhookUrl]);
 
   const handleSearch = useCallback(async () => {
     if (!source?.id) {
-      toast.error('Connect Fireflies first');
+      toast.error("Connect Fireflies first");
       return;
     }
     if (!dateRange.from) {
-      toast.error('Choose a date range');
+      toast.error("Choose a date range");
       return;
     }
 
@@ -184,40 +214,56 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
 
     try {
       const createdAfter = toUTCStart(dateRange.from);
-      const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
-      const { data, error } = await supabase.functions.invoke('fireflies-fetch-meetings', {
-        body: {
-          sourceId: source.id,
-          createdAfter,
-          createdBefore,
-          limit: 50,
-          skip: 0,
+      const createdBefore = dateRange.to
+        ? toUTCEnd(dateRange.to)
+        : toUTCEnd(dateRange.from);
+      const { data, error } = await supabase.functions.invoke(
+        "fireflies-fetch-meetings",
+        {
+          body: {
+            sourceId: source.id,
+            createdAfter,
+            createdBefore,
+            limit: 50,
+            skip: 0,
+          },
         },
-      });
+      );
       if (error) throw error;
       if ((data as { error?: string } | null)?.error) {
         throw new Error((data as { error: string }).error);
       }
 
-      const fetched = ((data as { meetings?: FirefliesMeeting[] } | null)?.meetings ?? []);
+      const fetched =
+        (data as { meetings?: FirefliesMeeting[] } | null)?.meetings ?? [];
       setMeetings(fetched);
       setHasFetched(true);
-      toast.success(`Found ${fetched.length} Fireflies recording${fetched.length === 1 ? '' : 's'}`);
+      toast.success(
+        `Found ${fetched.length} Fireflies recording${fetched.length === 1 ? "" : "s"}`,
+      );
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to fetch Fireflies recordings');
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to fetch Fireflies recordings",
+      );
     } finally {
       setLoading(false);
     }
   }, [dateRange, source?.id]);
 
   const unsyncedMeetings = meetings.filter((meeting) => !meeting.synced);
-  const allUnsyncedSelected = unsyncedMeetings.length > 0 && unsyncedMeetings.every((meeting) => selected.has(meeting.recording_id));
+  const allUnsyncedSelected =
+    unsyncedMeetings.length > 0 &&
+    unsyncedMeetings.every((meeting) => selected.has(meeting.recording_id));
 
   const toggleSelectAll = () => {
     if (allUnsyncedSelected) {
       setSelected(new Set());
     } else {
-      setSelected(new Set(unsyncedMeetings.map((meeting) => meeting.recording_id)));
+      setSelected(
+        new Set(unsyncedMeetings.map((meeting) => meeting.recording_id)),
+      );
     }
   };
 
@@ -232,15 +278,15 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
 
   const handleImport = useCallback(async () => {
     if (!source?.id) {
-      toast.error('Connect Fireflies first');
+      toast.error("Connect Fireflies first");
       return;
     }
     if (!workspaceId) {
-      toast.error('Choose a workspace before importing');
+      toast.error("Choose a workspace before importing");
       return;
     }
     if (selected.size === 0) {
-      toast.error('Choose at least one Fireflies recording');
+      toast.error("Choose at least one Fireflies recording");
       return;
     }
 
@@ -249,23 +295,43 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
 
     try {
       const transcriptIds = Array.from(selected);
-      const { data, error } = await supabase.functions.invoke('fireflies-sync-meetings', {
-        body: {
-          sourceId: source.id,
-          transcriptIds,
-          workspace_id: workspaceId,
+      const { data, error } = await supabase.functions.invoke(
+        "fireflies-sync-meetings",
+        {
+          body: {
+            sourceId: source.id,
+            transcriptIds,
+            workspace_id: workspaceId,
+          },
         },
-      });
+      );
       if (error) throw error;
       const jobId = (data as { jobId?: string } | null)?.jobId;
-      if (!jobId) throw new Error('Fireflies sync started without a job ID');
+      if (!jobId) throw new Error("Fireflies sync started without a job ID");
+
+      // 5-minute hard cap. If the edge function crashes after writing
+      // `status: processing` but before any later update, the row sits in
+      // 'processing' forever; without a cap the tab polls until close.
+      const POLL_INTERVAL_MS = 1000;
+      const MAX_POLL_MS = 5 * 60 * 1000;
+      const pollStartedAt = Date.now();
 
       pollRef.current = setInterval(async () => {
         try {
+          if (Date.now() - pollStartedAt > MAX_POLL_MS) {
+            stopPolling();
+            toast.error(
+              "Fireflies import timed out after 5 minutes. Check the import history for the final state.",
+            );
+            queryClient.invalidateQueries({ queryKey: queryKeys.calls.all });
+            queryClient.invalidateQueries({ queryKey: ["workspace-entries"] });
+            return;
+          }
+
           const { data: jobData, error: jobError } = await supabase
-            .from('sync_jobs')
-            .select('*')
-            .eq('id', jobId)
+            .from("sync_jobs")
+            .select("*")
+            .eq("id", jobId)
             .single();
           if (jobError || !jobData) return;
           const job = jobData as SyncJobPoll;
@@ -273,36 +339,47 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
             current: job.progress_current ?? 0,
             total: job.progress_total ?? transcriptIds.length,
           });
-          if (job.status === 'processing') return;
+          if (job.status === "processing") return;
 
           stopPolling();
           const syncedCount = job.synced_ids?.length ?? 0;
           const failedCount = job.failed_ids?.length ?? 0;
           const skippedCount = job.skipped_count ?? 0;
 
-          if (job.status === 'completed') {
-            toast.success(`Imported ${syncedCount} Fireflies recording${syncedCount === 1 ? '' : 's'}`);
-          } else if (job.status === 'completed_with_errors') {
-            toast.warning(`Fireflies import finished with ${syncedCount} imported, ${failedCount} failed, ${skippedCount} skipped`);
+          if (job.status === "completed") {
+            toast.success(
+              `Imported ${syncedCount} Fireflies recording${syncedCount === 1 ? "" : "s"}`,
+            );
+          } else if (job.status === "completed_with_errors") {
+            toast.warning(
+              `Fireflies import finished with ${syncedCount} imported, ${failedCount} failed, ${skippedCount} skipped`,
+            );
           } else {
-            toast.error(job.error_message || 'Fireflies import failed');
+            toast.error(job.error_message || "Fireflies import failed");
           }
 
           queryClient.invalidateQueries({ queryKey: queryKeys.calls.all });
-          queryClient.invalidateQueries({ queryKey: ['workspace-entries'] });
+          queryClient.invalidateQueries({ queryKey: ["workspace-entries"] });
           await handleSearch();
           setSelected(new Set());
         } catch {
           // Ignore transient poll failures.
         }
-      }, 1000);
+      }, POLL_INTERVAL_MS);
     } catch (error) {
       stopPolling();
-      toast.error(error instanceof Error ? error.message : 'Failed to start Fireflies import');
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to start Fireflies import",
+      );
     }
   }, [handleSearch, queryClient, selected, source?.id, workspaceId]);
 
-  const progressPct = syncProgress.total > 0 ? Math.round((syncProgress.current / syncProgress.total) * 100) : 0;
+  const progressPct =
+    syncProgress.total > 0
+      ? Math.round((syncProgress.current / syncProgress.total) * 100)
+      : 0;
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
@@ -315,23 +392,33 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
         <div className="rounded-xl border border-border bg-card p-4 space-y-4">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <h3 className="text-sm font-semibold text-foreground">Fireflies account connection</h3>
+              <h3 className="text-sm font-semibold text-foreground">
+                Fireflies account connection
+              </h3>
               <p className="text-sm text-muted-foreground mt-1">
-                Fireflies uses an account-level API key instead of OAuth. Connect the account once,
-                then bulk backfill and continue ingesting future calls from the same source.
+                Fireflies uses an account-level API key instead of OAuth.
+                Connect the account once, then bulk backfill and continue
+                ingesting future calls from the same source.
               </p>
               {source?.account_email && (
-                <p className="text-xs text-muted-foreground mt-2">Connected as {source.account_email}</p>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Connected as {source.account_email}
+                </p>
               )}
             </div>
             {source && onDisconnect && (
-              <Button variant="hollow" onClick={onDisconnect}>Disconnect</Button>
+              <Button variant="hollow" onClick={onDisconnect}>
+                Disconnect
+              </Button>
             )}
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="fireflies-api-key" className="text-xs flex items-center gap-2">
+              <Label
+                htmlFor="fireflies-api-key"
+                className="text-xs flex items-center gap-2"
+              >
                 <RiKey2Line className="h-3.5 w-3.5 text-muted-foreground" />
                 API Key
               </Label>
@@ -340,12 +427,19 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
                 type="password"
                 value={apiKey}
                 onChange={(event) => setApiKey(event.target.value)}
-                placeholder={source ? 'Enter a replacement API key to reconnect' : 'Your Fireflies API key'}
+                placeholder={
+                  source
+                    ? "Enter a replacement API key to reconnect"
+                    : "Your Fireflies API key"
+                }
                 autoComplete="off"
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="fireflies-webhook-secret" className="text-xs flex items-center gap-2">
+              <Label
+                htmlFor="fireflies-webhook-secret"
+                className="text-xs flex items-center gap-2"
+              >
                 <RiShieldKeyholeLine className="h-3.5 w-3.5 text-muted-foreground" />
                 Webhook signing secret
               </Label>
@@ -354,14 +448,22 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
                   id="fireflies-webhook-secret"
                   type="password"
                   value={webhookSigningSecret}
-                  onChange={(event) => setWebhookSigningSecret(event.target.value)}
-                  placeholder={source ? 'Leave blank to keep the existing secret' : 'Generated webhook secret'}
+                  onChange={(event) =>
+                    setWebhookSigningSecret(event.target.value)
+                  }
+                  placeholder={
+                    source
+                      ? "Leave blank to keep the existing secret"
+                      : "Generated webhook secret"
+                  }
                   autoComplete="off"
                 />
                 <Button
                   type="button"
                   variant="hollow"
-                  onClick={() => setWebhookSigningSecret(generateWebhookSigningSecret())}
+                  onClick={() =>
+                    setWebhookSigningSecret(generateWebhookSigningSecret())
+                  }
                 >
                   Generate
                 </Button>
@@ -370,8 +472,15 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
           </div>
 
           <div className="flex items-center gap-3">
-            <Button onClick={() => void handleSaveConnection()} disabled={savingConnection || !apiKey.trim()}>
-              {savingConnection ? 'Saving…' : source ? 'Reconnect Fireflies' : 'Connect Fireflies'}
+            <Button
+              onClick={() => void handleSaveConnection()}
+              disabled={savingConnection || !apiKey.trim()}
+            >
+              {savingConnection
+                ? "Saving…"
+                : source
+                  ? "Reconnect Fireflies"
+                  : "Connect Fireflies"}
             </Button>
             <p className="text-xs text-muted-foreground">
               One Fireflies account only for now.
@@ -381,13 +490,22 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
           <div className="rounded-lg border border-dashed border-border p-3 space-y-2">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-xs font-medium text-foreground">Webhook URL for Fireflies</p>
+                <p className="text-xs font-medium text-foreground">
+                  Webhook URL for Fireflies
+                </p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Use this friendly webhook URL in Fireflies. A single shared URL is enough for every CallVault user;
-                  the source token routes the delivery and the signing secret verifies it came from Fireflies.
+                  Use this friendly webhook URL in Fireflies. A single shared
+                  URL is enough for every CallVault user; the source token
+                  routes the delivery and the signing secret verifies it came
+                  from Fireflies.
                 </p>
               </div>
-              <Button variant="hollow" size="sm" onClick={() => void handleCopyWebhookUrl()} className="shrink-0">
+              <Button
+                variant="hollow"
+                size="sm"
+                onClick={() => void handleCopyWebhookUrl()}
+                className="shrink-0"
+              >
                 {copiedWebhookUrl ? (
                   <>
                     <RiCheckLine className="h-4 w-4 mr-2 text-emerald-500" />
@@ -403,26 +521,39 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
             </div>
             <Input value={webhookUrl} readOnly className="font-mono text-xs" />
             <p className="text-[11px] text-muted-foreground">
-              In Fireflies, set this URL as the webhook destination, paste the same signing secret, and subscribe to
-              meeting.transcribed and meeting.summarized. The signing secret is required so CallVault can verify and
-              route future calls to the correct connected account.
+              In Fireflies, set this URL as the webhook destination, paste the
+              same signing secret, and subscribe to meeting.transcribed and
+              meeting.summarized. The signing secret is required so CallVault
+              can verify and route future calls to the correct connected
+              account.
             </p>
           </div>
         </div>
 
         <div className="rounded-xl border border-border bg-card p-4 space-y-4">
           <div>
-            <h3 className="text-sm font-semibold text-foreground">Search and import recordings</h3>
+            <h3 className="text-sm font-semibold text-foreground">
+              Search and import recordings
+            </h3>
             <p className="text-sm text-muted-foreground mt-1">
-              This follows the Fathom/Zoom model: fetch provider-native recordings for a time window,
-              select many, then import them into a workspace.
+              This follows the Fathom/Zoom model: fetch provider-native
+              recordings for a time window, select many, then import them into a
+              workspace.
             </p>
           </div>
 
           <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
             <DateRangePicker value={dateRange} onChange={setDateRange} />
-            <Button onClick={() => void handleSearch()} disabled={!source || loading || syncing || !dateRange.from} className="gap-2">
-              {loading ? <RiLoader4Line className="h-4 w-4 animate-spin" /> : <RiSearchLine className="h-4 w-4" />}
+            <Button
+              onClick={() => void handleSearch()}
+              disabled={!source || loading || syncing || !dateRange.from}
+              className="gap-2"
+            >
+              {loading ? (
+                <RiLoader4Line className="h-4 w-4 animate-spin" />
+              ) : (
+                <RiSearchLine className="h-4 w-4" />
+              )}
               Search Fireflies
             </Button>
           </div>
@@ -437,7 +568,10 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
             <>
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2 text-sm text-foreground">
-                  <Checkbox checked={allUnsyncedSelected} onCheckedChange={toggleSelectAll} />
+                  <Checkbox
+                    checked={allUnsyncedSelected}
+                    onCheckedChange={toggleSelectAll}
+                  />
                   <span>Select all unsynced ({unsyncedMeetings.length})</span>
                 </div>
                 <WorkspaceSelector
@@ -451,15 +585,22 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
 
               <div className="rounded-xl border border-border divide-y divide-border overflow-hidden">
                 {meetings.map((meeting) => (
-                  <div key={meeting.recording_id} className="flex items-start gap-3 p-4 bg-card">
+                  <div
+                    key={meeting.recording_id}
+                    className="flex items-start gap-3 p-4 bg-card"
+                  >
                     <Checkbox
                       checked={selected.has(meeting.recording_id)}
                       disabled={meeting.synced || syncing}
-                      onCheckedChange={() => toggleMeeting(meeting.recording_id)}
+                      onCheckedChange={() =>
+                        toggleMeeting(meeting.recording_id)
+                      }
                     />
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-sm font-medium text-foreground truncate">{meeting.title}</span>
+                        <span className="text-sm font-medium text-foreground truncate">
+                          {meeting.title}
+                        </span>
                         {meeting.synced && (
                           <span className="text-[10px] uppercase tracking-wide rounded-full bg-emerald-500/10 text-emerald-600 px-2 py-0.5">
                             Imported
@@ -467,15 +608,32 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
                         )}
                       </div>
                       <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-x-3 gap-y-1">
-                        <span>{format(new Date(meeting.created_at), 'MMM d, yyyy')}</span>
-                        {meeting.duration != null && <span>{Math.max(1, Math.round(meeting.duration / 60))}m</span>}
-                        <span>{meeting.calendar_invitees.length} attendee{meeting.calendar_invitees.length === 1 ? '' : 's'}</span>
+                        <span>
+                          {format(new Date(meeting.created_at), "MMM d, yyyy")}
+                        </span>
+                        {meeting.duration != null && (
+                          <span>
+                            {Math.max(1, Math.round(meeting.duration / 60))}m
+                          </span>
+                        )}
+                        <span>
+                          {meeting.calendar_invitees.length} attendee
+                          {meeting.calendar_invitees.length === 1 ? "" : "s"}
+                        </span>
                       </div>
                       {meeting.share_url && (
                         <button
                           type="button"
-                          className={cn('mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground')}
-                          onClick={() => window.open(meeting.share_url || meeting.source_url || '', '_blank', 'noopener,noreferrer')}
+                          className={cn(
+                            "mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground",
+                          )}
+                          onClick={() =>
+                            window.open(
+                              meeting.share_url || meeting.source_url || "",
+                              "_blank",
+                              "noopener,noreferrer",
+                            )
+                          }
                         >
                           <RiLinkM className="h-3.5 w-3.5" />
                           View in Fireflies
@@ -487,9 +645,19 @@ export function FirefliesImportDetail({ source, onDisconnect }: FirefliesImportD
               </div>
 
               <div className="flex items-center gap-3">
-                <Button onClick={() => void handleImport()} disabled={syncing || selected.size === 0 || !workspaceId} className="gap-2">
-                  {syncing ? <RiLoader4Line className="h-4 w-4 animate-spin" /> : <RiRefreshLine className="h-4 w-4" />}
-                  {syncing ? 'Importing…' : `Import ${selected.size || ''} Fireflies recording${selected.size === 1 ? '' : 's'}`.trim()}
+                <Button
+                  onClick={() => void handleImport()}
+                  disabled={syncing || selected.size === 0 || !workspaceId}
+                  className="gap-2"
+                >
+                  {syncing ? (
+                    <RiLoader4Line className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RiRefreshLine className="h-4 w-4" />
+                  )}
+                  {syncing
+                    ? "Importing…"
+                    : `Import ${selected.size || ""} Fireflies recording${selected.size === 1 ? "" : "s"}`.trim()}
                 </Button>
                 {syncing && (
                   <span className="text-xs text-muted-foreground">

--- a/supabase/functions/_shared/__tests__/fireflies-connector.test.ts
+++ b/supabase/functions/_shared/__tests__/fireflies-connector.test.ts
@@ -1,77 +1,217 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from "vitest";
 import {
+  coerceFirefliesDate,
   fetchFirefliesTranscript,
+  fetchFirefliesUser,
   firefliesTranscriptToCanonical,
+  normalizeDurationSeconds,
   type FirefliesTranscript,
-} from '../fireflies-connector';
+} from "../fireflies-connector";
 
-describe('fireflies connector', () => {
+describe("fireflies connector", () => {
   const transcript: FirefliesTranscript = {
-    id: '01HXFIREFLIES',
-    title: 'CallVault Connector Design',
-    dateString: '2026-05-23T15:00:00Z',
+    id: "01HXFIREFLIES",
+    title: "CallVault Connector Design",
+    dateString: "2026-05-23T15:00:00Z",
     duration: 95,
-    host_email: 'host@example.com',
-    organizer_email: 'organizer@example.com',
-    transcript_url: 'https://app.fireflies.ai/view/01HXFIREFLIES',
-    meeting_link: 'https://meet.example.com/abc',
-    participants: ['guest@example.com'],
+    host_email: "host@example.com",
+    organizer_email: "organizer@example.com",
+    transcript_url: "https://app.fireflies.ai/view/01HXFIREFLIES",
+    meeting_link: "https://meet.example.com/abc",
+    participants: ["guest@example.com"],
     meeting_attendees: [
-      { displayName: 'Host User', email: 'host@example.com' },
-      { displayName: 'Guest User', email: 'guest@example.com' },
+      { displayName: "Host User", email: "host@example.com" },
+      { displayName: "Guest User", email: "guest@example.com" },
     ],
     sentences: [
-      { index: 2, speaker_name: 'Guest User', text: 'Second turn.', start_time: 12.2, end_time: 18 },
-      { index: 1, speaker_name: 'Host User', text: 'First turn.', start_time: 0, end_time: 5 },
+      {
+        index: 2,
+        speaker_name: "Guest User",
+        text: "Second turn.",
+        start_time: 12.2,
+        end_time: 18,
+      },
+      {
+        index: 1,
+        speaker_name: "Host User",
+        text: "First turn.",
+        start_time: 0,
+        end_time: 5,
+      },
     ],
     summary: {
-      short_summary: 'Connector design review.',
-      action_items: ['Build conformance tests'],
-      topics_discussed: ['Canonical recordings'],
+      short_summary: "Connector design review.",
+      action_items: ["Build conformance tests"],
+      topics_discussed: ["Canonical recordings"],
     },
   };
 
-  it('normalizes Fireflies transcript payloads into canonical recordings', () => {
+  it("normalizes Fireflies transcript payloads into canonical recordings", () => {
     const canonical = firefliesTranscriptToCanonical(transcript);
 
     expect(canonical).toMatchObject({
-      externalId: '01HXFIREFLIES',
-      sourceApp: 'fireflies',
-      title: 'CallVault Connector Design',
-      recordingStartTime: '2026-05-23T15:00:00.000Z',
-      recordingEndTime: '2026-05-23T15:01:35.000Z',
+      externalId: "01HXFIREFLIES",
+      sourceApp: "fireflies",
+      title: "CallVault Connector Design",
+      recordingStartTime: "2026-05-23T15:00:00.000Z",
+      recordingEndTime: "2026-05-23T15:01:35.000Z",
       durationSeconds: 95,
-      sourceUrl: 'https://app.fireflies.ai/view/01HXFIREFLIES',
-      recordedByEmail: 'host@example.com',
-      participantEmails: ['host@example.com', 'organizer@example.com', 'guest@example.com'],
+      sourceUrl: "https://app.fireflies.ai/view/01HXFIREFLIES",
+      recordedByEmail: "host@example.com",
+      participantEmails: [
+        "host@example.com",
+        "organizer@example.com",
+        "guest@example.com",
+      ],
     });
-    expect(canonical.fullTranscript).toBe('[0:00] Host User: First turn.\n\n[0:12] Guest User: Second turn.');
-    expect(canonical.summary).toContain('Connector design review.');
-    expect(canonical.summary).toContain('- Build conformance tests');
+    expect(canonical.fullTranscript).toBe(
+      "[0:00] Host User: First turn.\n\n[0:12] Guest User: Second turn.",
+    );
+    expect(canonical.summary).toContain("Connector design review.");
+    expect(canonical.summary).toContain("- Build conformance tests");
     expect(canonical.sourceMetadata).toMatchObject({
-      fireflies_transcript_id: '01HXFIREFLIES',
-      recorded_by_name: 'Host User',
-      recorded_by_email: 'host@example.com',
-      action_items: ['Build conformance tests'],
-      topics_discussed: ['Canonical recordings'],
+      fireflies_transcript_id: "01HXFIREFLIES",
+      recorded_by_name: "Host User",
+      recorded_by_email: "host@example.com",
+      action_items: ["Build conformance tests"],
+      topics_discussed: ["Canonical recordings"],
     });
   });
 
-  it('uses the documented GraphQL endpoint and bearer auth', async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ data: { transcript } }), { status: 200 })) as unknown as typeof fetch;
+  it("uses the documented GraphQL endpoint and bearer auth", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { transcript } }), { status: 200 }),
+    ) as unknown as typeof fetch;
 
-    const result = await fetchFirefliesTranscript('secret-key', '01HXFIREFLIES', fetchImpl);
+    const result = await fetchFirefliesTranscript(
+      "secret-key",
+      "01HXFIREFLIES",
+      fetchImpl,
+    );
 
-    expect(result.id).toBe('01HXFIREFLIES');
+    expect(result.id).toBe("01HXFIREFLIES");
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://api.fireflies.ai/graphql',
+      "https://api.fireflies.ai/graphql",
       expect.objectContaining({
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer secret-key',
+          "Content-Type": "application/json",
+          Authorization: "Bearer secret-key",
         },
       }),
     );
+  });
+});
+
+describe("fireflies connector — fetchFirefliesUser", () => {
+  it("returns the user payload on a successful GraphQL response", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              user: {
+                user_id: "user_123",
+                email: "andrew@example.com",
+                name: "Andrew Naegele",
+                integrations: ["google_calendar"],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const user = await fetchFirefliesUser("secret-key", fetchImpl);
+
+    expect(user).toMatchObject({
+      user_id: "user_123",
+      email: "andrew@example.com",
+      name: "Andrew Naegele",
+    });
+  });
+
+  it("throws a descriptive error when GraphQL returns an errors array", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ errors: [{ message: "Invalid API key" }] }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    await expect(fetchFirefliesUser("bad-key", fetchImpl)).rejects.toThrow(
+      /Invalid API key/,
+    );
+  });
+
+  it("throws with the HTTP status when a non-2xx response carries no errors array", async () => {
+    // Fireflies returns a JSON envelope even on 5xx. The connector calls
+    // response.json() before checking response.ok, so a non-JSON body would
+    // surface a parse error rather than the status — document the
+    // JSON-shaped-error contract by matching it here.
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ data: null }), { status: 500 }),
+    ) as unknown as typeof fetch;
+
+    await expect(fetchFirefliesUser("any-key", fetchImpl)).rejects.toThrow(
+      /HTTP 500/,
+    );
+  });
+
+  it("throws when the GraphQL response has no user object", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { user: null } }), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    await expect(fetchFirefliesUser("any-key", fetchImpl)).rejects.toThrow(
+      /Fireflies user lookup failed/,
+    );
+  });
+});
+
+describe("fireflies connector — coerceFirefliesDate epoch branch", () => {
+  // Reference: 2024-05-23T14:00:00.000Z
+  // seconds:      1_716_472_800
+  // milliseconds: 1_716_472_800_000
+  const EXPECTED_ISO = "2024-05-23T14:00:00.000Z";
+
+  it("treats values <= 10_000_000_000 as epoch seconds", () => {
+    expect(coerceFirefliesDate(1_716_472_800)).toBe(EXPECTED_ISO);
+  });
+
+  it("treats values > 10_000_000_000 as epoch milliseconds", () => {
+    expect(coerceFirefliesDate(1_716_472_800_000)).toBe(EXPECTED_ISO);
+  });
+
+  it("prefers an ISO-8601 string when one is provided", () => {
+    expect(coerceFirefliesDate("2024-05-23T14:00:00Z")).toBe(EXPECTED_ISO);
+  });
+
+  it("throws when no valid date is available", () => {
+    expect(() => coerceFirefliesDate(null)).toThrow(/missing a valid date/);
+    expect(() => coerceFirefliesDate(undefined)).toThrow(
+      /missing a valid date/,
+    );
+    expect(() => coerceFirefliesDate("")).toThrow(/missing a valid date/);
+    expect(() => coerceFirefliesDate("not-a-date")).toThrow(
+      /missing a valid date/,
+    );
+  });
+});
+
+describe("fireflies connector — normalizeDurationSeconds", () => {
+  it("rounds positive numeric durations", () => {
+    expect(normalizeDurationSeconds(95.4)).toBe(95);
+    expect(normalizeDurationSeconds(95.6)).toBe(96);
+  });
+
+  it("returns null for nullish, NaN, or negative values", () => {
+    expect(normalizeDurationSeconds(null)).toBeNull();
+    expect(normalizeDurationSeconds(undefined)).toBeNull();
+    expect(normalizeDurationSeconds(Number.NaN)).toBeNull();
+    expect(normalizeDurationSeconds(-1)).toBeNull();
   });
 });

--- a/supabase/functions/_shared/fireflies-connector.ts
+++ b/supabase/functions/_shared/fireflies-connector.ts
@@ -3,9 +3,9 @@ import {
   normalizeEmailList,
   type CanonicalRecording,
   type CanonicalTranscriptTurn,
-} from './canonical-recording.ts';
+} from "./canonical-recording.ts";
 
-const FIREFLIES_GRAPHQL_URL = 'https://api.fireflies.ai/graphql';
+const FIREFLIES_GRAPHQL_URL = "https://api.fireflies.ai/graphql";
 
 export const FIREFLIES_USER_QUERY = `
   query CallVaultFirefliesUser {
@@ -129,7 +129,11 @@ export interface FirefliesSummary {
 }
 
 export interface FirefliesGraphQLResponse {
-  data?: { transcript?: FirefliesTranscript | null; transcripts?: FirefliesTranscript[] | null; user?: FirefliesUser | null };
+  data?: {
+    transcript?: FirefliesTranscript | null;
+    transcripts?: FirefliesTranscript[] | null;
+    user?: FirefliesUser | null;
+  };
   errors?: Array<{ message?: string }>;
 }
 
@@ -145,13 +149,14 @@ export async function fetchFirefliesTranscript(
   transcriptId: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<FirefliesTranscript> {
-  if (!apiKey.trim()) throw new Error('Fireflies API key is required');
-  if (!transcriptId.trim()) throw new Error('Fireflies transcript ID is required');
+  if (!apiKey.trim()) throw new Error("Fireflies API key is required");
+  if (!transcriptId.trim())
+    throw new Error("Fireflies transcript ID is required");
 
   const response = await fetchImpl(FIREFLIES_GRAPHQL_URL, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
@@ -160,10 +165,14 @@ export async function fetchFirefliesTranscript(
     }),
   });
 
-  const payload = await response.json() as FirefliesGraphQLResponse;
+  const payload = (await response.json()) as FirefliesGraphQLResponse;
   if (!response.ok || payload.errors?.length) {
-    const message = payload.errors?.map((error) => error.message).filter(Boolean).join('; ')
-      || `Fireflies API request failed with HTTP ${response.status}`;
+    const message =
+      payload.errors
+        ?.map((error) => error.message)
+        .filter(Boolean)
+        .join("; ") ||
+      `Fireflies API request failed with HTTP ${response.status}`;
     throw new Error(message);
   }
 
@@ -178,14 +187,11 @@ export async function fetchFirefliesUser(
   apiKey: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<FirefliesUser> {
-  const payload = await firefliesGraphqlRequest<{ user?: FirefliesUser | null }>(
-    apiKey,
-    FIREFLIES_USER_QUERY,
-    {},
-    fetchImpl,
-  );
+  const payload = await firefliesGraphqlRequest<{
+    user?: FirefliesUser | null;
+  }>(apiKey, FIREFLIES_USER_QUERY, {}, fetchImpl);
   if (!payload.user) {
-    throw new Error('Fireflies user lookup failed');
+    throw new Error("Fireflies user lookup failed");
   }
   return payload.user;
 }
@@ -200,7 +206,9 @@ export async function fetchFirefliesTranscripts(
   },
   fetchImpl: typeof fetch = fetch,
 ): Promise<FirefliesTranscript[]> {
-  const payload = await firefliesGraphqlRequest<{ transcripts?: FirefliesTranscript[] | null }>(
+  const payload = await firefliesGraphqlRequest<{
+    transcripts?: FirefliesTranscript[] | null;
+  }>(
     apiKey,
     FIREFLIES_TRANSCRIPTS_QUERY,
     {
@@ -214,22 +222,29 @@ export async function fetchFirefliesTranscripts(
   return payload.transcripts ?? [];
 }
 
-export function firefliesTranscriptToCanonical(transcript: FirefliesTranscript): CanonicalRecording {
+export function firefliesTranscriptToCanonical(
+  transcript: FirefliesTranscript,
+): CanonicalRecording {
   const turns = firefliesSentencesToTurns(transcript.sentences ?? []);
   const fullTranscript = formatCanonicalTranscript(turns);
-  const recordingStartTime = coerceFirefliesDate(transcript.dateString ?? transcript.date);
+  const recordingStartTime = coerceFirefliesDate(
+    transcript.dateString ?? transcript.date,
+  );
   const durationSeconds = normalizeDurationSeconds(transcript.duration);
-  const recordingEndTime = durationSeconds != null
-    ? new Date(new Date(recordingStartTime).getTime() + durationSeconds * 1000).toISOString()
-    : null;
+  const recordingEndTime =
+    durationSeconds != null
+      ? new Date(
+          new Date(recordingStartTime).getTime() + durationSeconds * 1000,
+        ).toISOString()
+      : null;
   const attendeeEmails = (transcript.meeting_attendees ?? [])
     .map((attendee) => attendee.email)
-    .filter((email): email is string => typeof email === 'string');
+    .filter((email): email is string => typeof email === "string");
 
   return {
     externalId: transcript.id,
-    sourceApp: 'fireflies',
-    title: transcript.title?.trim() || 'Untitled Fireflies Call',
+    sourceApp: "fireflies",
+    title: transcript.title?.trim() || "Untitled Fireflies Call",
     fullTranscript,
     summary: summarizeFirefliesSummary(transcript.summary),
     recordingStartTime,
@@ -237,10 +252,11 @@ export function firefliesTranscriptToCanonical(transcript: FirefliesTranscript):
     durationSeconds,
     sourceUrl: transcript.transcript_url ?? transcript.meeting_link ?? null,
     shareUrl: transcript.transcript_url ?? transcript.meeting_link ?? null,
-    recordedByEmail: transcript.host_email ?? transcript.organizer_email ?? null,
+    recordedByEmail:
+      transcript.host_email ?? transcript.organizer_email ?? null,
     participantEmails: normalizeEmailList([
-      transcript.host_email ?? '',
-      transcript.organizer_email ?? '',
+      transcript.host_email ?? "",
+      transcript.organizer_email ?? "",
       ...attendeeEmails,
       ...extractEmailsFromParticipants(transcript.participants),
     ]),
@@ -251,84 +267,128 @@ export function firefliesTranscriptToCanonical(transcript: FirefliesTranscript):
       fireflies_audio_url: transcript.audio_url ?? null,
       fireflies_video_url: transcript.video_url ?? null,
       fireflies_meeting_link: transcript.meeting_link ?? null,
-      recorded_by_email: transcript.host_email ?? transcript.organizer_email ?? null,
+      recorded_by_email:
+        transcript.host_email ?? transcript.organizer_email ?? null,
       recorded_by_name: findHostName(transcript),
       action_items: normalizeSummaryList(transcript.summary?.action_items),
-      topics_discussed: normalizeSummaryList(transcript.summary?.topics_discussed),
+      topics_discussed: normalizeSummaryList(
+        transcript.summary?.topics_discussed,
+      ),
     },
     rawPayload: transcript,
   };
 }
 
-function firefliesSentencesToTurns(sentences: FirefliesSentence[]): CanonicalTranscriptTurn[] {
+function firefliesSentencesToTurns(
+  sentences: FirefliesSentence[],
+): CanonicalTranscriptTurn[] {
   return [...sentences]
     .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
     .map((sentence) => ({
-      speakerName: sentence.speaker_name ?? 'Unknown',
-      text: sentence.text ?? '',
+      speakerName: sentence.speaker_name ?? "Unknown",
+      text: sentence.text ?? "",
       startSeconds: sentence.start_time ?? 0,
       endSeconds: sentence.end_time ?? null,
     }));
 }
 
-function coerceFirefliesDate(value: number | string | null | undefined): string {
-  if (typeof value === 'number' && Number.isFinite(value)) {
+/**
+ * Coerce a Fireflies `date` / `dateString` value into an ISO-8601 string.
+ *
+ * Fireflies sends `date` as either epoch seconds *or* epoch milliseconds
+ * depending on the payload variant. We disambiguate using the standard
+ * convention: anything <= 10_000_000_000 (2286-11-20 in seconds, 1970-04-26
+ * in millis) is treated as seconds. `dateString` is always ISO-8601 when
+ * present and takes precedence on the call site.
+ *
+ * Exported so the edge-function mapper can share the exact same coercion
+ * and so the seconds/millis branch is testable.
+ */
+export function coerceFirefliesDate(
+  value: number | string | null | undefined,
+): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
     const millis = value > 10_000_000_000 ? value : value * 1000;
     return new Date(millis).toISOString();
   }
 
-  if (typeof value === 'string' && value.trim()) {
+  if (typeof value === "string" && value.trim()) {
     const parsed = Date.parse(value);
     if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
   }
 
-  throw new Error('Fireflies transcript is missing a valid date/dateString');
+  throw new Error("Fireflies transcript is missing a valid date/dateString");
 }
 
-function normalizeDurationSeconds(value: number | null | undefined): number | null {
+/**
+ * Normalize a Fireflies `duration` value (seconds, possibly null/NaN/negative)
+ * into a non-negative integer or null. Exported for reuse by the edge-function
+ * list mapper.
+ */
+export function normalizeDurationSeconds(
+  value: number | null | undefined,
+): number | null {
   if (value == null || !Number.isFinite(value) || value < 0) return null;
   return Math.round(value);
 }
 
-function summarizeFirefliesSummary(summary: FirefliesSummary | null | undefined): string | null {
+function summarizeFirefliesSummary(
+  summary: FirefliesSummary | null | undefined,
+): string | null {
   if (!summary) return null;
   const sections = [
     summary.short_summary,
     summary.short_overview,
     summary.overview,
     summary.gist,
-    stringifyList('Topics discussed', summary.topics_discussed),
-    stringifyList('Action items', summary.action_items),
-    stringifyList('Highlights', summary.bullet_gist),
-  ].filter((section): section is string => typeof section === 'string' && section.trim().length > 0);
+    stringifyList("Topics discussed", summary.topics_discussed),
+    stringifyList("Action items", summary.action_items),
+    stringifyList("Highlights", summary.bullet_gist),
+  ].filter(
+    (section): section is string =>
+      typeof section === "string" && section.trim().length > 0,
+  );
 
-  return sections.length > 0 ? sections.join('\n\n') : null;
+  return sections.length > 0 ? sections.join("\n\n") : null;
 }
 
-function stringifyList(label: string, value: string | string[] | null | undefined): string | null {
+function stringifyList(
+  label: string,
+  value: string | string[] | null | undefined,
+): string | null {
   if (Array.isArray(value)) {
     const items = value.map((item) => item.trim()).filter(Boolean);
-    return items.length > 0 ? `${label}:\n${items.map((item) => `- ${item}`).join('\n')}` : null;
+    return items.length > 0
+      ? `${label}:\n${items.map((item) => `- ${item}`).join("\n")}`
+      : null;
   }
-  return typeof value === 'string' && value.trim() ? `${label}: ${value.trim()}` : null;
+  return typeof value === "string" && value.trim()
+    ? `${label}: ${value.trim()}`
+    : null;
 }
 
-function normalizeSummaryList(value: string | string[] | null | undefined): string[] {
+function normalizeSummaryList(
+  value: string | string[] | null | undefined,
+): string[] {
   if (Array.isArray(value)) {
     return value.map((item) => item.trim()).filter(Boolean);
   }
-  return typeof value === 'string' && value.trim() ? [value.trim()] : [];
+  return typeof value === "string" && value.trim() ? [value.trim()] : [];
 }
 
 function extractEmailsFromParticipants(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
     .map((participant) => {
-      if (typeof participant === 'string') return participant;
-      if (participant && typeof participant === 'object' && 'email' in participant) {
-        return String((participant as { email?: unknown }).email ?? '');
+      if (typeof participant === "string") return participant;
+      if (
+        participant &&
+        typeof participant === "object" &&
+        "email" in participant
+      ) {
+        return String((participant as { email?: unknown }).email ?? "");
       }
-      return '';
+      return "";
     })
     .filter(Boolean);
 }
@@ -336,7 +396,9 @@ function extractEmailsFromParticipants(value: unknown): string[] {
 function findHostName(transcript: FirefliesTranscript): string | null {
   const hostEmail = transcript.host_email ?? transcript.organizer_email;
   if (!hostEmail) return null;
-  const attendee = (transcript.meeting_attendees ?? []).find((item) => item.email === hostEmail);
+  const attendee = (transcript.meeting_attendees ?? []).find(
+    (item) => item.email === hostEmail,
+  );
   return attendee?.displayName ?? attendee?.name ?? null;
 }
 
@@ -346,21 +408,25 @@ async function firefliesGraphqlRequest<T>(
   variables: Record<string, unknown>,
   fetchImpl: typeof fetch,
 ): Promise<T> {
-  if (!apiKey.trim()) throw new Error('Fireflies API key is required');
+  if (!apiKey.trim()) throw new Error("Fireflies API key is required");
 
   const response = await fetchImpl(FIREFLIES_GRAPHQL_URL, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({ query, variables }),
   });
 
-  const payload = await response.json() as FirefliesGraphQLResponse;
+  const payload = (await response.json()) as FirefliesGraphQLResponse;
   if (!response.ok || payload.errors?.length) {
-    const message = payload.errors?.map((error) => error.message).filter(Boolean).join('; ')
-      || `Fireflies API request failed with HTTP ${response.status}`;
+    const message =
+      payload.errors
+        ?.map((error) => error.message)
+        .filter(Boolean)
+        .join("; ") ||
+      `Fireflies API request failed with HTTP ${response.status}`;
     throw new Error(message);
   }
 

--- a/supabase/functions/_shared/fireflies-credentials.ts
+++ b/supabase/functions/_shared/fireflies-credentials.ts
@@ -1,0 +1,274 @@
+/**
+ * Fireflies credential helpers — encrypted-at-rest read/write for
+ * `import_sources.api_key` and `import_sources.webhook_signing_secret`.
+ *
+ * Mirrors the pattern in `_shared/oauth-encrypt.ts`:
+ *   - Reads `OAUTH_ENCRYPTION_KEY` from env.
+ *   - When the key is set, calls the SECURITY DEFINER RPCs added in migration
+ *     `20260524000000_encrypt_fireflies_credentials.sql` which wrap
+ *     `pgp_sym_encrypt` / `pgp_sym_decrypt`.
+ *   - Falls back to a plaintext read/write when no key is configured (local
+ *     dev, CI without secrets). The `decrypt_token` SQL helper also gracefully
+ *     returns plaintext if a row predates encryption, so a mixed-state table
+ *     reads correctly from either branch.
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type SupabaseLike = ReturnType<typeof createClient>;
+
+export interface DecryptedFirefliesCredentials {
+  id: string;
+  user_id: string;
+  api_key: string | null;
+  webhook_signing_secret: string | null;
+}
+
+export interface DecryptedFirefliesCredentialsWithPathToken extends DecryptedFirefliesCredentials {
+  webhook_path_token: string | null;
+}
+
+function encryptionKey(): string | null {
+  return Deno.env.get("OAUTH_ENCRYPTION_KEY") ?? null;
+}
+
+/**
+ * Read the active Fireflies source for a user with plaintext credentials.
+ * Returns null when the user has no active source.
+ */
+export async function getDecryptedFirefliesSourceForUser(
+  supabase: SupabaseLike,
+  userId: string,
+): Promise<DecryptedFirefliesCredentials | null> {
+  const client = supabase as any;
+  const key = encryptionKey();
+
+  if (key) {
+    const { data, error } = await client.rpc(
+      "get_decrypted_fireflies_source_for_user",
+      {
+        p_user_id: userId,
+        p_encryption_key: key,
+      },
+    );
+    if (!error && Array.isArray(data) && data.length > 0) {
+      const row = data[0];
+      return {
+        id: String(row.id),
+        user_id: String(row.user_id),
+        api_key: row.api_key ?? null,
+        webhook_signing_secret: row.webhook_signing_secret ?? null,
+      };
+    }
+    if (error) {
+      console.warn(
+        "Fireflies decryption RPC failed, falling back to plaintext:",
+        error.message,
+      );
+    }
+  }
+
+  const { data: row, error: queryError } = await client
+    .from("import_sources")
+    .select("id, user_id, api_key, webhook_signing_secret")
+    .eq("user_id", userId)
+    .eq("source_app", "fireflies")
+    .eq("is_active", true)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (queryError) throw queryError;
+  if (!row) return null;
+  return {
+    id: String(row.id),
+    user_id: String(row.user_id),
+    api_key: row.api_key ?? null,
+    webhook_signing_secret: row.webhook_signing_secret ?? null,
+  };
+}
+
+/**
+ * Look up the Fireflies source addressed by a webhook path token, with the
+ * api_key and webhook_signing_secret decrypted. Returns null if no active
+ * source matches the token.
+ */
+export async function getDecryptedFirefliesSourceByPathToken(
+  supabase: SupabaseLike,
+  pathToken: string,
+): Promise<DecryptedFirefliesCredentialsWithPathToken | null> {
+  const client = supabase as any;
+  const key = encryptionKey();
+
+  if (key) {
+    const { data, error } = await client.rpc(
+      "get_decrypted_fireflies_source_by_path_token",
+      {
+        p_path_token: pathToken,
+        p_encryption_key: key,
+      },
+    );
+    if (!error && Array.isArray(data) && data.length > 0) {
+      const row = data[0];
+      return {
+        id: String(row.id),
+        user_id: String(row.user_id),
+        api_key: row.api_key ?? null,
+        webhook_signing_secret: row.webhook_signing_secret ?? null,
+        webhook_path_token: row.webhook_path_token ?? null,
+      };
+    }
+    if (error) {
+      console.warn(
+        "Fireflies path-token decryption RPC failed, falling back to plaintext:",
+        error.message,
+      );
+    }
+  }
+
+  const { data: row, error: queryError } = await client
+    .from("import_sources")
+    .select("id, user_id, api_key, webhook_signing_secret, webhook_path_token")
+    .eq("source_app", "fireflies")
+    .eq("is_active", true)
+    .eq("webhook_path_token", pathToken)
+    .maybeSingle();
+
+  if (queryError) throw queryError;
+  if (!row) return null;
+  return {
+    id: String(row.id),
+    user_id: String(row.user_id),
+    api_key: row.api_key ?? null,
+    webhook_signing_secret: row.webhook_signing_secret ?? null,
+    webhook_path_token: row.webhook_path_token ?? null,
+  };
+}
+
+/**
+ * List every active Fireflies source whose webhook_signing_secret is non-null,
+ * with credentials decrypted. Used by the webhook signature-scan fallback for
+ * legacy senders that don't include a path token.
+ */
+export async function listDecryptedActiveFirefliesSources(
+  supabase: SupabaseLike,
+): Promise<DecryptedFirefliesCredentials[]> {
+  const client = supabase as any;
+  const key = encryptionKey();
+
+  if (key) {
+    const { data, error } = await client.rpc(
+      "list_decrypted_active_fireflies_sources",
+      {
+        p_encryption_key: key,
+      },
+    );
+    if (!error && Array.isArray(data)) {
+      return data.map((row: any) => ({
+        id: String(row.id),
+        user_id: String(row.user_id),
+        api_key: row.api_key ?? null,
+        webhook_signing_secret: row.webhook_signing_secret ?? null,
+      }));
+    }
+    if (error) {
+      console.warn(
+        "Fireflies list decryption RPC failed, falling back to plaintext:",
+        error.message,
+      );
+    }
+  }
+
+  const { data: rows, error: queryError } = await client
+    .from("import_sources")
+    .select("id, user_id, api_key, webhook_signing_secret")
+    .eq("source_app", "fireflies")
+    .eq("is_active", true)
+    .not("webhook_signing_secret", "is", null);
+
+  if (queryError) throw queryError;
+  return ((rows ?? []) as Array<Record<string, unknown>>).map((row) => ({
+    id: String(row.id),
+    user_id: String(row.user_id),
+    api_key: (row.api_key as string | null) ?? null,
+    webhook_signing_secret:
+      (row.webhook_signing_secret as string | null) ?? null,
+  }));
+}
+
+/**
+ * Write Fireflies credentials encrypted at rest. Updates an existing
+ * import_sources row in place, or inserts a new one if `existingSourceId` is
+ * null. Returns the persisted row id.
+ */
+export async function storeEncryptedFirefliesCredentials(
+  supabase: SupabaseLike,
+  params: {
+    existingSourceId: string | null;
+    userId: string;
+    accountEmail: string | null;
+    apiKey: string;
+    webhookSigningSecret: string;
+    webhookPathToken: string;
+  },
+): Promise<{ id: string }> {
+  const client = supabase as any;
+  const key = encryptionKey();
+
+  if (key) {
+    const { data, error } = await client.rpc(
+      "store_encrypted_fireflies_credentials",
+      {
+        p_source_id: params.existingSourceId,
+        p_user_id: params.userId,
+        p_account_email: params.accountEmail,
+        p_api_key: params.apiKey,
+        p_webhook_signing_secret: params.webhookSigningSecret,
+        p_webhook_path_token: params.webhookPathToken,
+        p_encryption_key: key,
+      },
+    );
+    if (!error && data) {
+      return { id: String(data) };
+    }
+    if (error) {
+      console.warn(
+        "Fireflies credential encryption RPC failed, falling back to plaintext:",
+        error.message,
+      );
+    }
+  }
+
+  // Plaintext fallback (no encryption key configured — local dev only).
+  const payload = {
+    user_id: params.userId,
+    source_app: "fireflies",
+    account_email: params.accountEmail,
+    is_active: true,
+    error_message: null,
+    api_key: params.apiKey,
+    webhook_signing_secret: params.webhookSigningSecret,
+    webhook_path_token: params.webhookPathToken,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (params.existingSourceId) {
+    const { data, error } = await client
+      .from("import_sources")
+      .update(payload)
+      .eq("id", params.existingSourceId)
+      .eq("user_id", params.userId)
+      .select("id")
+      .single();
+    if (error) throw error;
+    return { id: String(data.id) };
+  }
+
+  const { data, error } = await client
+    .from("import_sources")
+    .insert(payload)
+    .select("id")
+    .single();
+  if (error) throw error;
+  return { id: String(data.id) };
+}

--- a/supabase/functions/_shared/webhook-signing.ts
+++ b/supabase/functions/_shared/webhook-signing.ts
@@ -1,0 +1,50 @@
+/**
+ * Webhook signing helpers — HMAC-SHA256 signature compute + constant-time compare.
+ *
+ * Extracted from fireflies-webhook so the primitives are testable in isolation
+ * and reusable by any future webhook handler that uses the GitHub-style
+ * `X-Hub-Signature: sha256=<hex>` header convention.
+ */
+
+/**
+ * Compute the GitHub-style HMAC-SHA256 signature for a raw request body.
+ * Returns the value formatted exactly as it appears in the `X-Hub-Signature`
+ * header: `sha256=<lowercase-hex>`.
+ */
+export async function computeHmacSha256Signature(
+  rawBody: string,
+  secret: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(rawBody),
+  );
+  const hex = Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256=${hex}`;
+}
+
+/**
+ * Constant-time string comparison. Returns true iff `a` and `b` are equal.
+ * Short-circuits on length mismatch — only the *length* of the expected
+ * signature is leaked, which is constant (always 71 chars for `sha256=<64 hex>`),
+ * so no exploitable timing channel.
+ */
+export function timingSafeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/supabase/functions/fireflies-fetch-meetings/index.ts
+++ b/supabase/functions/fireflies-fetch-meetings/index.ts
@@ -1,7 +1,13 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { authenticateRequest } from '../_shared/auth.ts';
-import { getCorsHeaders } from '../_shared/cors.ts';
-import { fetchFirefliesTranscripts, type FirefliesTranscript } from '../_shared/fireflies-connector.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { authenticateRequest } from "../_shared/auth.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import {
+  coerceFirefliesDate,
+  fetchFirefliesTranscripts,
+  normalizeDurationSeconds,
+  type FirefliesTranscript,
+} from "../_shared/fireflies-connector.ts";
+import { getDecryptedFirefliesSourceForUser } from "../_shared/fireflies-credentials.ts";
 
 interface FirefliesFetchMeetingsRequest {
   createdAfter?: string | null;
@@ -25,43 +31,47 @@ interface FirefliesListRow {
 }
 
 Deno.serve(async (req) => {
-  const origin = req.headers.get('Origin');
+  const origin = req.headers.get("Origin");
   const corsHeaders = getCorsHeaders(origin);
 
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, serviceRoleKey);
 
     const authResult = await authenticateRequest(req, supabase, corsHeaders);
     if (authResult instanceof Response) return authResult;
     const userId = authResult.userId;
 
-    const body = await req.json() as FirefliesFetchMeetingsRequest;
+    const body = (await req.json()) as FirefliesFetchMeetingsRequest;
     const limit = Math.min(Math.max(body.limit ?? 50, 1), 50);
     const skip = Math.max(body.skip ?? 0, 0);
 
-    const { data: source, error: sourceError } = await supabase
-      .from('import_sources')
-      .select('id, api_key, webhook_signing_secret, account_email')
-      .eq('user_id', userId)
-      .eq('source_app', 'fireflies')
-      .eq('is_active', true)
-      .order('updated_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (sourceError) throw sourceError;
+    const source = await getDecryptedFirefliesSourceForUser(supabase, userId);
     if (!source?.api_key) {
-      return new Response(JSON.stringify({ error: 'Fireflies is not connected. Save an API key first.' }), {
-        status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({
+          error: "Fireflies is not connected. Save an API key first.",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
+
+    // Also pull the row's account_email for the response. Cheap second read —
+    // splits keep the credential-decryption RPC focused on the secret fields.
+    const { data: sourceMeta } = await (supabase as any)
+      .from("import_sources")
+      .select("account_email")
+      .eq("id", source.id)
+      .eq("user_id", userId)
+      .maybeSingle();
 
     const transcripts = await fetchFirefliesTranscripts(source.api_key, {
       fromDate: body.createdAfter ?? null,
@@ -74,44 +84,76 @@ Deno.serve(async (req) => {
     const syncedIds = new Set<string>();
     if (ids.length > 0) {
       const { data: recordings, error: recordingsError } = await supabase
-        .from('recordings')
-        .select('source_call_id')
-        .eq('owner_user_id', userId)
-        .eq('source_app', 'fireflies')
-        .in('source_call_id', ids);
+        .from("recordings")
+        .select("source_call_id")
+        .eq("owner_user_id", userId)
+        .eq("source_app", "fireflies")
+        .in("source_call_id", ids);
       if (recordingsError) throw recordingsError;
       for (const row of recordings ?? []) {
         if (row.source_call_id) syncedIds.add(String(row.source_call_id));
       }
     }
 
-    const meetings: FirefliesListRow[] = transcripts.map((transcript) => mapTranscriptToListRow(transcript, syncedIds));
+    // Per-item try/catch — a single malformed transcript (e.g. missing
+    // dateString and missing date) must not nuke the entire listing with a 500.
+    // Drop the bad row and keep going; the user sees what Fireflies returned
+    // minus the unmappable entry, and we log enough context to chase the
+    // mapper bug.
+    const meetings: FirefliesListRow[] = [];
+    for (const transcript of transcripts) {
+      try {
+        meetings.push(mapTranscriptToListRow(transcript, syncedIds));
+      } catch (mapError) {
+        console.error(
+          `Fireflies fetch-meetings: dropping malformed transcript ${transcript.id ?? "<no id>"}:`,
+          mapError,
+        );
+      }
+    }
 
-    return new Response(JSON.stringify({
-      meetings,
-      nextSkip: transcripts.length === limit ? skip + transcripts.length : null,
-      sourceId: source.id,
-      accountEmail: source.account_email,
-    }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({
+        meetings,
+        nextSkip:
+          transcripts.length === limit ? skip + transcripts.length : null,
+        sourceId: source.id,
+        accountEmail: sourceMeta?.account_email ?? null,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   } catch (error) {
-    console.error('Error fetching Fireflies meetings:', error);
-    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    console.error("Error fetching Fireflies meetings:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   }
 });
 
-function mapTranscriptToListRow(transcript: FirefliesTranscript, syncedIds: Set<string>): FirefliesListRow {
-  const start = coerceDate(transcript.dateString ?? transcript.date);
+function mapTranscriptToListRow(
+  transcript: FirefliesTranscript,
+  syncedIds: Set<string>,
+): FirefliesListRow {
+  const start = coerceFirefliesDate(transcript.dateString ?? transcript.date);
   const durationSeconds = normalizeDurationSeconds(transcript.duration);
-  const end = durationSeconds != null ? new Date(new Date(start).getTime() + durationSeconds * 1000).toISOString() : null;
+  const end =
+    durationSeconds != null
+      ? new Date(
+          new Date(start).getTime() + durationSeconds * 1000,
+        ).toISOString()
+      : null;
 
   return {
     recording_id: transcript.id,
-    title: transcript.title?.trim() || 'Untitled Fireflies Call',
+    title: transcript.title?.trim() || "Untitled Fireflies Call",
     created_at: start,
     recording_start_time: start,
     recording_end_time: end,
@@ -124,21 +166,4 @@ function mapTranscriptToListRow(transcript: FirefliesTranscript, syncedIds: Set<
     source_url: transcript.transcript_url ?? transcript.meeting_link ?? null,
     share_url: transcript.transcript_url ?? transcript.meeting_link ?? null,
   };
-}
-
-function normalizeDurationSeconds(value: number | null | undefined): number | null {
-  if (value == null || !Number.isFinite(value) || value < 0) return null;
-  return Math.round(value);
-}
-
-function coerceDate(value: number | string | null | undefined): string {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    const millis = value > 10_000_000_000 ? value : value * 1000;
-    return new Date(millis).toISOString();
-  }
-  if (typeof value === 'string' && value.trim()) {
-    const parsed = Date.parse(value);
-    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
-  }
-  throw new Error('Fireflies transcript is missing a valid date/dateString');
 }

--- a/supabase/functions/fireflies-save-source/index.ts
+++ b/supabase/functions/fireflies-save-source/index.ts
@@ -1,144 +1,185 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { authenticateRequest } from '../_shared/auth.ts';
-import { getCorsHeaders } from '../_shared/cors.ts';
-import { fetchFirefliesUser } from '../_shared/fireflies-connector.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { z } from "https://esm.sh/zod@3.23.8";
+import { authenticateRequest } from "../_shared/auth.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import { fetchFirefliesUser } from "../_shared/fireflies-connector.ts";
+import { storeEncryptedFirefliesCredentials } from "../_shared/fireflies-credentials.ts";
 
-interface FirefliesSaveSourceRequest {
-  apiKey?: string;
-  webhookSigningSecret?: string | null;
-  webhookPathToken?: string | null;
-}
+// Fireflies API keys are alphanumeric UUID-like tokens (length seen in the
+// wild: 36 chars). We accept 24-128 chars of printable ASCII to avoid being
+// brittle if Fireflies changes the format; the call to fetchFirefliesUser()
+// below is the authoritative check.
+const SaveSourceSchema = z.object({
+  apiKey: z
+    .string()
+    .trim()
+    .min(24, "Fireflies API key looks too short")
+    .max(128, "Fireflies API key looks too long")
+    .regex(/^[\x20-\x7E]+$/, "Fireflies API key contains invalid characters"),
+  webhookSigningSecret: z.string().trim().min(8).max(256).nullable().optional(),
+  webhookPathToken: z
+    .string()
+    .trim()
+    .regex(/^ffwh_[a-f0-9]{32}$/)
+    .nullable()
+    .optional(),
+});
 
 Deno.serve(async (req) => {
-  const origin = req.headers.get('Origin');
+  const origin = req.headers.get("Origin");
   const corsHeaders = getCorsHeaders(origin);
 
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, serviceRoleKey);
 
-    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    const authResult = await authenticateRequest(
+      req,
+      supabase as any,
+      corsHeaders,
+    );
     if (authResult instanceof Response) return authResult;
     const userId = authResult.userId;
 
-    const body = await req.json() as FirefliesSaveSourceRequest;
-    const apiKey = body.apiKey?.trim() ?? '';
-    const submittedWebhookSigningSecret = body.webhookSigningSecret?.trim() || null;
-    const submittedWebhookPathToken = normalizeWebhookPathToken(body.webhookPathToken);
-
-    if (!apiKey) {
-      return new Response(JSON.stringify({ error: 'Fireflies API key is required' }), {
-        status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+    const rawBody = await req.json();
+    const parsed = SaveSourceSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const message = parsed.error.issues
+        .map((issue) => issue.message)
+        .join("; ");
+      return new Response(
+        JSON.stringify({
+          error: message || "Invalid Fireflies credentials payload",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
+
+    const apiKey = parsed.data.apiKey;
+    const submittedWebhookSigningSecret =
+      parsed.data.webhookSigningSecret?.trim() || null;
+    const submittedWebhookPathToken =
+      parsed.data.webhookPathToken?.trim() || null;
 
     const firefliesUser = await fetchFirefliesUser(apiKey);
     const accountEmail = firefliesUser.email?.trim() || null;
 
-    const { data: existing } = await supabase
-      .from('import_sources')
-      .select('id, webhook_signing_secret, webhook_path_token')
-      .eq('user_id', userId)
-      .eq('source_app', 'fireflies')
-      .order('updated_at', { ascending: false })
+    const { data: existing } = await (supabase as any)
+      .from("import_sources")
+      .select("id, webhook_signing_secret, webhook_path_token")
+      .eq("user_id", userId)
+      .eq("source_app", "fireflies")
+      .order("updated_at", { ascending: false })
       .limit(1)
       .maybeSingle();
 
-    const generatedWebhookSigningSecret = !submittedWebhookSigningSecret && !existing?.webhook_signing_secret
-      ? generateWebhookSigningSecret()
-      : null;
+    const generatedWebhookSigningSecret =
+      !submittedWebhookSigningSecret && !existing?.webhook_signing_secret
+        ? generateWebhookSigningSecret()
+        : null;
     const webhookSigningSecret =
-      submittedWebhookSigningSecret ?? existing?.webhook_signing_secret ?? generatedWebhookSigningSecret;
+      submittedWebhookSigningSecret ??
+      existing?.webhook_signing_secret ??
+      generatedWebhookSigningSecret;
 
     if (!webhookSigningSecret) {
-      return new Response(JSON.stringify({ error: 'Fireflies webhook signing secret is required' }), {
-        status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({
+          error: "Fireflies webhook signing secret is required",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    const generatedWebhookPathToken = !submittedWebhookPathToken && !existing?.webhook_path_token
-      ? generateWebhookPathToken()
-      : null;
+    const generatedWebhookPathToken =
+      !submittedWebhookPathToken && !existing?.webhook_path_token
+        ? generateWebhookPathToken()
+        : null;
     const webhookPathToken =
-      submittedWebhookPathToken ?? existing?.webhook_path_token ?? generatedWebhookPathToken;
+      submittedWebhookPathToken ??
+      existing?.webhook_path_token ??
+      generatedWebhookPathToken;
 
     if (!webhookPathToken) {
-      return new Response(JSON.stringify({ error: 'Fireflies webhook URL token is required' }), {
-        status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({ error: "Fireflies webhook URL token is required" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    const payload = {
-      user_id: userId,
-      source_app: 'fireflies',
-      account_email: accountEmail,
-      is_active: true,
-      error_message: null,
-      api_key: apiKey,
-      webhook_signing_secret: webhookSigningSecret,
-      webhook_path_token: webhookPathToken,
-      updated_at: new Date().toISOString(),
-    };
-
-    let sourceRow;
-    if (existing?.id) {
-      const { data, error } = await supabase
-        .from('import_sources')
-        .update(payload)
-        .eq('id', existing.id)
-        .eq('user_id', userId)
-        .select('id, source_app, account_email, is_active, last_sync_at, error_message, webhook_path_token, created_at, updated_at')
-        .single();
-      if (error) throw error;
-      sourceRow = data;
-    } else {
-      const { data, error } = await supabase
-        .from('import_sources')
-        .insert(payload)
-        .select('id, source_app, account_email, is_active, last_sync_at, error_message, webhook_path_token, created_at, updated_at')
-        .single();
-      if (error) throw error;
-      sourceRow = data;
-    }
-
-    return new Response(JSON.stringify({
-      success: true,
-      source: sourceRow,
-      webhookSigningSecret: generatedWebhookSigningSecret ?? submittedWebhookSigningSecret ?? undefined,
+    const stored = await storeEncryptedFirefliesCredentials(supabase, {
+      existingSourceId: existing?.id ? String(existing.id) : null,
+      userId,
+      accountEmail,
+      apiKey,
+      webhookSigningSecret,
       webhookPathToken,
-    }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
+
+    const { data: sourceRow, error: readError } = await (supabase as any)
+      .from("import_sources")
+      .select(
+        "id, source_app, account_email, is_active, last_sync_at, error_message, webhook_path_token, created_at, updated_at",
+      )
+      .eq("id", stored.id)
+      .eq("user_id", userId)
+      .single();
+    if (readError) throw readError;
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        source: sourceRow,
+        webhookSigningSecret:
+          generatedWebhookSigningSecret ??
+          submittedWebhookSigningSecret ??
+          undefined,
+        webhookPathToken,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   } catch (error) {
-    console.error('Error saving Fireflies source:', error);
-    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    console.error("Error saving Fireflies source:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   }
 });
 
 function generateWebhookSigningSecret(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return Array.from(bytes).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 function generateWebhookPathToken(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `ffwh_${Array.from(bytes).map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
-}
-
-function normalizeWebhookPathToken(value: string | null | undefined): string | null {
-  const token = value?.trim() ?? '';
-  return /^ffwh_[a-f0-9]{32}$/.test(token) ? token : null;
+  return `ffwh_${Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
 }

--- a/supabase/functions/fireflies-sync-meetings/index.ts
+++ b/supabase/functions/fireflies-sync-meetings/index.ts
@@ -1,8 +1,12 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { authenticateRequest } from '../_shared/auth.ts';
-import { getCorsHeaders } from '../_shared/cors.ts';
-import { fetchFirefliesTranscript, firefliesTranscriptToCanonical } from '../_shared/fireflies-connector.ts';
-import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { authenticateRequest } from "../_shared/auth.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import {
+  fetchFirefliesTranscript,
+  firefliesTranscriptToCanonical,
+} from "../_shared/fireflies-connector.ts";
+import { getDecryptedFirefliesSourceForUser } from "../_shared/fireflies-credentials.ts";
+import { runCanonicalConnectorPipeline } from "../_shared/recording-connectors.ts";
 
 interface FirefliesSyncRequest {
   transcriptIds?: string[];
@@ -11,79 +15,122 @@ interface FirefliesSyncRequest {
   workspace_id?: string | null;
 }
 
+// Caps the number of transcripts that can be processed in a single
+// EdgeRuntime.waitUntil() background invocation. Deno Deploy enforces an
+// open-ended wall-clock limit on background tasks (per Supabase docs, on the
+// order of minutes), so very large batches silently die mid-loop. The UI
+// already pages requests at 50 to match fetch-meetings.
+const MAX_BATCH_SIZE = 50;
+
 Deno.serve(async (req) => {
-  const origin = req.headers.get('Origin');
+  const origin = req.headers.get("Origin");
   const corsHeaders = getCorsHeaders(origin);
 
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     const authResult = await authenticateRequest(req, supabase, corsHeaders);
     if (authResult instanceof Response) return authResult;
     const userId = authResult.userId;
 
-    const body = await req.json() as FirefliesSyncRequest;
-    const transcriptIds = body.singleCallId ? [body.singleCallId] : body.transcriptIds ?? [];
+    const body = (await req.json()) as FirefliesSyncRequest;
+    const transcriptIds = body.singleCallId
+      ? [body.singleCallId]
+      : (body.transcriptIds ?? []);
 
     if (!Array.isArray(transcriptIds) || transcriptIds.length === 0) {
       return new Response(
-        JSON.stringify({ error: 'transcriptIds must be an array or singleCallId must be provided' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        JSON.stringify({
+          error:
+            "transcriptIds must be an array or singleCallId must be provided",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
-    const { data: source, error: sourceError } = await supabase
-      .from('import_sources')
-      .select('id, api_key')
-      .eq('user_id', userId)
-      .eq('source_app', 'fireflies')
-      .eq('is_active', true)
-      .order('updated_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
+    if (transcriptIds.length > MAX_BATCH_SIZE) {
+      return new Response(
+        JSON.stringify({
+          error: `Too many transcripts: max ${MAX_BATCH_SIZE} per request, received ${transcriptIds.length}. Submit them in smaller batches.`,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
 
-    if (sourceError) throw sourceError;
+    const source = await getDecryptedFirefliesSourceForUser(supabase, userId);
     const sourceId = body.sourceId ?? source?.id ?? null;
-    const apiKey = source?.api_key?.trim() ?? '';
+    const apiKey = source?.api_key?.trim() ?? "";
 
     if (!sourceId || !apiKey) {
       return new Response(
-        JSON.stringify({ error: 'Fireflies is not connected. Save an API key first.' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        JSON.stringify({
+          error: "Fireflies is not connected. Save an API key first.",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
     let validatedWorkspaceId: string | null = null;
     if (body.workspace_id) {
       const { data: membership, error: membershipError } = await supabase
-        .from('workspace_memberships')
-        .select('id')
-        .eq('workspace_id', body.workspace_id)
-        .eq('user_id', userId)
+        .from("workspace_memberships")
+        .select("id")
+        .eq("workspace_id", body.workspace_id)
+        .eq("user_id", userId)
         .maybeSingle();
 
       if (membershipError) {
-        console.error('Error checking workspace membership:', membershipError);
-      } else if (membership) {
-        validatedWorkspaceId = body.workspace_id;
+        // Transient DB failure — surface it instead of silently dropping the
+        // user's workspace selection and routing recordings to the default.
+        console.error("Workspace membership lookup failed:", membershipError);
+        return new Response(
+          JSON.stringify({
+            error: "Failed to verify workspace membership. Try again.",
+          }),
+          {
+            status: 500,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
       }
+      if (!membership) {
+        return new Response(
+          JSON.stringify({
+            error: "You are not a member of the requested workspace.",
+          }),
+          {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+      validatedWorkspaceId = body.workspace_id;
     }
 
     const { data: syncJob, error: jobError } = await supabase
-      .from('sync_jobs')
+      .from("sync_jobs")
       .insert({
         user_id: userId,
         recording_ids: transcriptIds,
-        status: 'processing',
+        status: "processing",
         progress_current: 0,
         progress_total: transcriptIds.length,
-        type: 'fireflies',
+        type: "fireflies",
       })
       .select()
       .single();
@@ -96,60 +143,115 @@ Deno.serve(async (req) => {
       const failed: string[] = [];
       let skippedCount = 0;
 
-      for (const transcriptId of transcriptIds) {
-        try {
-          const transcript = await fetchFirefliesTranscript(apiKey, transcriptId);
-          const canonical = firefliesTranscriptToCanonical(transcript);
-          const result = await runCanonicalConnectorPipeline(supabase, userId, canonical, {
-            importSource: 'fireflies-sync-meetings',
-            workspaceId: validatedWorkspaceId,
-            includeRawPayload: true,
-          });
+      try {
+        for (const transcriptId of transcriptIds) {
+          try {
+            const transcript = await fetchFirefliesTranscript(
+              apiKey,
+              transcriptId,
+            );
+            const canonical = firefliesTranscriptToCanonical(transcript);
+            const result = await runCanonicalConnectorPipeline(
+              supabase,
+              userId,
+              canonical,
+              {
+                importSource: "fireflies-sync-meetings",
+                workspaceId: validatedWorkspaceId,
+                includeRawPayload: true,
+              },
+            );
 
-          if (result.success) {
-            synced.push(transcriptId);
-          } else if (result.skipped) {
-            skippedCount++;
-          } else {
+            if (result.success) {
+              synced.push(transcriptId);
+            } else if (result.skipped) {
+              skippedCount++;
+            } else {
+              failed.push(transcriptId);
+              console.error(
+                `Fireflies sync failed for ${transcriptId}:`,
+                result.error,
+              );
+            }
+          } catch (error) {
             failed.push(transcriptId);
-            console.error(`Fireflies sync failed for ${transcriptId}:`, result.error);
+            console.error(`Fireflies sync failed for ${transcriptId}:`, error);
           }
-        } catch (error) {
-          failed.push(transcriptId);
-          console.error(`Fireflies sync failed for ${transcriptId}:`, error);
+
+          await supabase
+            .from("sync_jobs")
+            .update({
+              progress_current: synced.length + failed.length + skippedCount,
+              synced_ids: synced,
+              failed_ids: failed,
+              skipped_count: skippedCount,
+            })
+            .eq("id", jobId);
         }
 
+        const finalStatus =
+          failed.length === 0
+            ? "completed"
+            : synced.length === 0
+              ? "failed"
+              : "completed_with_errors";
+
         await supabase
-          .from('sync_jobs')
+          .from("sync_jobs")
           .update({
-            progress_current: synced.length + failed.length + skippedCount,
-            synced_ids: synced,
-            failed_ids: failed,
+            status: finalStatus,
+            completed_at: new Date().toISOString(),
             skipped_count: skippedCount,
           })
-          .eq('id', jobId);
+          .eq("id", jobId);
+        await supabase
+          .from("import_sources")
+          .update({
+            last_sync_at: new Date().toISOString(),
+            error_message:
+              failed.length > 0
+                ? `${failed.length} Fireflies recording${failed.length === 1 ? "" : "s"} failed to sync`
+                : null,
+          })
+          .eq("id", sourceId)
+          .eq("user_id", userId);
+      } catch (outerError) {
+        // Last-resort handler — if the loop itself throws (e.g. supabase
+        // client failure between iterations), make sure the job row gets
+        // marked failed so the frontend poller stops polling instead of
+        // showing "processing" forever.
+        console.error(`Fireflies sync job ${jobId} crashed:`, outerError);
+        const message =
+          outerError instanceof Error ? outerError.message : "Sync job crashed";
+        try {
+          await supabase
+            .from("sync_jobs")
+            .update({
+              status: "failed",
+              error_message: message,
+              completed_at: new Date().toISOString(),
+              synced_ids: synced,
+              failed_ids: failed,
+              skipped_count: skippedCount,
+            })
+            .eq("id", jobId);
+          await supabase
+            .from("import_sources")
+            .update({
+              last_sync_at: new Date().toISOString(),
+              error_message: `Fireflies sync job crashed: ${message}`,
+            })
+            .eq("id", sourceId)
+            .eq("user_id", userId);
+        } catch (markFailedError) {
+          // Nothing more we can do — log and let the frontend poll timeout
+          // (5 min default) surface the stuck job to the user.
+          console.error(
+            `Failed to mark sync job ${jobId} as failed:`,
+            markFailedError,
+          );
+        }
       }
-
-      const finalStatus = failed.length === 0 ? 'completed'
-        : synced.length === 0 ? 'failed'
-        : 'completed_with_errors';
-
-      await supabase
-        .from('sync_jobs')
-        .update({
-          status: finalStatus,
-          completed_at: new Date().toISOString(),
-          skipped_count: skippedCount,
-        })
-        .eq('id', jobId);
-      await supabase
-        .from('import_sources')
-        .update({
-          last_sync_at: new Date().toISOString(),
-          error_message: failed.length > 0 ? `${failed.length} Fireflies recording${failed.length === 1 ? '' : 's'} failed to sync` : null,
-        })
-        .eq('id', sourceId)
-        .eq('user_id', userId);
     };
 
     // @ts-expect-error - EdgeRuntime is available in Deno Deploy
@@ -161,14 +263,14 @@ Deno.serve(async (req) => {
         jobId,
         message: `Fireflies sync job started for ${transcriptIds.length} transcripts`,
       }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
   } catch (error) {
-    console.error('Error syncing Fireflies transcripts:', error);
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(
-      JSON.stringify({ error: message }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-    );
+    console.error("Error syncing Fireflies transcripts:", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 });

--- a/supabase/functions/fireflies-webhook/__tests__/signature.test.ts
+++ b/supabase/functions/fireflies-webhook/__tests__/signature.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeHmacSha256Signature,
+  timingSafeEqualString,
+} from "../../_shared/webhook-signing";
+
+describe("webhook signing — computeHmacSha256Signature", () => {
+  it("produces the canonical sha256= hex string for a known body/secret pair", async () => {
+    // Reference value computed via:
+    //   node -e "console.log(require('crypto').createHmac('sha256','shh').update('{}').digest('hex'))"
+    const expectedHex =
+      "9b7038c05edccf643d722b52dbaf2cea2b159caf339a5e12c0356e0b8b7b0794";
+    const signature = await computeHmacSha256Signature("{}", "shh");
+    expect(signature).toBe(`sha256=${expectedHex}`);
+  });
+
+  it("produces different signatures for different bodies", async () => {
+    const a = await computeHmacSha256Signature(
+      '{"meeting_id":"abc"}',
+      "secret",
+    );
+    const b = await computeHmacSha256Signature(
+      '{"meeting_id":"xyz"}',
+      "secret",
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("produces different signatures for different secrets on the same body", async () => {
+    const body = '{"meeting_id":"abc"}';
+    const a = await computeHmacSha256Signature(body, "secret-one");
+    const b = await computeHmacSha256Signature(body, "secret-two");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("webhook signing — timingSafeEqualString", () => {
+  it("returns true for identical strings", () => {
+    const sig = "sha256=deadbeef";
+    expect(timingSafeEqualString(sig, sig)).toBe(true);
+  });
+
+  it("returns false when bodies have been tampered with (same length, different content)", async () => {
+    const expected = await computeHmacSha256Signature(
+      '{"meeting_id":"abc"}',
+      "shh",
+    );
+    const tampered = await computeHmacSha256Signature(
+      '{"meeting_id":"def"}',
+      "shh",
+    );
+    // Both are sha256=<64 hex>; identical length, mismatched content.
+    expect(expected.length).toBe(tampered.length);
+    expect(timingSafeEqualString(expected, tampered)).toBe(false);
+  });
+
+  it("returns false when lengths differ (defensive case for malformed input)", () => {
+    expect(
+      timingSafeEqualString("sha256=deadbeef", "sha256=deadbeefcafe"),
+    ).toBe(false);
+  });
+
+  it("returns true for two equal empty strings (degenerate but legal input)", () => {
+    expect(timingSafeEqualString("", "")).toBe(true);
+  });
+});

--- a/supabase/functions/fireflies-webhook/index.ts
+++ b/supabase/functions/fireflies-webhook/index.ts
@@ -1,6 +1,18 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { fetchFirefliesTranscript, firefliesTranscriptToCanonical } from '../_shared/fireflies-connector.ts';
-import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  fetchFirefliesTranscript,
+  firefliesTranscriptToCanonical,
+} from "../_shared/fireflies-connector.ts";
+import {
+  getDecryptedFirefliesSourceByPathToken,
+  listDecryptedActiveFirefliesSources,
+  type DecryptedFirefliesCredentials,
+} from "../_shared/fireflies-credentials.ts";
+import { runCanonicalConnectorPipeline } from "../_shared/recording-connectors.ts";
+import {
+  computeHmacSha256Signature,
+  timingSafeEqualString,
+} from "../_shared/webhook-signing.ts";
 
 interface FirefliesWebhookEvent {
   event?: string;
@@ -9,114 +21,186 @@ interface FirefliesWebhookEvent {
   client_reference_id?: string;
 }
 
-interface FirefliesSourceRow {
-  id: string;
-  user_id: string;
-  api_key: string | null;
-  webhook_signing_secret: string | null;
-  webhook_path_token?: string | null;
-}
+// Server-to-server webhook — keep the wildcard origin (Fireflies calls us from
+// arbitrary IPs, not a browser), but echo the same Allow-Headers list that the
+// rest of our edge functions advertise so sentry-trace/baggage headers from
+// any future Fireflies retry tooling are accepted.
+const WEBHOOK_CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, sentry-trace, baggage, x-hub-signature",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
 
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-hub-signature' } });
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: WEBHOOK_CORS_HEADERS });
   }
 
   try {
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, serviceRoleKey);
 
     const rawBody = await req.text();
-    const signature = req.headers.get('X-Hub-Signature') || req.headers.get('x-hub-signature') || '';
+    const signature =
+      req.headers.get("X-Hub-Signature") ||
+      req.headers.get("x-hub-signature") ||
+      "";
     if (!signature) {
-      return new Response(JSON.stringify({ error: 'Missing X-Hub-Signature header' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+      return new Response(
+        JSON.stringify({ error: "Missing X-Hub-Signature header" }),
+        {
+          status: 401,
+          headers: {
+            ...WEBHOOK_CORS_HEADERS,
+            "Content-Type": "application/json",
+          },
+        },
+      );
     }
 
     const webhookPathToken = extractWebhookPathToken(req.url);
     const matchedSource = webhookPathToken
-      ? await findMatchingSourceByPathToken(supabase, rawBody, signature, webhookPathToken)
+      ? await findMatchingSourceByPathToken(
+          supabase,
+          rawBody,
+          signature,
+          webhookPathToken,
+        )
       : await findMatchingSourceBySignatureScan(supabase, rawBody, signature);
     if (!matchedSource || !matchedSource.api_key) {
-      return new Response(JSON.stringify({ error: 'No matching Fireflies webhook secret configured' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+      return new Response(
+        JSON.stringify({
+          error: "No matching Fireflies webhook secret configured",
+        }),
+        {
+          status: 401,
+          headers: {
+            ...WEBHOOK_CORS_HEADERS,
+            "Content-Type": "application/json",
+          },
+        },
+      );
     }
 
     const payload = JSON.parse(rawBody) as FirefliesWebhookEvent;
     if (!payload.meeting_id) {
-      return new Response(JSON.stringify({ error: 'meeting_id is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      return new Response(JSON.stringify({ error: "meeting_id is required" }), {
+        status: 400,
+        headers: {
+          ...WEBHOOK_CORS_HEADERS,
+          "Content-Type": "application/json",
+        },
+      });
     }
-    if (payload.event !== 'meeting.transcribed' && payload.event !== 'meeting.summarized') {
-      return new Response(JSON.stringify({ success: true, ignored: true, event: payload.event ?? null }), { headers: { 'Content-Type': 'application/json' } });
+    if (
+      payload.event !== "meeting.transcribed" &&
+      payload.event !== "meeting.summarized"
+    ) {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          ignored: true,
+          event: payload.event ?? null,
+        }),
+        {
+          headers: {
+            ...WEBHOOK_CORS_HEADERS,
+            "Content-Type": "application/json",
+          },
+        },
+      );
     }
 
-    const transcript = await fetchFirefliesTranscript(matchedSource.api_key, payload.meeting_id);
+    const transcript = await fetchFirefliesTranscript(
+      matchedSource.api_key,
+      payload.meeting_id,
+    );
     const canonical = firefliesTranscriptToCanonical(transcript);
-    const result = await runCanonicalConnectorPipeline(supabase, matchedSource.user_id, canonical, {
-      importSource: 'fireflies-webhook',
-      includeRawPayload: true,
-    });
+    const result = await runCanonicalConnectorPipeline(
+      supabase,
+      matchedSource.user_id,
+      canonical,
+      {
+        importSource: "fireflies-webhook",
+        includeRawPayload: true,
+      },
+    );
 
     await supabase
-      .from('import_sources')
+      .from("import_sources")
       .update({
         last_sync_at: new Date().toISOString(),
-        error_message: result.success || result.skipped ? null : result.error ?? 'Webhook import failed',
+        error_message:
+          result.success || result.skipped
+            ? null
+            : (result.error ?? "Webhook import failed"),
       })
-      .eq('id', matchedSource.id)
-      .eq('user_id', matchedSource.user_id);
+      .eq("id", matchedSource.id)
+      .eq("user_id", matchedSource.user_id);
 
-    return new Response(JSON.stringify({ success: result.success, skipped: result.skipped ?? false, recordingId: result.recordingId ?? null }), {
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({
+        success: result.success,
+        skipped: result.skipped ?? false,
+        recordingId: result.recordingId ?? null,
+      }),
+      {
+        headers: {
+          ...WEBHOOK_CORS_HEADERS,
+          "Content-Type": "application/json",
+        },
+      },
+    );
   } catch (error) {
-    console.error('Fireflies webhook error:', error);
-    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    console.error("Fireflies webhook error:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: {
+          ...WEBHOOK_CORS_HEADERS,
+          "Content-Type": "application/json",
+        },
+      },
+    );
   }
 });
 
 async function findMatchingSourceByPathToken(
-  supabase: any,
+  supabase: ReturnType<typeof createClient>,
   rawBody: string,
   actualSignature: string,
   webhookPathToken: string,
-): Promise<FirefliesSourceRow | null> {
-  const { data: source, error } = await supabase
-    .from('import_sources')
-    .select('id, user_id, api_key, webhook_signing_secret, webhook_path_token')
-    .eq('source_app', 'fireflies')
-    .eq('is_active', true)
-    .eq('webhook_path_token', webhookPathToken)
-    .maybeSingle();
-
-  if (error) throw error;
-  const typedSource = source as FirefliesSourceRow | null;
-  if (!typedSource?.webhook_signing_secret) return null;
-
-  const expected = await computeSignature(rawBody, typedSource.webhook_signing_secret);
-  return timingSafeEqual(expected, actualSignature) ? typedSource : null;
+): Promise<DecryptedFirefliesCredentials | null> {
+  const source = await getDecryptedFirefliesSourceByPathToken(
+    supabase,
+    webhookPathToken,
+  );
+  if (!source?.webhook_signing_secret) return null;
+  const expected = await computeHmacSha256Signature(
+    rawBody,
+    source.webhook_signing_secret,
+  );
+  return timingSafeEqualString(expected, actualSignature) ? source : null;
 }
 
 async function findMatchingSourceBySignatureScan(
-  supabase: any,
+  supabase: ReturnType<typeof createClient>,
   rawBody: string,
   actualSignature: string,
-): Promise<FirefliesSourceRow | null> {
-  const { data: sources, error } = await supabase
-    .from('import_sources')
-    .select('id, user_id, api_key, webhook_signing_secret')
-    .eq('source_app', 'fireflies')
-    .eq('is_active', true)
-    .not('webhook_signing_secret', 'is', null);
-
-  if (error) throw error;
-
-  for (const source of (sources ?? []) as FirefliesSourceRow[]) {
+): Promise<DecryptedFirefliesCredentials | null> {
+  const sources = await listDecryptedActiveFirefliesSources(supabase);
+  for (const source of sources) {
     if (!source.webhook_signing_secret) continue;
-    const expected = await computeSignature(rawBody, source.webhook_signing_secret);
-    if (timingSafeEqual(expected, actualSignature)) {
+    const expected = await computeHmacSha256Signature(
+      rawBody,
+      source.webhook_signing_secret,
+    );
+    if (timingSafeEqualString(expected, actualSignature)) {
       return source;
     }
   }
@@ -127,27 +211,4 @@ function extractWebhookPathToken(requestUrl: string): string | null {
   const pathname = new URL(requestUrl).pathname;
   const match = pathname.match(/\/fireflies-webhook\/(ffwh_[a-f0-9]{32})\/?$/);
   return match?.[1] ?? null;
-}
-
-async function computeSignature(rawBody: string, secret: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    'raw',
-    encoder.encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  );
-  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
-  const hex = Array.from(new Uint8Array(signature)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
-  return `sha256=${hex}`;
-}
-
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let mismatch = 0;
-  for (let i = 0; i < a.length; i += 1) {
-    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return mismatch === 0;
 }

--- a/supabase/migrations/20260524000000_encrypt_fireflies_credentials.sql
+++ b/supabase/migrations/20260524000000_encrypt_fireflies_credentials.sql
@@ -1,0 +1,276 @@
+-- Migration: Encrypt Fireflies credentials at rest
+-- Purpose: Encrypt `import_sources.api_key` and
+--          `import_sources.webhook_signing_secret` for the Fireflies source
+--          using the existing pgcrypto `encrypt_token` / `decrypt_token`
+--          helpers from migration 20260509000001. Adds RPCs that the
+--          fireflies-* edge functions use to read/write the encrypted values.
+-- Author: Fireflies cleanup PR — 2026-05-24
+--
+-- Encryption key: passed in by each call as `p_encryption_key`. Edge functions
+-- read it from the OAUTH_ENCRYPTION_KEY Supabase secret. The same key already
+-- protects OAuth tokens; reusing it keeps key rotation a single operation.
+--
+-- Backward compatibility: `decrypt_token()` returns the raw value if its input
+-- is not PGP-armored, so plaintext rows from before this migration continue
+-- to read correctly until the one-shot encrypt_existing_fireflies_credentials()
+-- backfill runs.
+
+BEGIN;
+
+-- ============================================================================
+-- INDEX cleanup
+-- ============================================================================
+-- The unique index on plaintext `webhook_signing_secret` is meaningless once
+-- the column is encrypted with pgp_sym_encrypt (each row encrypts to a
+-- different ciphertext for the same plaintext because of the random IV). The
+-- webhook_path_token unique index — added in the same prior migration — is
+-- what actually scopes incoming webhooks now.
+DROP INDEX IF EXISTS idx_import_sources_fireflies_webhook_secret_unique;
+
+-- ============================================================================
+-- RPC: get_decrypted_fireflies_source_for_user
+-- ============================================================================
+-- Returns the most-recently-updated active Fireflies source for a user with
+-- credentials decrypted. Used by fireflies-fetch-meetings and
+-- fireflies-sync-meetings.
+CREATE OR REPLACE FUNCTION get_decrypted_fireflies_source_for_user(
+  p_user_id UUID,
+  p_encryption_key TEXT
+)
+RETURNS TABLE(
+  id BIGINT,
+  user_id UUID,
+  api_key TEXT,
+  webhook_signing_secret TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    s.id,
+    s.user_id,
+    decrypt_token(s.api_key, p_encryption_key) AS api_key,
+    decrypt_token(s.webhook_signing_secret, p_encryption_key) AS webhook_signing_secret
+  FROM import_sources s
+  WHERE s.user_id = p_user_id
+    AND s.source_app = 'fireflies'
+    AND s.is_active = TRUE
+  ORDER BY s.updated_at DESC
+  LIMIT 1;
+END;
+$$;
+
+COMMENT ON FUNCTION get_decrypted_fireflies_source_for_user IS
+'Returns the active Fireflies source for a user with api_key and webhook_signing_secret decrypted. Falls back to plaintext via decrypt_token() for pre-encryption rows.';
+
+-- ============================================================================
+-- RPC: get_decrypted_fireflies_source_by_path_token
+-- ============================================================================
+-- Look up the Fireflies source for an incoming webhook addressed by its
+-- per-source path token. Returns credentials decrypted.
+CREATE OR REPLACE FUNCTION get_decrypted_fireflies_source_by_path_token(
+  p_path_token TEXT,
+  p_encryption_key TEXT
+)
+RETURNS TABLE(
+  id BIGINT,
+  user_id UUID,
+  api_key TEXT,
+  webhook_signing_secret TEXT,
+  webhook_path_token TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    s.id,
+    s.user_id,
+    decrypt_token(s.api_key, p_encryption_key) AS api_key,
+    decrypt_token(s.webhook_signing_secret, p_encryption_key) AS webhook_signing_secret,
+    s.webhook_path_token
+  FROM import_sources s
+  WHERE s.source_app = 'fireflies'
+    AND s.is_active = TRUE
+    AND s.webhook_path_token = p_path_token
+  LIMIT 1;
+END;
+$$;
+
+COMMENT ON FUNCTION get_decrypted_fireflies_source_by_path_token IS
+'Resolves an active Fireflies source by webhook_path_token with credentials decrypted. Used by fireflies-webhook.';
+
+-- ============================================================================
+-- RPC: list_decrypted_active_fireflies_sources
+-- ============================================================================
+-- Returns every active Fireflies source whose webhook_signing_secret is set,
+-- with credentials decrypted. Used by the legacy signature-scan fallback in
+-- fireflies-webhook for senders that don't include a path token.
+CREATE OR REPLACE FUNCTION list_decrypted_active_fireflies_sources(
+  p_encryption_key TEXT
+)
+RETURNS TABLE(
+  id BIGINT,
+  user_id UUID,
+  api_key TEXT,
+  webhook_signing_secret TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    s.id,
+    s.user_id,
+    decrypt_token(s.api_key, p_encryption_key) AS api_key,
+    decrypt_token(s.webhook_signing_secret, p_encryption_key) AS webhook_signing_secret
+  FROM import_sources s
+  WHERE s.source_app = 'fireflies'
+    AND s.is_active = TRUE
+    AND s.webhook_signing_secret IS NOT NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION list_decrypted_active_fireflies_sources IS
+'Lists active Fireflies sources with credentials decrypted. Used by the legacy webhook signature-scan path; prefer the path-token resolver where possible.';
+
+-- ============================================================================
+-- RPC: store_encrypted_fireflies_credentials
+-- ============================================================================
+-- Upserts a Fireflies import_sources row with the api_key and
+-- webhook_signing_secret encrypted at rest. Returns the row id. Called from
+-- fireflies-save-source.
+CREATE OR REPLACE FUNCTION store_encrypted_fireflies_credentials(
+  p_source_id BIGINT,
+  p_user_id UUID,
+  p_account_email TEXT,
+  p_api_key TEXT,
+  p_webhook_signing_secret TEXT,
+  p_webhook_path_token TEXT,
+  p_encryption_key TEXT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_id BIGINT;
+BEGIN
+  IF p_source_id IS NOT NULL THEN
+    UPDATE import_sources
+    SET
+      account_email = p_account_email,
+      api_key = encrypt_token(p_api_key, p_encryption_key),
+      webhook_signing_secret = encrypt_token(p_webhook_signing_secret, p_encryption_key),
+      webhook_path_token = p_webhook_path_token,
+      is_active = TRUE,
+      error_message = NULL,
+      updated_at = NOW()
+    WHERE id = p_source_id
+      AND user_id = p_user_id
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'Fireflies source % not found for user %', p_source_id, p_user_id
+        USING ERRCODE = 'no_data_found';
+    END IF;
+  ELSE
+    INSERT INTO import_sources (
+      user_id,
+      source_app,
+      account_email,
+      api_key,
+      webhook_signing_secret,
+      webhook_path_token,
+      is_active,
+      error_message,
+      updated_at
+    )
+    VALUES (
+      p_user_id,
+      'fireflies',
+      p_account_email,
+      encrypt_token(p_api_key, p_encryption_key),
+      encrypt_token(p_webhook_signing_secret, p_encryption_key),
+      p_webhook_path_token,
+      TRUE,
+      NULL,
+      NOW()
+    )
+    RETURNING id INTO v_id;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION store_encrypted_fireflies_credentials IS
+'Upserts a Fireflies import_sources row with api_key and webhook_signing_secret encrypted at rest via encrypt_token().';
+
+-- ============================================================================
+-- RPC: encrypt_existing_fireflies_credentials (one-shot backfill)
+-- ============================================================================
+-- Encrypts every plaintext Fireflies api_key and webhook_signing_secret
+-- in-place. Idempotent — skips rows that look already-armored.
+-- Run manually after deploy:
+--   SELECT encrypt_existing_fireflies_credentials('<OAUTH_ENCRYPTION_KEY_value>');
+CREATE OR REPLACE FUNCTION encrypt_existing_fireflies_credentials(p_key TEXT)
+RETURNS JSON
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_count INT := 0;
+BEGIN
+  UPDATE import_sources
+  SET
+    api_key = CASE
+      WHEN api_key IS NOT NULL
+       AND api_key NOT LIKE '-----BEGIN PGP MESSAGE-----%'
+      THEN encrypt_token(api_key, p_key)
+      ELSE api_key
+    END,
+    webhook_signing_secret = CASE
+      WHEN webhook_signing_secret IS NOT NULL
+       AND webhook_signing_secret NOT LIKE '-----BEGIN PGP MESSAGE-----%'
+      THEN encrypt_token(webhook_signing_secret, p_key)
+      ELSE webhook_signing_secret
+    END
+  WHERE source_app = 'fireflies'
+    AND (
+      (api_key IS NOT NULL AND api_key NOT LIKE '-----BEGIN PGP MESSAGE-----%')
+      OR
+      (webhook_signing_secret IS NOT NULL
+       AND webhook_signing_secret NOT LIKE '-----BEGIN PGP MESSAGE-----%')
+    );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  RETURN json_build_object('fireflies_rows_encrypted', v_count);
+END;
+$$;
+
+COMMENT ON FUNCTION encrypt_existing_fireflies_credentials IS
+'One-shot backfill — encrypts plaintext Fireflies api_key and webhook_signing_secret in-place. Idempotent. Run with the OAUTH_ENCRYPTION_KEY value after deploy.';
+
+-- ============================================================================
+-- VIEW: fireflies_credential_encryption_status (ops visibility)
+-- ============================================================================
+CREATE OR REPLACE VIEW fireflies_credential_encryption_status AS
+SELECT
+  COUNT(*) FILTER (
+    WHERE (api_key IS NOT NULL AND api_key NOT LIKE '-----BEGIN PGP MESSAGE-----%')
+       OR (webhook_signing_secret IS NOT NULL
+           AND webhook_signing_secret NOT LIKE '-----BEGIN PGP MESSAGE-----%')
+  ) AS plaintext_rows,
+  COUNT(*) FILTER (
+    WHERE api_key LIKE '-----BEGIN PGP MESSAGE-----%'
+       OR webhook_signing_secret LIKE '-----BEGIN PGP MESSAGE-----%'
+  ) AS encrypted_rows,
+  COUNT(*) AS total_rows
+FROM import_sources
+WHERE source_app = 'fireflies';
+
+COMMENT ON VIEW fireflies_credential_encryption_status IS
+'Ops view: counts plaintext vs PGP-armored Fireflies credential rows. Query before and after running encrypt_existing_fireflies_credentials().';
+
+COMMIT;


### PR DESCRIPTION
## Why

Fireflies feature shipped to `main` with 5 review-branch CRIT/HIGH findings and 15 additional findings from a follow-up review. None of them had been fixed in code — only surfaced as comments. This PR closes the real ones and skips the noise.

## What's in scope

### 🔴 Original review-branch findings (all 5)
1. **CRIT** — Webhook HMAC signature verification (`computeSignature`, `timingSafeEqual`) had zero tests → extracted into `_shared/webhook-signing.ts`, 7 cases covering known reference value, body/secret variation, tamper detection, length-mismatch defense, degenerate empty input.
2. **HIGH** — `processSyncJob` had no outer try/catch → wrapped; the `sync_jobs` row now gets marked `failed` even if the loop itself throws, so the frontend poller stops instead of seeing `processing` forever.
3. **HIGH** — Unguarded `.map()` in `fireflies-fetch-meetings` returned HTTP 500 on a single bad row → per-item try/catch drops the bad row, logs context, keeps the listing alive.
4. **HIGH** — Webhook URL hardcoded to `api.callvaultai.com` in the import UI → reads `VITE_API_BASE_URL` (falls back to prod when unset). `.env.example` documents it.
5. **HIGH** — Workspace membership DB error silently routed to default workspace → DB error returns **500**, missing membership returns **403**. User's workspace selection is never silently dropped.

### 🟥 Follow-up review (the real ones)
- **CRIT** — `api_key` and `webhook_signing_secret` stored plaintext → encrypted at rest via the existing `pgcrypto` `encrypt_token()`/`decrypt_token()` helpers (migration `20260524000000`). New SECURITY DEFINER RPCs + a one-shot `encrypt_existing_fireflies_credentials()` backfill + a `fireflies_credential_encryption_status` view for ops.
- **CRIT** — No Zod validation on the API key → `SaveSourceSchema` enforces length (24–128) + printable-ASCII format. `fetchFirefliesUser()` remains the authoritative check.
- **CRIT** — No batch size limit on sync → capped at 50 (matches fetch-meetings pagination and the Fathom connector). Returns 400 above the cap.
- **HIGH** — Frontend polling no timeout → 5-minute hard cap with a user-facing toast and cache invalidation.
- **MED** — `coerceFirefliesDate` / `normalizeDurationSeconds` duplicated → exported from `_shared/fireflies-connector.ts`, edge function imports them.
- **LOW** — `fetch-meetings` selecting `webhook_signing_secret` it never used → removed.

### 🟦 Explicitly skipped (with rationale)
- **Webhook wildcard CORS** — server-to-server, Fireflies calls from arbitrary IPs. The wildcard is correct; the Allow-Headers list is now consistent with `getCorsHeaders()`.
- **Webhook O(n) signature scan** — the `webhook_path_token` resolver is the happy path and is O(1). The scan only runs for legacy senders without a path token. Don't optimize what we're about to delete.
- **Query invalidation scope** — perf nit, defer until profiling says it matters.
- **`handleImport` stale-closure** — original reviewer marked "fine for now."
- **`timingSafeEqual` length leak** — reviewer conceded "actually fine as-is." Documented in the new helper's JSDoc.
- **`save-source` TOCTOU** — better solved by a UNIQUE constraint in a separate migration; out of scope here.
- **Full edge-function + component test suite** — separate sprint, not a cleanup-PR scope.

## What's new

| File | Purpose |
|---|---|
| `supabase/migrations/20260524000000_encrypt_fireflies_credentials.sql` | RPCs + backfill + ops view for encrypted Fireflies credentials |
| `supabase/functions/_shared/webhook-signing.ts` | `computeHmacSha256Signature` + `timingSafeEqualString` |
| `supabase/functions/_shared/fireflies-credentials.ts` | Encrypted read/write wrappers (RPC + plaintext fallback) |
| `supabase/functions/fireflies-webhook/__tests__/signature.test.ts` | 7 HMAC test cases |

## What's modified

| File | Change |
|---|---|
| `supabase/functions/_shared/fireflies-connector.ts` | Export `coerceFirefliesDate` + `normalizeDurationSeconds` for reuse + testability |
| `supabase/functions/_shared/__tests__/fireflies-connector.test.ts` | +12 cases: `fetchFirefliesUser` paths, epoch seconds/ms branch, duration normalization |
| `supabase/functions/fireflies-save-source/index.ts` | Zod validation + encrypted credential store |
| `supabase/functions/fireflies-sync-meetings/index.ts` | Decryption + batch cap + workspace 500/403 + outer try/catch |
| `supabase/functions/fireflies-fetch-meetings/index.ts` | Decryption + drop unused select + shared utils + per-item catch |
| `supabase/functions/fireflies-webhook/index.ts` | Use new credential + signing helpers; allow-list parity with `getCorsHeaders()` |
| `src/components/import/FirefliesImportDetail.tsx` | Env-derived webhook URL + 5-min poll timeout |
| `.env.example` | Document `VITE_API_BASE_URL` |

## Deploy steps

1. **Deploy code + apply migration.** New rows are written encrypted automatically.
2. **One-shot backfill for existing rows** (idempotent — safe to re-run):
   ```sql
   SELECT encrypt_existing_fireflies_credentials('<OAUTH_ENCRYPTION_KEY value>');
   SELECT * FROM fireflies_credential_encryption_status;
   ```
   Expected: `plaintext_rows = 0` after the call.
3. **Set `VITE_API_BASE_URL`** in staging/preview environments so the UI renders the correct webhook URL there. Prod defaults to `https://api.callvaultai.com` when unset; no change needed.

## Validation

- ✅ `npm run type-check` — clean
- ✅ `npm run lint` — 0 errors (216 pre-existing warnings, all in unrelated files)
- ✅ `npm run build` — clean
- ✅ `npm test -- supabase/functions/fireflies-webhook supabase/functions/_shared/__tests__/fireflies-connector.test.ts` — **19/19 pass** (7 HMAC + 12 connector)
- ⚠️ One pre-existing flaky integration test (`auto-tag-calls.integration.test.ts`) fails on duplicate-key during seed — this is the cleanup-not-running issue Don already flagged on 2026-05-22; not touched by this PR.

## Risk

- **Migration is additive** — RPCs + view + index drop. The dropped index (`idx_import_sources_fireflies_webhook_secret_unique`) is meaningless once the column is ciphertext (`pgp_sym_encrypt` uses a random IV, same plaintext → different ciphertext every time). `webhook_path_token`'s unique index is what actually scopes inbound webhooks.
- **Mixed-state reads are safe** — `decrypt_token()` returns the raw value when its input isn't PGP-armored, so plaintext rows continue to work until the backfill runs.
- **No breaking API contracts** — all edge-function request/response shapes are unchanged.
