### PR TITLE
feat(connectors): Composio meta-integration layer — framework + adapter scaffold

### DIFF
--- a/docs/adr/adr-006-composio-selective-adoption.md
+++ b/docs/adr/adr-006-composio-selective-adoption.md
@@ -1,0 +1,72 @@
+# ADR-006: Composio selective adoption for integration platform sources
+
+- **Status:** Accepted (Phase B — scaffolded 2026-05-23)
+- **Date:** 2026-05-23
+- **Authors:** AI-assisted, reviewed by Andrew Naegele
+- **Supersedes:** —
+- **Related:** [ADR-001 Vercel AI SDK](./adr-001-vercel-ai-sdk.md), `docs/specs/SPEC-connector-framework.md`, `docs/integrations/03-connector-sop.md`
+
+> **NOTE:** This ADR is a STUB. It captures the decisions currently asserted by code-comments and PR descriptions in PR #279. Expand to the full ADR template (`adr-template.md`) when the Composio integration moves out of scaffold and into pilot.
+
+---
+
+## Context
+
+CallVault currently ships native connectors for Fathom, Fireflies, Zoom, Plaud, and YouTube. Each native connector owns its OAuth flow, token refresh, webhook signing, retry, and pagination. The marginal cost of adding the next native connector (Otter, Avoma, Grain, Read.ai, Chorus, Gong, Dialpad, Webex, Microsoft Teams, Google Meet) is dominated by per-vendor auth + webhook engineering rather than canonical-pipeline mapping work.
+
+Composio (composio.dev) provides a meta-integration platform: it owns OAuth registration, token refresh, and webhook delivery for ~250 vendors and re-emits a uniform trigger envelope. Adopting it for every vendor would lock CallVault into Composio's roadmap; adopting it for none would force CallVault to spend per-vendor engineering on commoditized auth glue.
+
+## Decision
+
+CallVault adopts Composio **selectively**, not wholesale.
+
+1. **Native sources stay native.** Fathom, Fireflies, Zoom, Plaud, YouTube remain on their dedicated edge functions and Composio is not introduced into their paths.
+2. **Composio targets the enterprise call-platform tier.** Initial in-scope vendors: **Gong, Dialpad, Webex, Microsoft Teams, Google Meet**. These share three traits — substantial per-vendor OAuth complexity, webhook delivery, and Composio first-class support.
+3. **Selective adoption requires a connector framework.** A dispatcher edge function (`connector-dispatcher`) routes `{ source, action }` to registered adapters. Adapters declare `adapter: 'native' | 'composio'`. The canonical recording pipeline is unchanged — every adapter terminates in `runCanonicalConnectorPipeline`.
+4. **Webhook policy:** Composio deliveries are HMAC-SHA256 signed; signature verification uses the same constant-time-compare pattern as fireflies-webhook. Unmatched `connected_account_id` returns **HTTP 200 ignored** (anti-enumeration, matches fireflies-webhook precedent) — Composio retries on non-2xx, so 4xx/5xx for unknown accounts would either leak which accounts exist or create infinite retry storms.
+5. **Storage:** Composio's `connected_account_id` lives on a dedicated `import_sources.composio_connected_account_id` column with a partial unique index, NOT inside the `connection_metadata` JSONB blob. The JSONB blob remains shared infrastructure for other adapters.
+
+## Acceptance criteria (success gate for Phase B exit)
+
+The Composio framework is accepted when:
+
+- **Otter native ≤ 2 days** of focused work to add (proves the native-side scaffolding holds).
+- **Gong via Composio ≤ 1 day** of focused work to add (proves the Composio-side scaffolding holds).
+- At least one Composio-routed source passes end-to-end against a live Composio account and lands a canonical recording.
+- Anti-enumeration posture verified: webhook returns 200 ignored on unknown accounts in production traffic.
+
+## Consequences
+
+**Positive:**
+
+- Per-vendor engineering for in-scope Composio targets compresses from days to hours (auth + webhook is Composio's surface).
+- Migration plan is reversible — Composio adapters can be re-implemented natively if Composio's product diverges from CallVault's needs.
+- Native connectors are unaffected; risk is bounded to in-scope vendors.
+
+**Negative:**
+
+- Composio is a new vendor dependency for these sources. Outage on Composio's side = outage for CallVault's Gong/Dialpad/Webex paths.
+- Two integration models now exist; reviewers need to know which path applies. Mitigated by SPEC-connector-framework.md and the SOP appendix.
+- Composio's pricing scales per workspace-connection — economics need a periodic review.
+
+## Out of scope (for this ADR)
+
+- Fireflies-via-Composio (Fireflies is already native and works).
+- Migrating native connectors backward to Composio.
+- Composio's polling-based adapter pattern for vendors with zero trigger support — covered by SPEC-connector-framework.md when adopted.
+
+## Rollout
+
+Phase A (this PR): scaffold. The dispatcher, adapter interface, and three vendor normalizers exist but are NOT wired into the production import path. `@composio-unverified` tag marks every call site that requires live-traffic confirmation.
+
+Phase B (next): pilot Gong via Composio against a real workspace.
+
+Phase C: open the gate for additional Composio targets (Dialpad, Webex, MS Teams, Google Meet) one vendor at a time.
+
+## References
+
+- `docs/specs/SPEC-connector-framework.md` — dispatcher contract, adapter interface
+- `docs/integrations/03-connector-sop.md` — Composio adapter appendix
+- `supabase/functions/_shared/connector-framework.ts` — discriminated request shape
+- `supabase/functions/composio-trigger-webhook/index.ts` — webhook ingress
+- `supabase/migrations/20260523192117_composio_integration_ids.sql` — storage column

--- a/docs/source-connector-gap-analysis.md
+++ b/docs/source-connector-gap-analysis.md
@@ -285,8 +285,8 @@ From the current matrix:
 3. **Extract transcript normalization**
    - one helper used by Fireflies, Grain, Riverside, etc.
 
-4. **Create source registry for import surfaces**
-   - reduce hardcoded UI branching
+4. **Create source registry for import surfaces** — shipped in PR #279
+   - registry-driven add-source UI reduces hardcoded branching
 
 5. **Use Fireflies and Grain as proof vendors**
    - if both fit with little special casing, the abstraction is probably real

--- a/docs/source-connector-spec.md
+++ b/docs/source-connector-spec.md
@@ -19,6 +19,7 @@ They are not identical today.
 
 - Pipeline insert path: `supabase/functions/_shared/connector-pipeline.ts:197-215`
 - Canonical draft wrapper: `supabase/functions/_shared/canonical-recording.ts`
+- Connector framework contract: `docs/specs/SPEC-connector-framework.md`
 - Meeting mapping into UI: `src/hooks/useWorkspaces.ts:357-415`
 - Summary generation/caching: `supabase/functions/summarize-call/index.ts:175-344`
 - AI title generation: `supabase/functions/generate-ai-titles/index.ts`

--- a/docs/specs/SPEC-connector-framework.md
+++ b/docs/specs/SPEC-connector-framework.md
@@ -1,0 +1,106 @@
+# SPEC: Connector framework (dispatcher + adapter contract)
+
+- **Status:** Draft (Phase B — scaffolded 2026-05-23)
+- **Related:** [ADR-006 Composio selective adoption](../adr/adr-006-composio-selective-adoption.md), `docs/integrations/03-connector-sop.md`
+
+> **NOTE:** This SPEC is a STUB. It captures the contract the scaffold in PR #279 already implements. Expand each section to operator-grade detail when the framework moves out of scaffold and into pilot.
+
+---
+
+## Purpose
+
+Defines the shared dispatcher + adapter layer that sits above the canonical recording pipeline. Native and Composio-routed connectors both terminate in `runCanonicalConnectorPipeline`; this framework defines how requests arrive at the right adapter and what an adapter implementation must expose.
+
+## Surfaces
+
+| Surface | Path | Purpose |
+|---------|------|---------|
+| Frontend registry | `src/config/source-registry.ts` | Source identity, label, icon, `adapter: 'native' \| 'composio'`, optional `composioToolkit` slug |
+| Backend dispatcher | `supabase/functions/connector-dispatcher/index.ts` | Routes `{ source, action }` to a registered adapter |
+| Adapter contract | `supabase/functions/_shared/connector-framework.ts` | `ConnectorAdapter` interface + adapter registry |
+| Canonical recording shape | `supabase/functions/_shared/canonical-recording.ts` | Unchanged — every adapter's terminal output |
+| Pipeline | `supabase/functions/_shared/recording-connectors.ts` → `connector-pipeline.ts` | Hard-insert path, deduplication, workspace routing |
+
+## Dispatcher contract
+
+`POST /connector-dispatcher`
+
+```jsonc
+{
+  "source": "<source_app id from registry>",
+  "action": "connect" | "disconnect" | "fetch" | "sync" | "status",
+  "payload": { /* per-action; dispatcher does not inspect */ }
+}
+```
+
+| Response | When |
+|----------|------|
+| 200 + `{ success: true, ... }` | Adapter executed successfully |
+| 200 + `{ success: false, skipped: true }` | Idempotent dedup — record already exists |
+| 400 | Request shape invalid (missing source, unknown action) |
+| 404 | No adapter registered for `source` |
+| 501 | Adapter exists but does not implement the requested `action` |
+| 500 | Adapter handler threw; sanitized `error.message` returned |
+
+## Adapter interface
+
+```ts
+interface ConnectorAdapter {
+  source: string; // must match a SourceConfig.id on the frontend
+  connect?:    (ctx, request) => Promise<AdapterResult>;
+  disconnect?: (ctx, request) => Promise<AdapterResult>;
+  fetch?:      (ctx, request) => Promise<AdapterResult>;
+  sync?:       (ctx, request) => Promise<AdapterResult>;
+  status?:     (ctx, request) => Promise<AdapterResult>;
+}
+
+interface AdapterResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  skipped?: boolean;
+}
+```
+
+Unimplemented actions return 501 — the dispatcher does not paper over missing handlers.
+
+## Registry change-management
+
+Registry entries are append-only for an adopted source. Removing or renaming a `source_app` value is a data-migration concern, not a code change. New entries MUST:
+
+- Use lowercase-kebab-case for `id` (matches `canonical-recording.ts` `SOURCE_APP_PATTERN`).
+- Declare `adapter`. If `adapter === 'composio'`, also declare `composioToolkit`.
+- Use the existing Remix Icon set (per root CLAUDE.md hard constraint).
+
+A future test (planned per `consolidated-review.md` M7) will pin these invariants at build time so a typo in a new entry surfaces in CI, not on click.
+
+## Native vs Composio adapter expectations
+
+| Concern | Native adapter | Composio adapter |
+|---------|---------------|------------------|
+| OAuth flow | Per-vendor function (`{vendor}-oauth-url`/`{vendor}-oauth-callback`) | `composio-oauth-callback` (single function) |
+| Token refresh | Per-vendor function (`{vendor}-oauth-refresh`) | Composio platform handles refresh |
+| Webhook ingress | Per-vendor function (`{vendor}-webhook`) | `composio-trigger-webhook` (single function, per-toolkit normalizer) |
+| Signature verification | Per-vendor scheme (HMAC, JWT, etc.) | HMAC-SHA256 with `COMPOSIO_WEBHOOK_SECRET` |
+| Storage key | `import_sources.connection_metadata` JSONB + vendor-specific columns | `import_sources.composio_connected_account_id` (typed column, partial unique index) |
+
+## Anti-patterns (rejected before merge)
+
+- An adapter writing directly to `recordings` instead of going through `runCanonicalConnectorPipeline`.
+- Routing identifiers stored in `connection_metadata` JSONB when a typed column exists — bypasses partial unique indexes and breaks `.maybeSingle()` determinism.
+- Returning 5xx for a malformed Composio payload — Composio retries on non-2xx; bad data becomes an infinite retry loop. Return 200 ignored with a redacted `console.error` breadcrumb.
+- Returning 4xx for an unknown `connected_account_id` — leaks which accounts CallVault tracks (anti-enumeration).
+
+## Pilot acceptance criteria
+
+Per ADR-006:
+
+- **Otter native** ≤ 2 days to add — proves the native scaffolding holds.
+- **Gong via Composio** ≤ 1 day to add — proves the Composio scaffolding holds.
+- At least one Composio-routed source passes end-to-end against a live Composio account.
+
+## References
+
+- ADR-006 — selective adoption rationale
+- `docs/integrations/03-connector-sop.md` — the SOP every connector PR is reviewed against (Composio appendix pending)
+- `supabase/functions/_shared/__tests__/connector-framework.test.ts` — dispatcher unit tests

--- a/src/components/import/AddImportSourceDialog.tsx
+++ b/src/components/import/AddImportSourceDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * AddImportSourceDialog — Phase 36-06 BUG-07
+ * AddImportSourceDialog
  *
  * Triggered by the "+" button on ImportSourcePane. Lets the user pick a
  * source to add. Tiles are rendered from `SOURCE_REGISTRY` in

--- a/src/components/import/AddImportSourceDialog.tsx
+++ b/src/components/import/AddImportSourceDialog.tsx
@@ -2,47 +2,21 @@
  * AddImportSourceDialog — Phase 36-06 BUG-07
  *
  * Triggered by the "+" button on ImportSourcePane. Lets the user pick a
- * source to add: Fathom, Zoom, YouTube, File Upload, or Paste Transcript.
- * Each tile, when clicked, closes the dialog and either kicks off the
- * source-specific OAuth flow (Fathom/Zoom) or navigates to the in-app
- * import surface (YouTube/File Upload/Paste).
+ * source to add. Tiles are rendered from `SOURCE_REGISTRY` in
+ * `src/config/source-registry.ts` — adding a new source = adding one
+ * registry entry, no edits to this file required.
  */
 
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import {
-  RiCloudLine,
-  RiVideoLine,
-  RiYoutubeLine,
-  RiUploadCloud2Line,
-  RiClipboardLine,
-} from '@remixicon/react';
-import { cn } from '@/lib/utils';
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { SOURCE_REGISTRY, type SourceId } from "@/config/source-registry";
 
-export type AddImportSourceChoice =
-  | 'fathom'
-  | 'zoom'
-  | 'fireflies'
-  | 'plaud'
-  | 'youtube'
-  | 'file-upload'
-  | 'paste-transcript';
-
-interface SourceTile {
-  id: AddImportSourceChoice;
-  label: string;
-  subtitle: string;
-  icon: React.ComponentType<{ className?: string }>;
-}
-
-const TILES: SourceTile[] = [
-  { id: 'fathom', label: 'Fathom', subtitle: 'Connect your Fathom account via OAuth', icon: RiCloudLine },
-  { id: 'zoom', label: 'Zoom', subtitle: 'Connect Zoom Cloud Recordings via OAuth', icon: RiVideoLine },
-  { id: 'fireflies', label: 'Fireflies', subtitle: 'Import Fireflies transcripts with an API key', icon: RiCloudLine },
-  { id: 'plaud', label: 'Plaud', subtitle: 'Connect Plaud recordings with a web access token', icon: RiCloudLine },
-  { id: 'youtube', label: 'YouTube', subtitle: 'Import calls from public YouTube URLs', icon: RiYoutubeLine },
-  { id: 'file-upload', label: 'File Upload', subtitle: 'Upload audio or video files directly', icon: RiUploadCloud2Line },
-  { id: 'paste-transcript', label: 'Paste Transcript', subtitle: 'Manually paste or upload a transcript', icon: RiClipboardLine },
-];
+export type AddImportSourceChoice = SourceId;
 
 export interface AddImportSourceDialogProps {
   open: boolean;
@@ -66,7 +40,7 @@ export function AddImportSourceDialog({
         </DialogDescription>
 
         <div className="grid grid-cols-1 gap-2 mt-4">
-          {TILES.map(({ id, label, subtitle, icon: Icon }) => (
+          {SOURCE_REGISTRY.map(({ id, label, subtitle, icon: Icon }) => (
             <button
               key={id}
               type="button"
@@ -75,18 +49,22 @@ export function AddImportSourceDialog({
                 onOpenChange(false);
               }}
               className={cn(
-                'flex items-start gap-3 p-3 rounded-lg text-left',
-                'border border-border bg-card',
-                'hover:bg-muted/60 hover:border-foreground/20 transition-colors',
-                'focus:outline-none focus:ring-2 focus:ring-vibe-orange/40',
+                "flex items-start gap-3 p-3 rounded-lg text-left",
+                "border border-border bg-card",
+                "hover:bg-muted/60 hover:border-foreground/20 transition-colors",
+                "focus:outline-none focus:ring-2 focus:ring-vibe-orange/40",
               )}
             >
               <div className="w-9 h-9 rounded-md flex items-center justify-center flex-shrink-0 bg-muted">
                 <Icon className="h-4 w-4 text-foreground" />
               </div>
               <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium text-foreground">{label}</div>
-                <div className="text-xs text-muted-foreground mt-0.5">{subtitle}</div>
+                <div className="text-sm font-medium text-foreground">
+                  {label}
+                </div>
+                <div className="text-xs text-muted-foreground mt-0.5">
+                  {subtitle}
+                </div>
               </div>
             </button>
           ))}

--- a/src/components/import/ConnectorDetailPanel.tsx
+++ b/src/components/import/ConnectorDetailPanel.tsx
@@ -1,0 +1,108 @@
+/**
+ * ConnectorDetailPanel — generic, registry-driven detail surface for
+ * connector-framework sources.
+ *
+ * Status: PARALLEL implementation. The seven existing sources (Fathom,
+ * Fireflies, Zoom, Plaud, YouTube, file-upload, paste-transcript) keep
+ * rendering through their dedicated detail panels in `ImportPage.tsx`. This
+ * panel is the target shape for NEW sources added under the framework.
+ *
+ * Dispatch contract:
+ *   source.adapter === 'native'    → renders <NativeAdapter />
+ *   source.adapter === 'composio'  → renders <ComposioAdapter />  (@composio-unverified)
+ *   source.adapter === 'internal'  → renders a "use the dedicated surface" notice;
+ *                                    internal sources (file-upload, paste-transcript)
+ *                                    don't have an adapter shape — their UI lives
+ *                                    in dedicated components.
+ */
+
+import type { SourceConfig } from "@/config/source-registry";
+import type { ImportSource } from "@/services/import-sources.service";
+import {
+  NativeAdapter,
+  type NativeAdapterActions,
+} from "./adapters/NativeAdapter";
+import { ComposioAdapter } from "./adapters/ComposioAdapter";
+
+export interface ConnectorDetailPanelProps {
+  source: SourceConfig;
+  sourceRow: ImportSource | null;
+  /**
+   * Native-source action handlers. Required when source.adapter === 'native'.
+   * Ignored for other adapters.
+   */
+  nativeActions?: NativeAdapterActions;
+  onDisconnect?: (source: ImportSource) => void;
+  children?: React.ReactNode;
+}
+
+export function ConnectorDetailPanel({
+  source,
+  sourceRow,
+  nativeActions,
+  onDisconnect,
+  children,
+}: ConnectorDetailPanelProps) {
+  if (source.adapter === "composio") {
+    return (
+      <ComposioAdapter
+        source={source}
+        sourceRow={sourceRow}
+        onDisconnect={onDisconnect}
+      />
+    );
+  }
+
+  if (source.adapter === "native") {
+    if (!nativeActions) {
+      return (
+        <UsageError
+          sourceLabel={source.label}
+          reason={`ConnectorDetailPanel was rendered for a native source (${source.id}) without nativeActions. Wire the connect/sync/disconnect handlers.`}
+        />
+      );
+    }
+    return (
+      <NativeAdapter
+        source={source}
+        sourceRow={sourceRow}
+        onConnect={nativeActions.onConnect}
+        onSyncNow={nativeActions.onSyncNow}
+        onDisconnect={nativeActions.onDisconnect ?? onDisconnect}
+      >
+        {children}
+      </NativeAdapter>
+    );
+  }
+
+  // adapter === 'internal' — file-upload, paste-transcript
+  return (
+    <UsageError
+      sourceLabel={source.label}
+      reason={`${source.label} is an internal source and does not flow through ConnectorDetailPanel. Render its dedicated component instead.`}
+    />
+  );
+}
+
+function UsageError({
+  sourceLabel,
+  reason,
+}: {
+  sourceLabel: string;
+  reason: string;
+}) {
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <div className="px-6 py-4 max-w-2xl">
+        <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-4 space-y-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            {sourceLabel} — wiring error
+          </h3>
+          <p className="text-xs text-muted-foreground">{reason}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConnectorDetailPanel;

--- a/src/components/import/adapters/ComposioAdapter.tsx
+++ b/src/components/import/adapters/ComposioAdapter.tsx
@@ -1,0 +1,179 @@
+/**
+ * ComposioAdapter — @composio-unverified
+ *
+ * UI surface for sources whose OAuth + transport are delegated to Composio
+ * (composio.dev). Designed for the enterprise call-platform tier covered by
+ * Composio's catalog: Gong, Dialpad, Webex, Microsoft Teams, Google Meet.
+ *
+ * Status: SCAFFOLD. This component is not exercised end-to-end yet. The
+ * supporting edge functions (`composio-oauth-callback`,
+ * `composio-trigger-webhook`) and Composio account provisioning land in
+ * Phase B per ADR-006. Until Phase B is accepted:
+ *   - This adapter MUST NOT be wired into ImportPage's render path.
+ *   - It MUST NOT be referenced from a registry entry with adapter='composio'
+ *     unless that entry's `status` is 'scaffold'.
+ *
+ * Reviewers: if you see this rendered in production traffic, that is the bug.
+ */
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import type { SourceConfig } from "@/config/source-registry";
+import type { ImportSource } from "@/services/import-sources.service";
+
+export interface ComposioAdapterProps {
+  source: SourceConfig;
+  sourceRow: ImportSource | null;
+  onDisconnect?: (source: ImportSource) => void;
+}
+
+export function ComposioAdapter({
+  source,
+  sourceRow,
+  onDisconnect,
+}: ComposioAdapterProps) {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const composioAccountId = readComposioAccountId(sourceRow);
+  const isConnected = !!sourceRow?.is_active && !!composioAccountId;
+
+  if (!source.composioToolkit) {
+    return (
+      <UnconfiguredNotice
+        sourceLabel={source.label}
+        reason={`No Composio toolkit slug is configured for ${source.id} — fix the registry entry.`}
+      />
+    );
+  }
+
+  async function handleConnect() {
+    setIsConnecting(true);
+    try {
+      // @composio-unverified — the `composio-oauth-callback` edge function
+      // does not exist yet. This call WILL fail until Phase B ships and a
+      // Composio account is provisioned with API credentials.
+      const { data, error } = await supabase.functions.invoke(
+        "composio-oauth-callback",
+        {
+          body: {
+            action: "initiate",
+            toolkit: source.composioToolkit,
+            sourceId: sourceRow?.id ?? null,
+          },
+        },
+      );
+
+      if (error || !data?.authUrl) {
+        throw new Error(error?.message || "Composio OAuth initiation failed");
+      }
+
+      window.open(data.authUrl as string, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Composio connect failed",
+      );
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <PageHeader
+        title={source.label}
+        subtitle={source.subtitle}
+        icon={source.icon}
+      />
+
+      <div className="px-6 py-4 max-w-2xl space-y-4">
+        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-foreground">
+              {isConnected
+                ? `${source.label} connected`
+                : `Connect ${source.label}`}
+            </h3>
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground/80 px-1.5 py-0.5 rounded border border-border">
+              via Composio
+            </span>
+          </div>
+          {sourceRow?.account_email && (
+            <p className="text-xs text-muted-foreground">
+              Connected as {sourceRow.account_email}
+            </p>
+          )}
+          {composioAccountId && (
+            <p className="text-[11px] text-muted-foreground font-mono">
+              composio:{composioAccountId.slice(0, 8)}…
+            </p>
+          )}
+          {sourceRow?.last_sync_at && (
+            <p className="text-xs text-muted-foreground">
+              Last sync: {new Date(sourceRow.last_sync_at).toLocaleString()}
+            </p>
+          )}
+          {sourceRow?.error_message && (
+            <p className="text-xs text-destructive">
+              {sourceRow.error_message}
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            {source.label} is routed through Composio. OAuth credentials, token
+            refresh, and webhook signing are managed by Composio's
+            infrastructure (see ADR-006).
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="default"
+            onClick={() => void handleConnect()}
+            disabled={isConnecting}
+          >
+            {isConnecting
+              ? "Opening Composio…"
+              : isConnected
+                ? `Reconnect ${source.label}`
+                : `Connect ${source.label}`}
+          </Button>
+          {isConnected && sourceRow && onDisconnect && (
+            <Button variant="hollow" onClick={() => onDisconnect(sourceRow)}>
+              Disconnect
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UnconfiguredNotice({
+  sourceLabel,
+  reason,
+}: {
+  sourceLabel: string;
+  reason: string;
+}) {
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <div className="px-6 py-4 max-w-2xl">
+        <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-4 space-y-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            {sourceLabel} — configuration error
+          </h3>
+          <p className="text-xs text-muted-foreground">{reason}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function readComposioAccountId(row: ImportSource | null): string | null {
+  if (!row?.connection_metadata) return null;
+  const value = row.connection_metadata["composio_connected_account_id"];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export default ComposioAdapter;

--- a/src/components/import/adapters/ComposioAdapter.tsx
+++ b/src/components/import/adapters/ComposioAdapter.tsx
@@ -171,9 +171,19 @@ function UnconfiguredNotice({
 }
 
 function readComposioAccountId(row: ImportSource | null): string | null {
-  if (!row?.connection_metadata) return null;
-  const value = row.connection_metadata["composio_connected_account_id"];
-  return typeof value === "string" && value.trim() ? value : null;
+  if (!row) return null;
+  // Prefer the dedicated column (typed, indexed). Fall back to the legacy
+  // JSONB key only if a row was written by a pre-fix client and never
+  // upserted again — once the row goes through composio-oauth-callback
+  // post-fix the typed column is the source of truth.
+  if (
+    typeof row.composio_connected_account_id === "string" &&
+    row.composio_connected_account_id.trim()
+  ) {
+    return row.composio_connected_account_id;
+  }
+  const legacy = row.connection_metadata?.["composio_connected_account_id"];
+  return typeof legacy === "string" && legacy.trim() ? legacy : null;
 }
 
 export default ComposioAdapter;

--- a/src/components/import/adapters/NativeAdapter.tsx
+++ b/src/components/import/adapters/NativeAdapter.tsx
@@ -1,0 +1,152 @@
+/**
+ * NativeAdapter — connector-framework adapter for sources whose OAuth, API
+ * calls, and webhook delivery are owned by CallVault.
+ *
+ * Status: PARALLEL implementation. The five existing native sources (Fathom,
+ * Fireflies, Zoom, Plaud, YouTube) continue to render through their dedicated
+ * detail panels in `ImportPage.tsx`. This adapter is the target shape for
+ * NEW native sources added under the connector framework (Otter, Avoma,
+ * Grain, Read.ai, Chorus per ADR-006).
+ *
+ * Contract: any consumer of this adapter must supply the source-specific
+ * connect / disconnect / sync handlers via props. The adapter owns layout,
+ * loading/error states, and badge rendering only.
+ */
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import type { SourceConfig } from "@/config/source-registry";
+import type { ImportSource } from "@/services/import-sources.service";
+
+export interface NativeAdapterActions {
+  /** Trigger the source's connect / OAuth flow. Required. */
+  onConnect: () => Promise<void> | void;
+  /** Trigger a manual sync against the connected account. Optional. */
+  onSyncNow?: () => Promise<void> | void;
+  /** Disconnect the source. Receives the active row so the caller can confirm. */
+  onDisconnect?: (source: ImportSource) => void;
+}
+
+export interface NativeAdapterProps extends NativeAdapterActions {
+  source: SourceConfig;
+  /** The matching `import_sources` row, if the user has connected this source. */
+  sourceRow: ImportSource | null;
+  /**
+   * Source-specific body (token-paste field, account picker, etc.). Rendered
+   * BETWEEN the status block and the action buttons. Native sources with no
+   * extra configuration omit this entirely.
+   */
+  children?: React.ReactNode;
+}
+
+export function NativeAdapter({
+  source,
+  sourceRow,
+  onConnect,
+  onSyncNow,
+  onDisconnect,
+  children,
+}: NativeAdapterProps) {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const isConnected = !!sourceRow?.is_active;
+
+  async function handleConnect() {
+    setIsConnecting(true);
+    try {
+      await onConnect();
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : `Failed to connect ${source.label}`,
+      );
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  async function handleSync() {
+    if (!onSyncNow) return;
+    setIsSyncing(true);
+    try {
+      await onSyncNow();
+      toast.success(`${source.label} sync started`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : `Failed to sync ${source.label}`,
+      );
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <PageHeader
+        title={source.label}
+        subtitle={source.subtitle}
+        icon={source.icon}
+      />
+
+      <div className="px-6 py-4 max-w-2xl space-y-4">
+        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            {isConnected
+              ? `${source.label} connected`
+              : `Connect ${source.label}`}
+          </h3>
+          {sourceRow?.account_email && (
+            <p className="text-xs text-muted-foreground">
+              Connected as {sourceRow.account_email}
+            </p>
+          )}
+          {sourceRow?.last_sync_at && (
+            <p className="text-xs text-muted-foreground">
+              Last sync: {new Date(sourceRow.last_sync_at).toLocaleString()}
+            </p>
+          )}
+          {sourceRow?.error_message && (
+            <p className="text-xs text-destructive">
+              {sourceRow.error_message}
+            </p>
+          )}
+        </div>
+
+        {children}
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="default"
+            onClick={() => void handleConnect()}
+            disabled={isConnecting}
+          >
+            {isConnecting
+              ? "Connecting…"
+              : isConnected
+                ? `Reconnect ${source.label}`
+                : `Connect ${source.label}`}
+          </Button>
+          {isConnected && onSyncNow && (
+            <Button
+              variant="hollow"
+              onClick={() => void handleSync()}
+              disabled={isSyncing}
+            >
+              {isSyncing ? "Syncing…" : "Sync Now"}
+            </Button>
+          )}
+          {isConnected && sourceRow && onDisconnect && (
+            <Button variant="hollow" onClick={() => onDisconnect(sourceRow)}>
+              Disconnect
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default NativeAdapter;

--- a/src/config/source-registry.ts
+++ b/src/config/source-registry.ts
@@ -1,0 +1,177 @@
+/**
+ * Source registry — single typed source-of-truth for every transcript / recording
+ * source surfaced in the import flow. Replaces the inline TILES array that used
+ * to live in `src/components/import/AddImportSourceDialog.tsx`.
+ *
+ * Adding a new source = add a single entry here. Downstream consumers
+ * (AddImportSourceDialog, ConnectorDetailPanel, adapter dispatcher) read from
+ * this registry — no other files need to change.
+ *
+ * Design contract:
+ * - `id` is the canonical lowercase kebab-case identifier; it MUST match
+ *   `CanonicalRecording.sourceApp` for any source that produces canonical
+ *   recordings (see `supabase/functions/_shared/canonical-recording.ts`).
+ * - `adapter` selects which front-end + back-end adapter handles the source.
+ *   - `native` — CallVault owns the OAuth/API code (today's pattern).
+ *   - `composio` — Composio handles auth + transport; CallVault only normalizes
+ *      the canonical payload. Requires `composioToolkit`. @composio-unverified
+ *      until ADR-006 is accepted and the Composio account is provisioned.
+ *   - `internal` — In-product surface that doesn't touch an external vendor
+ *      (file upload, paste-transcript). Has no auth/webhook.
+ */
+
+import {
+  RiCloudLine,
+  RiVideoLine,
+  RiYoutubeLine,
+  RiUploadCloud2Line,
+  RiClipboardLine,
+} from "@remixicon/react";
+import type { ComponentType } from "react";
+
+/**
+ * Stable union derived from registry entries. Keep AddImportSourceChoice
+ * importable from this file so callers don't need to depend on the dialog.
+ */
+export type SourceId =
+  | "fathom"
+  | "zoom"
+  | "fireflies"
+  | "plaud"
+  | "youtube"
+  | "file-upload"
+  | "paste-transcript";
+
+export type SourceAdapter = "native" | "composio" | "internal";
+
+export type AuthMode =
+  | "oauth2"
+  | "api-key"
+  | "token-paste"
+  | "public-url"
+  | "none";
+
+export interface SourceConfig {
+  id: SourceId;
+  label: string;
+  subtitle: string;
+  icon: ComponentType<{ className?: string }>;
+  adapter: SourceAdapter;
+  authMode: AuthMode;
+  /** Whether the vendor delivers webhooks (vs polling). */
+  hasWebhook: boolean;
+  /** Composio toolkit slug — required iff adapter === 'composio'. */
+  composioToolkit?: string;
+  /**
+   * Connector status, surfaced in UI badges.
+   * - `stable` — has at least one canonical recording flowing through production.
+   * - `beta` — code merged, low usage, may still drift.
+   * - `scaffold` — adapter exists but is not exercised end-to-end yet.
+   */
+  status: "stable" | "beta" | "scaffold";
+}
+
+/**
+ * Canonical registry. Ordering controls UI presentation in
+ * `AddImportSourceDialog` and `ImportSourcePane`.
+ *
+ * IMPORTANT: do not reorder or remove existing entries without updating the
+ * `SourceId` union and the migration plan in SPEC-connector-framework.md.
+ */
+export const SOURCE_REGISTRY: readonly SourceConfig[] = [
+  {
+    id: "fathom",
+    label: "Fathom",
+    subtitle: "Connect your Fathom account via OAuth",
+    icon: RiCloudLine,
+    adapter: "native",
+    authMode: "oauth2",
+    hasWebhook: true,
+    status: "stable",
+  },
+  {
+    id: "zoom",
+    label: "Zoom",
+    subtitle: "Connect Zoom Cloud Recordings via OAuth",
+    icon: RiVideoLine,
+    adapter: "native",
+    authMode: "oauth2",
+    hasWebhook: true,
+    status: "stable",
+  },
+  {
+    id: "fireflies",
+    label: "Fireflies",
+    subtitle: "Import Fireflies transcripts with an API key",
+    icon: RiCloudLine,
+    adapter: "native",
+    authMode: "api-key",
+    hasWebhook: true,
+    status: "stable",
+  },
+  {
+    id: "plaud",
+    label: "Plaud",
+    subtitle: "Connect Plaud recordings with a web access token",
+    icon: RiCloudLine,
+    adapter: "native",
+    authMode: "token-paste",
+    hasWebhook: false,
+    status: "stable",
+  },
+  {
+    id: "youtube",
+    label: "YouTube",
+    subtitle: "Import calls from public YouTube URLs",
+    icon: RiYoutubeLine,
+    adapter: "native",
+    authMode: "public-url",
+    hasWebhook: false,
+    status: "stable",
+  },
+  {
+    id: "file-upload",
+    label: "File Upload",
+    subtitle: "Upload audio or video files directly",
+    icon: RiUploadCloud2Line,
+    adapter: "internal",
+    authMode: "none",
+    hasWebhook: false,
+    status: "stable",
+  },
+  {
+    id: "paste-transcript",
+    label: "Paste Transcript",
+    subtitle: "Manually paste or upload a transcript",
+    icon: RiClipboardLine,
+    adapter: "internal",
+    authMode: "none",
+    hasWebhook: false,
+    status: "stable",
+  },
+] as const;
+
+const REGISTRY_BY_ID: Readonly<Record<SourceId, SourceConfig>> =
+  Object.fromEntries(
+    SOURCE_REGISTRY.map((entry) => [entry.id, entry]),
+  ) as Record<SourceId, SourceConfig>;
+
+export function getSourceConfig(id: SourceId): SourceConfig {
+  const config = REGISTRY_BY_ID[id];
+  if (!config) {
+    throw new Error(`[source-registry] Unknown source id: ${id}`);
+  }
+  return config;
+}
+
+export function tryGetSourceConfig(id: string): SourceConfig | undefined {
+  return (REGISTRY_BY_ID as Record<string, SourceConfig | undefined>)[id];
+}
+
+/**
+ * Source display name resolver. Centralized so detail-panel headers,
+ * disconnect dialogs, and the alert dialog don't drift.
+ */
+export function getSourceDisplayName(id: string): string {
+  return tryGetSourceConfig(id)?.label ?? id;
+}

--- a/src/services/import-sources.service.ts
+++ b/src/services/import-sources.service.ts
@@ -8,37 +8,45 @@
  * Pattern: flat exported async functions, same as recordings.service.ts.
  */
 
-import { supabase } from '@/integrations/supabase/client'
+import { supabase } from "@/integrations/supabase/client";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface ImportSource {
-  id: string
-  user_id: string
-  source_app: string
-  is_active: boolean
-  account_email: string | null
-  last_sync_at: string | null
-  error_message: string | null
-  connection_metadata: Record<string, unknown> | null
-  webhook_path_token: string | null
-  created_at: string
-  updated_at: string
+  id: string;
+  user_id: string;
+  source_app: string;
+  is_active: boolean;
+  account_email: string | null;
+  last_sync_at: string | null;
+  error_message: string | null;
+  connection_metadata: Record<string, unknown> | null;
+  webhook_path_token: string | null;
+  /**
+   * Composio (composio.dev) connected_account_id when the source is routed
+   * through the Composio adapter. NULL for native sources.
+   * Stored as a dedicated column with a partial unique index (see
+   * 20260523192117_composio_integration_ids.sql) so the webhook ingress
+   * can resolve deliveries with a single indexed lookup.
+   */
+  composio_connected_account_id: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface ImportSourceWithCount extends ImportSource {
-  call_count: number
+  call_count: number;
 }
 
 export interface FailedImport {
-  source_app: string
-  failed_external_id: string
-  error_message: string | null
-  sync_job_id: string
+  source_app: string;
+  failed_external_id: string;
+  error_message: string | null;
+  sync_job_id: string;
   /** Call title looked up from fathom_raw_calls (may be null if never partially synced) */
-  title: string | null
+  title: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -47,20 +55,24 @@ export interface FailedImport {
 
 export async function getImportSources(): Promise<ImportSource[]> {
   // import_sources are user-scoped, NOT org-scoped — connected accounts shared across orgs (ORG-05)
-  const { data: { session } } = await supabase.auth.getSession()
-  const user = session?.user
-  if (!user) return []
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user;
+  if (!user) return [];
 
   const { data: sourceRows, error: sourceError } = await supabase
-    .from('import_sources')
-    .select('id, user_id, source_app, is_active, account_email, last_sync_at, error_message, connection_metadata, webhook_path_token, created_at, updated_at')
-    .order('source_app', { ascending: true })
+    .from("import_sources")
+    .select(
+      "id, user_id, source_app, is_active, account_email, last_sync_at, error_message, connection_metadata, webhook_path_token, composio_connected_account_id, created_at, updated_at",
+    )
+    .order("source_app", { ascending: true });
 
   if (sourceError) {
-    throw new Error(`Failed to fetch import sources: ${sourceError.message}`)
+    throw new Error(`Failed to fetch import sources: ${sourceError.message}`);
   }
 
-  return sourceRows ?? []
+  return sourceRows ?? [];
 }
 
 /**
@@ -68,32 +80,36 @@ export async function getImportSources(): Promise<ImportSource[]> {
  * Counts from the recordings table scoped to both user and organization.
  * organizationId is required to ensure counts reflect only the current org (ORG-01).
  */
-export async function getImportCounts(organizationId: string): Promise<Record<string, number>> {
-  const { data: { session } } = await supabase.auth.getSession()
-  const user = session?.user
+export async function getImportCounts(
+  organizationId: string,
+): Promise<Record<string, number>> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user;
 
-  if (!user || !organizationId) return {}
+  if (!user || !organizationId) return {};
 
   // Direct query instead of RPC so we can filter by both user and org.
   // The legacy get_import_counts RPC only accepts p_user_id and would return
   // counts across all orgs — not suitable for multi-org users.
   const { data, error } = await supabase
-    .from('recordings')
-    .select('source_app')
-    .eq('owner_user_id', user.id)
-    .eq('organization_id', organizationId)
-    .not('source_app', 'is', null)
+    .from("recordings")
+    .select("source_app")
+    .eq("owner_user_id", user.id)
+    .eq("organization_id", organizationId)
+    .not("source_app", "is", null);
 
-  const counts: Record<string, number> = {}
+  const counts: Record<string, number> = {};
   if (!error && Array.isArray(data)) {
     for (const row of data as { source_app: string | null }[]) {
       if (row.source_app) {
-        counts[row.source_app] = (counts[row.source_app] || 0) + 1
+        counts[row.source_app] = (counts[row.source_app] || 0) + 1;
       }
     }
   }
 
-  return counts
+  return counts;
 }
 
 // ---------------------------------------------------------------------------
@@ -106,20 +122,20 @@ export async function getImportCounts(organizationId: string): Promise<Record<st
  */
 export async function toggleSourceActive(
   sourceId: string,
-  isActive: boolean
+  isActive: boolean,
 ): Promise<ImportSource> {
   const { data, error } = await supabase
-    .from('import_sources')
+    .from("import_sources")
     .update({ is_active: isActive, updated_at: new Date().toISOString() })
-    .eq('id', sourceId)
+    .eq("id", sourceId)
     .select()
-    .single()
+    .single();
 
   if (error) {
-    throw new Error(`Failed to toggle source: ${error.message}`)
+    throw new Error(`Failed to toggle source: ${error.message}`);
   }
 
-  return data
+  return data;
 }
 
 /**
@@ -132,66 +148,67 @@ export async function toggleSourceActive(
  * For single-account sources, falls back to upsert by (user_id, source_app).
  */
 export async function upsertImportSource(source: {
-  source_app: string
-  account_email?: string
-  source_id?: string
+  source_app: string;
+  account_email?: string;
+  source_id?: string;
 }): Promise<ImportSource> {
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+  } = await supabase.auth.getUser();
 
-  if (!user) throw new Error('Must be authenticated to connect a source')
+  if (!user) throw new Error("Must be authenticated to connect a source");
 
   // If sourceId provided (multi-account flow), update that specific row
   if (source.source_id) {
     const { data, error } = await supabase
-      .from('import_sources')
+      .from("import_sources")
       .update({
         account_email: source.account_email ?? null,
         is_active: true,
         updated_at: new Date().toISOString(),
       })
-      .eq('id', source.source_id)
-      .eq('user_id', user.id)
+      .eq("id", source.source_id)
+      .eq("user_id", user.id)
       .select()
-      .single()
+      .single();
 
     if (error) {
-      throw new Error(`Failed to update import source: ${error.message}`)
+      throw new Error(`Failed to update import source: ${error.message}`);
     }
 
-    return data
+    return data;
   }
 
   // Legacy single-account path: insert or find existing
   // First check if a row already exists
   const { data: existing } = await supabase
-    .from('import_sources')
-    .select('*')
-    .eq('user_id', user.id)
-    .eq('source_app', source.source_app)
+    .from("import_sources")
+    .select("*")
+    .eq("user_id", user.id)
+    .eq("source_app", source.source_app)
     .limit(1)
-    .maybeSingle()
+    .maybeSingle();
 
   if (existing) {
     const { data, error } = await supabase
-      .from('import_sources')
+      .from("import_sources")
       .update({
         account_email: source.account_email ?? existing.account_email,
         is_active: true,
         updated_at: new Date().toISOString(),
       })
-      .eq('id', existing.id)
+      .eq("id", existing.id)
       .select()
-      .single()
+      .single();
 
-    if (error) throw new Error(`Failed to update import source: ${error.message}`)
-    return data
+    if (error)
+      throw new Error(`Failed to update import source: ${error.message}`);
+    return data;
   }
 
   // No existing row — insert new
   const { data, error } = await supabase
-    .from('import_sources')
+    .from("import_sources")
     .insert({
       user_id: user.id,
       source_app: source.source_app,
@@ -199,13 +216,13 @@ export async function upsertImportSource(source: {
       is_active: true,
     })
     .select()
-    .single()
+    .single();
 
   if (error) {
-    throw new Error(`Failed to create import source: ${error.message}`)
+    throw new Error(`Failed to create import source: ${error.message}`);
   }
 
-  return data
+  return data;
 }
 
 /**
@@ -215,22 +232,25 @@ export async function upsertImportSource(source: {
  * Per locked decision: 25MB limit is enforced client-side before calling this.
  */
 export async function uploadFile(file: File): Promise<{ recordingId: string }> {
-  const formData = new FormData()
-  formData.append('file', file)
+  const formData = new FormData();
+  formData.append("file", file);
 
-  const { data, error } = await supabase.functions.invoke('file-upload-transcribe', {
-    body: formData,
-  })
+  const { data, error } = await supabase.functions.invoke(
+    "file-upload-transcribe",
+    {
+      body: formData,
+    },
+  );
 
   if (error) {
-    throw new Error(`File upload failed: ${error.message}`)
+    throw new Error(`File upload failed: ${error.message}`);
   }
 
   if (!data?.recordingId) {
-    throw new Error('File upload succeeded but no recording ID returned')
+    throw new Error("File upload succeeded but no recording ID returned");
   }
 
-  return { recordingId: data.recordingId as string }
+  return { recordingId: data.recordingId as string };
 }
 
 /**
@@ -241,64 +261,66 @@ export async function uploadFile(file: File): Promise<{ recordingId: string }> {
  * Per locked decision: imported calls are kept; only future syncs stop.
  */
 export async function disconnectImportSource(sourceId: string): Promise<void> {
-  const { data: { session } } = await supabase.auth.getSession()
-  const user = session?.user
-  if (!user) throw new Error('Not authenticated')
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user;
+  if (!user) throw new Error("Not authenticated");
 
   // Look up the source to know which tokens to clear
   const { data: source } = await supabase
-    .from('import_sources')
-    .select('source_app')
-    .eq('id', sourceId)
-    .single()
+    .from("import_sources")
+    .select("source_app")
+    .eq("id", sourceId)
+    .single();
 
   if (source) {
     // For Zoom, still clear tokens from user_settings (Zoom is single-account)
-    if (source.source_app === 'zoom') {
+    if (source.source_app === "zoom") {
       await supabase
-        .from('user_settings')
+        .from("user_settings")
         .update({
           zoom_oauth_access_token: null,
           zoom_oauth_refresh_token: null,
           zoom_oauth_token_expires: null,
           zoom_oauth_state: null,
         })
-        .eq('user_id', user.id)
+        .eq("user_id", user.id);
     }
 
     // For Fathom with multi-account, check if this is the LAST fathom source.
     // If so, also clear legacy user_settings tokens.
-    if (source.source_app === 'fathom') {
+    if (source.source_app === "fathom") {
       const { count } = await supabase
-        .from('import_sources')
-        .select('id', { count: 'exact', head: true })
-        .eq('user_id', user.id)
-        .eq('source_app', 'fathom')
-        .neq('id', sourceId)
+        .from("import_sources")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", user.id)
+        .eq("source_app", "fathom")
+        .neq("id", sourceId);
 
       if (!count || count === 0) {
         // Last Fathom account — clear legacy tokens too
         await supabase
-          .from('user_settings')
+          .from("user_settings")
           .update({
             oauth_access_token: null,
             oauth_refresh_token: null,
             oauth_token_expires: null,
             fathom_api_key: null,
           })
-          .eq('user_id', user.id)
+          .eq("user_id", user.id);
       }
     }
   }
 
   // Delete the import_sources row (tokens stored inline are deleted with it)
   const { error } = await supabase
-    .from('import_sources')
+    .from("import_sources")
     .delete()
-    .eq('id', sourceId)
+    .eq("id", sourceId);
 
   if (error) {
-    throw new Error(`Failed to disconnect source: ${error.message}`)
+    throw new Error(`Failed to disconnect source: ${error.message}`);
   }
 }
 
@@ -313,37 +335,38 @@ export async function disconnectImportSource(sourceId: string): Promise<void> {
  */
 export async function retryFailedImport(
   sourceApp: string,
-  failedExternalId: string
+  failedExternalId: string,
 ): Promise<{ success: boolean; error?: string }> {
   const edgeFunctionMap: Record<string, string> = {
-    fathom: 'sync-meetings',
-    zoom: 'zoom-sync-meetings',
-    youtube: 'youtube-import',
-    fireflies: 'fireflies-sync-meetings',
-    plaud: 'plaud-sync-recordings',
-  }
+    fathom: "sync-meetings",
+    zoom: "zoom-sync-meetings",
+    youtube: "youtube-import",
+    fireflies: "fireflies-sync-meetings",
+    plaud: "plaud-sync-recordings",
+  };
 
-  if (sourceApp === 'file-upload') {
+  if (sourceApp === "file-upload") {
     return {
       success: false,
-      error: 'File uploads cannot be retried automatically. Please re-upload the file.',
-    }
+      error:
+        "File uploads cannot be retried automatically. Please re-upload the file.",
+    };
   }
 
-  const fnName = edgeFunctionMap[sourceApp]
+  const fnName = edgeFunctionMap[sourceApp];
   if (!fnName) {
-    return { success: false, error: `Unknown source: ${sourceApp}` }
+    return { success: false, error: `Unknown source: ${sourceApp}` };
   }
 
   const { error } = await supabase.functions.invoke(fnName, {
     body: { singleCallId: failedExternalId },
-  })
+  });
 
   if (error) {
-    return { success: false, error: error.message }
+    return { success: false, error: error.message };
   }
 
-  return { success: true }
+  return { success: true };
 }
 
 /**
@@ -353,88 +376,93 @@ export async function retryFailedImport(
  * Note: sync_jobs table has no organization_id column, so we scope indirectly
  * by filtering the synced recordings check to the current org.
  */
-export async function getFailedImports(organizationId: string): Promise<FailedImport[]> {
+export async function getFailedImports(
+  organizationId: string,
+): Promise<FailedImport[]> {
   const { data, error } = await supabase
-    .from('sync_jobs')
-    .select('id, failed_ids, error, type')
-    .not('failed_ids', 'is', null)
-    .order('created_at', { ascending: false })
-    .limit(100)
+    .from("sync_jobs")
+    .select("id, failed_ids, error, type")
+    .not("failed_ids", "is", null)
+    .order("created_at", { ascending: false })
+    .limit(100);
 
   if (error) {
-    console.warn('Failed to fetch failed imports:', error.message)
-    return []
+    console.warn("Failed to fetch failed imports:", error.message);
+    return [];
   }
 
-  if (!data || data.length === 0) return []
+  if (!data || data.length === 0) return [];
 
   // Get user once — use cached session to avoid N+1 /auth/v1/user requests
-  const { data: { session } } = await supabase.auth.getSession()
-  const user = session?.user
-  if (!user) return []
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user;
+  if (!user) return [];
 
   // Get all synced external_ids scoped to current org to filter out false-positives.
   // Without org scoping, a call synced in org A would suppress the failure in org B.
   // Check BOTH source_metadata.external_id and legacy_recording_id
   const { data: syncedRecs } = await supabase
-    .from('recordings')
-    .select('source_metadata, legacy_recording_id')
-    .eq('owner_user_id', user.id)
-    .eq('organization_id', organizationId)
+    .from("recordings")
+    .select("source_metadata, legacy_recording_id")
+    .eq("owner_user_id", user.id)
+    .eq("organization_id", organizationId);
 
-  const syncedIds = new Set<string>()
+  const syncedIds = new Set<string>();
   if (syncedRecs) {
     for (const r of syncedRecs) {
-      const extId = (r.source_metadata as any)?.external_id
-      if (extId) syncedIds.add(String(extId))
-      if ((r as any).legacy_recording_id) syncedIds.add(String((r as any).legacy_recording_id))
+      const extId = (r.source_metadata as any)?.external_id;
+      if (extId) syncedIds.add(String(extId));
+      if ((r as any).legacy_recording_id)
+        syncedIds.add(String((r as any).legacy_recording_id));
     }
   }
 
   // Collect all failed external IDs first, then batch-lookup titles
-  const allFailedIds: string[] = []
-  const jobs = data as any[]
+  const allFailedIds: string[] = [];
+  const jobs = data as any[];
   for (const job of jobs) {
-    if (!job.failed_ids || job.failed_ids.length === 0) continue
+    if (!job.failed_ids || job.failed_ids.length === 0) continue;
     for (const externalId of job.failed_ids) {
-      const extStr = String(externalId)
-      if (!syncedIds.has(extStr)) allFailedIds.push(extStr)
+      const extStr = String(externalId);
+      if (!syncedIds.has(extStr)) allFailedIds.push(extStr);
     }
   }
 
   // Batch lookup titles from fathom_raw_calls for Fathom failures
-  const titleMap = new Map<string, string>()
+  const titleMap = new Map<string, string>();
   if (allFailedIds.length > 0) {
     const numericIds = allFailedIds
       .map(Number)
-      .filter(n => Number.isFinite(n))
+      .filter((n) => Number.isFinite(n));
 
     if (numericIds.length > 0) {
       const { data: rawCalls } = await supabase
-        .from('fathom_raw_calls')
-        .select('recording_id, title')
-        .in('recording_id', numericIds)
-        .eq('user_id', user.id)
+        .from("fathom_raw_calls")
+        .select("recording_id, title")
+        .in("recording_id", numericIds)
+        .eq("user_id", user.id);
 
       if (rawCalls) {
         for (const rc of rawCalls) {
-          titleMap.set(String(rc.recording_id), rc.title)
+          titleMap.set(String(rc.recording_id), rc.title);
         }
       }
     }
   }
 
   // Flatten: one FailedImport per failed external_id
-  const results: FailedImport[] = []
+  const results: FailedImport[] = [];
   for (const job of jobs) {
-    if (!job.failed_ids || job.failed_ids.length === 0) continue
+    if (!job.failed_ids || job.failed_ids.length === 0) continue;
 
     for (const externalId of job.failed_ids) {
-      const extStr = String(externalId)
-      if (syncedIds.has(extStr)) continue
+      const extStr = String(externalId);
+      if (syncedIds.has(extStr)) continue;
 
       const type = job.type?.toLowerCase();
-      const sourceApp = (type === 'sync' || !type) ? 'fathom' : type;
+      const sourceApp = type === "sync" || !type ? "fathom" : type;
 
       results.push({
         source_app: sourceApp,
@@ -447,10 +475,10 @@ export async function getFailedImports(organizationId: string): Promise<FailedIm
   }
 
   // Final dedupe by external_id (only show the most recent failure for a specific call)
-  const dedupedMap = new Map<string, FailedImport>()
+  const dedupedMap = new Map<string, FailedImport>();
   for (const res of results) {
     if (!dedupedMap.has(res.failed_external_id)) {
-      dedupedMap.set(res.failed_external_id, res)
+      dedupedMap.set(res.failed_external_id, res);
     }
   }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,17 @@
-import { expect, afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import * as matchers from '@testing-library/jest-dom/matchers';
+import { expect, afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+// Edge-function shim: when vitest imports a module from supabase/functions/_shared,
+// any top-level `Deno.env.get(...)` call resolves through this stub instead of
+// throwing ReferenceError. Falls back to process.env so tests can still drive
+// configuration through real env vars when needed.
+const denoGlobal = globalThis as unknown as {
+  Deno?: { env: { get: (key: string) => string | undefined } };
+};
+if (!denoGlobal.Deno) {
+  denoGlobal.Deno = { env: { get: (key: string) => process.env[key] } };
+}
 
 // Extend Vitest's expect with jest-dom matchers
 expect.extend(matchers);
@@ -10,12 +21,18 @@ const localStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
     getItem: (key: string) => store[key] ?? null,
-    setItem: (key: string, value: string) => { store[key] = value; },
-    removeItem: (key: string) => { delete store[key]; },
-    clear: () => { store = {}; },
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
   };
 })();
-Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
 // Cleanup after each test
 afterEach(() => {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -157,3 +157,21 @@ verify_jwt = false
 [functions.polar-webhook]
 # Receives external Polar payment webhook callbacks — no user JWT available
 verify_jwt = false
+
+# --- Composio meta-integration (Phase B per ADR-006) ---
+
+[functions.connector-dispatcher]
+# Dispatcher routes { source, action } requests to registered adapters.
+# Auth is enforced in function code via supabase.auth.getUser(token).
+verify_jwt = false
+
+[functions.composio-oauth-callback]
+# Frontend-mediated handoff after Composio OAuth completion. Auth is enforced
+# in function code via supabase.auth.getUser(token).
+verify_jwt = false
+
+[functions.composio-trigger-webhook]
+# Receives external Composio trigger webhook deliveries — no user JWT.
+# Auth is enforced via HMAC-SHA256 signature verification against
+# COMPOSIO_WEBHOOK_SECRET inside the function.
+verify_jwt = false

--- a/supabase/functions/_shared/__tests__/composio-client-signature.test.ts
+++ b/supabase/functions/_shared/__tests__/composio-client-signature.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { verifyComposioSignature } from "../composio-client";
+
+// Reference HMAC reused across this suite:
+//   node -e "console.log(require('crypto').createHmac('sha256','shh').update('{}').digest('hex'))"
+const REFERENCE_HEX =
+  "9b7038c05edccf643d722b52dbaf2cea2b159caf339a5e12c0356e0b8b7b0794";
+
+describe("verifyComposioSignature — happy paths", () => {
+  it("accepts a raw hex signature matching the body+secret", async () => {
+    expect(await verifyComposioSignature("{}", REFERENCE_HEX, "shh")).toBe(
+      true,
+    );
+  });
+
+  it("accepts a `sha256=`-prefixed signature", async () => {
+    expect(
+      await verifyComposioSignature("{}", `sha256=${REFERENCE_HEX}`, "shh"),
+    ).toBe(true);
+  });
+
+  it("trims trailing whitespace after the `sha256=` prefix is stripped", async () => {
+    // The prefix strip runs before .trim(), so leading whitespace before
+    // `sha256=` would not be stripped. Composio's header format has no
+    // leading whitespace; this test pins the documented behavior.
+    expect(
+      await verifyComposioSignature("{}", `sha256=${REFERENCE_HEX}  `, "shh"),
+    ).toBe(true);
+  });
+});
+
+describe("verifyComposioSignature — rejection paths", () => {
+  it('rejects a tampered body (signature for `{}` against body `{"x":1}`)', async () => {
+    expect(await verifyComposioSignature('{"x":1}', REFERENCE_HEX, "shh")).toBe(
+      false,
+    );
+  });
+
+  it("rejects an empty signature header", async () => {
+    expect(await verifyComposioSignature("{}", "", "shh")).toBe(false);
+  });
+
+  it("rejects an empty secret (misconfigured deploy)", async () => {
+    expect(await verifyComposioSignature("{}", REFERENCE_HEX, "")).toBe(false);
+  });
+
+  it("rejects a signature of the right shape but wrong content (same length, different chars)", async () => {
+    // Same length, differs in last char only.
+    const sameLengthDifferent = REFERENCE_HEX.slice(0, -1) + "0";
+    expect(
+      await verifyComposioSignature("{}", sameLengthDifferent, "shh"),
+    ).toBe(false);
+  });
+
+  it("rejects when secret mismatches the signing key", async () => {
+    expect(
+      await verifyComposioSignature("{}", REFERENCE_HEX, "different-secret"),
+    ).toBe(false);
+  });
+});

--- a/supabase/functions/_shared/__tests__/composio-normalizer-dialpad.test.ts
+++ b/supabase/functions/_shared/__tests__/composio-normalizer-dialpad.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  dialpadCallToCanonical,
+  type DialpadCallPayload,
+} from "../composio-normalizers/dialpad";
+
+const basePayload: DialpadCallPayload = {
+  call_id: "dp-555",
+  call: {
+    id: "dp-555",
+    internal_number: "+15555550101",
+    external_number: "+15555559999",
+    direction: "outbound",
+    date_started: "2026-05-23T16:00:00Z",
+    date_ended: "2026-05-23T16:18:00Z",
+    duration: 1080,
+    recording_url: "https://dialpad.com/recording/dp-555",
+    target: { email: "rep@callvault.dev", name: "Rep" },
+    contact: { email: "lead@buyer.com", name: "Lead", phone: "+15555559999" },
+  },
+  transcript: [
+    {
+      content: "Hello?",
+      name: "Lead",
+      email: "lead@buyer.com",
+      start_time: 0,
+      end_time: 2,
+      speaker_type: "contact",
+    },
+    {
+      content: "Hi, this is Rep.",
+      name: "Rep",
+      email: "rep@callvault.dev",
+      start_time: 3,
+      end_time: 6,
+      speaker_type: "user",
+    },
+  ],
+  connected_account_id: "ca_dialpad_42",
+};
+
+describe("composio dialpad normalizer — canonical shape", () => {
+  it("maps Dialpad payload into canonical recording fields", () => {
+    const canonical = dialpadCallToCanonical(basePayload);
+    expect(canonical).toMatchObject({
+      externalId: "dp-555",
+      sourceApp: "dialpad",
+      title: "Outbound call to Lead",
+      durationSeconds: 1080,
+      sourceUrl: "https://dialpad.com/recording/dp-555",
+      recordedByEmail: "rep@callvault.dev",
+      recordedByName: "Rep",
+    });
+    expect(canonical.participantEmails).toEqual([
+      "rep@callvault.dev",
+      "lead@buyer.com",
+    ]);
+    expect(canonical.fullTranscript).toContain("Hello?");
+    expect(canonical.fullTranscript).toContain("Hi, this is Rep.");
+  });
+
+  it("stamps composio_connected_account_id + composio_routed into sourceMetadata", () => {
+    const canonical = dialpadCallToCanonical(basePayload);
+    expect(canonical.sourceMetadata).toMatchObject({
+      dialpad_call_id: "dp-555",
+      composio_connected_account_id: "ca_dialpad_42",
+      composio_routed: true,
+    });
+  });
+
+  it("treats numeric date_started > 1e12 as milliseconds, not seconds", () => {
+    // Heuristic guard: if removed, every Dialpad call's start time would
+    // be wrong by 1000x for any number larger than 2001-09-09.
+    const millis = 1748016000000; // 2025-05-23T16:00:00Z
+    const canonical = dialpadCallToCanonical({
+      ...basePayload,
+      call: { ...basePayload.call, date_started: millis },
+    });
+    expect(canonical.recordingStartTime).toBe(new Date(millis).toISOString());
+  });
+
+  it("treats numeric date_started <= 1e12 as seconds (legacy Dialpad responses)", () => {
+    const seconds = 1748016000; // 2025-05-23T16:00:00Z
+    const canonical = dialpadCallToCanonical({
+      ...basePayload,
+      call: { ...basePayload.call, date_started: seconds },
+    });
+    expect(canonical.recordingStartTime).toBe(
+      new Date(seconds * 1000).toISOString(),
+    );
+  });
+
+  it("throws when call id is missing — webhook treats as ignored, not retry", () => {
+    expect(() =>
+      dialpadCallToCanonical({ ...basePayload, call_id: null, call: {} }),
+    ).toThrow(/missing call id/);
+  });
+
+  it("throws when date_started is missing — webhook treats as ignored, not retry", () => {
+    expect(() =>
+      dialpadCallToCanonical({
+        ...basePayload,
+        call: { id: "dp-x", date_started: null },
+      }),
+    ).toThrow(/missing call.date_started/);
+  });
+});

--- a/supabase/functions/_shared/__tests__/composio-normalizer-gong.test.ts
+++ b/supabase/functions/_shared/__tests__/composio-normalizer-gong.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  gongCallToCanonical,
+  type GongCallPayload,
+} from "../composio-normalizers/gong";
+
+const basePayload: GongCallPayload = {
+  metaData: {
+    id: "gong-9999",
+    title: "Discovery — Acme Corp",
+    started: "2026-05-23T15:00:00Z",
+    duration: 1820,
+    url: "https://app.gong.io/call/gong-9999",
+    primaryUserId: "u-host",
+    direction: "Outbound",
+    media: "audio_video",
+  },
+  parties: [
+    {
+      id: "u-host",
+      speakerId: "spk-1",
+      emailAddress: "ae@callvault.dev",
+      name: "AE Host",
+      affiliation: "Internal",
+    },
+    {
+      id: "u-guest",
+      speakerId: "spk-2",
+      emailAddress: "buyer@acme.com",
+      name: "Buyer",
+      affiliation: "External",
+    },
+  ],
+  transcript: [
+    {
+      speakerId: "spk-1",
+      sentences: [
+        { start: 0, end: 4000, text: "Hi there, thanks for joining." },
+      ],
+    },
+    {
+      speakerId: "spk-2",
+      sentences: [{ start: 5000, end: 9000, text: "Happy to be here." }],
+    },
+  ],
+  connected_account_id: "ca_gong_123",
+};
+
+describe("composio gong normalizer — canonical shape", () => {
+  it("maps Gong payload into canonical recording fields", () => {
+    const canonical = gongCallToCanonical(basePayload);
+    expect(canonical).toMatchObject({
+      externalId: "gong-9999",
+      sourceApp: "gong",
+      title: "Discovery — Acme Corp",
+      recordingStartTime: "2026-05-23T15:00:00.000Z",
+      durationSeconds: 1820,
+      sourceUrl: "https://app.gong.io/call/gong-9999",
+      recordedByEmail: "ae@callvault.dev",
+      recordedByName: "AE Host",
+    });
+    expect(canonical.participantEmails).toEqual([
+      "ae@callvault.dev",
+      "buyer@acme.com",
+    ]);
+  });
+
+  it("converts sentence millisecond offsets to seconds (NOT the raw value)", () => {
+    // Regression guard: removing the /1000 divisor makes every Gong call's
+    // timestamp wrong by 1000x.
+    const canonical = gongCallToCanonical(basePayload);
+    expect(canonical.fullTranscript).toContain("[0:00] AE Host: Hi there");
+    expect(canonical.fullTranscript).toContain("[0:05] Buyer: Happy to be");
+  });
+
+  it("stamps composio_connected_account_id into sourceMetadata for framework symmetry", () => {
+    const canonical = gongCallToCanonical(basePayload);
+    expect(canonical.sourceMetadata).toMatchObject({
+      gong_call_id: "gong-9999",
+      composio_connected_account_id: "ca_gong_123",
+      composio_routed: true,
+    });
+  });
+
+  it("throws when metaData.id is missing — webhook should treat as ignored, not retry", () => {
+    expect(() =>
+      gongCallToCanonical({ ...basePayload, metaData: { started: "x" } }),
+    ).toThrow(/missing metaData.id/);
+  });
+
+  it("throws when both started and scheduled are missing", () => {
+    expect(() =>
+      gongCallToCanonical({
+        ...basePayload,
+        metaData: { id: "x", started: null, scheduled: null },
+      }),
+    ).toThrow(/missing metaData.started\/scheduled/);
+  });
+
+  it("produces an empty fullTranscript when transcript is []", () => {
+    const canonical = gongCallToCanonical({
+      ...basePayload,
+      transcript: [],
+    });
+    expect(canonical.fullTranscript).toBe("");
+  });
+});

--- a/supabase/functions/_shared/__tests__/composio-normalizer-webex.test.ts
+++ b/supabase/functions/_shared/__tests__/composio-normalizer-webex.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  webexRecordingToCanonical,
+  type WebexRecordingPayload,
+} from "../composio-normalizers/webex";
+
+const basePayload: WebexRecordingPayload = {
+  recording: {
+    id: "wbx-rec-1",
+    meetingId: "wbx-meet-1",
+    topic: "Pricing Review",
+    timeRecorded: "2026-05-23T17:00:00Z",
+    durationSeconds: 1500,
+    hostEmail: "host@callvault.dev",
+    hostDisplayName: "Host",
+    playbackUrl: "https://webex.com/play/wbx-rec-1",
+    downloadUrl: "https://webex.com/download/wbx-rec-1",
+    format: "MP4",
+  },
+  meeting: {
+    id: "wbx-meet-1",
+    title: "Pricing Review",
+    start: "2026-05-23T17:00:00Z",
+    end: "2026-05-23T17:25:00Z",
+    hostEmail: "host@callvault.dev",
+    hostDisplayName: "Host",
+    invitees: [
+      { email: "buyer@acme.com", displayName: "Buyer" },
+      { email: "host@callvault.dev", displayName: "Host" },
+    ],
+  },
+  transcript: [
+    {
+      text: "Welcome.",
+      speaker: "Host",
+      speakerEmail: "host@callvault.dev",
+      startTime: 0,
+      endTime: 2,
+    },
+    {
+      text: "Thanks.",
+      speaker: "Buyer",
+      speakerEmail: "buyer@acme.com",
+      startTime: 3,
+      endTime: 4,
+    },
+  ],
+  connected_account_id: "ca_webex_7",
+};
+
+describe("composio webex normalizer — canonical shape", () => {
+  it("maps Webex payload into canonical recording fields", () => {
+    const canonical = webexRecordingToCanonical(basePayload);
+    expect(canonical).toMatchObject({
+      externalId: "wbx-rec-1",
+      sourceApp: "webex",
+      title: "Pricing Review",
+      recordingStartTime: "2026-05-23T17:00:00.000Z",
+      durationSeconds: 1500,
+      sourceUrl: "https://webex.com/play/wbx-rec-1",
+      recordedByEmail: "host@callvault.dev",
+      recordedByName: "Host",
+    });
+    expect(canonical.participantEmails).toEqual(
+      expect.arrayContaining(["host@callvault.dev", "buyer@acme.com"]),
+    );
+    expect(canonical.fullTranscript).toContain("Welcome.");
+    expect(canonical.fullTranscript).toContain("Thanks.");
+  });
+
+  it("stamps composio_connected_account_id + composio_routed into sourceMetadata", () => {
+    const canonical = webexRecordingToCanonical(basePayload);
+    expect(canonical.sourceMetadata).toMatchObject({
+      webex_recording_id: "wbx-rec-1",
+      webex_meeting_id: "wbx-meet-1",
+      composio_connected_account_id: "ca_webex_7",
+      composio_routed: true,
+    });
+  });
+
+  it("falls back to meeting.id when recording.id is absent", () => {
+    const canonical = webexRecordingToCanonical({
+      ...basePayload,
+      recording: { ...basePayload.recording, id: null },
+    });
+    expect(canonical.externalId).toBe("wbx-meet-1");
+  });
+
+  it("throws when both recording.id and meeting.id are missing", () => {
+    expect(() =>
+      webexRecordingToCanonical({
+        ...basePayload,
+        recording: { ...basePayload.recording, id: null },
+        meeting: { ...basePayload.meeting, id: null },
+      }),
+    ).toThrow(/missing recording.id and meeting.id/);
+  });
+
+  it("produces an empty fullTranscript when transcript is []", () => {
+    const canonical = webexRecordingToCanonical({
+      ...basePayload,
+      transcript: [],
+    });
+    expect(canonical.fullTranscript).toBe("");
+  });
+});

--- a/supabase/functions/_shared/__tests__/connector-framework.test.ts
+++ b/supabase/functions/_shared/__tests__/connector-framework.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetAdapterRegistryForTests,
+  dispatchConnectorRequest,
+  registerAdapter,
+  type AdapterContext,
+  type ConnectorAdapter,
+  type ConnectorRequest,
+} from "../connector-framework";
+
+const ctx = {
+  supabase: {} as AdapterContext["supabase"],
+  userId: "00000000-0000-0000-0000-000000000001",
+} satisfies AdapterContext;
+
+beforeEach(() => {
+  _resetAdapterRegistryForTests();
+});
+
+describe("dispatchConnectorRequest — validation", () => {
+  it("returns 400 when body is missing", async () => {
+    const result = await dispatchConnectorRequest(
+      ctx,
+      undefined as unknown as ConnectorRequest,
+    );
+    expect(result.status).toBe(400);
+    expect(result.body.success).toBe(false);
+  });
+
+  it("returns 400 when source is empty", async () => {
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "",
+      action: "connect",
+    });
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/source/);
+  });
+
+  it("returns 400 when action is not in the allowed set", async () => {
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "x",
+      action: "drop" as ConnectorRequest["action"],
+    });
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(
+      /connect, disconnect, fetch, sync, status/,
+    );
+  });
+});
+
+describe("dispatchConnectorRequest — adapter resolution", () => {
+  it("returns 404 when no adapter is registered for the source", async () => {
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "unknown",
+      action: "connect",
+    });
+    expect(result.status).toBe(404);
+    expect(result.body.success).toBe(false);
+  });
+
+  it("returns 501 when adapter doesn't implement the requested action", async () => {
+    const adapter: ConnectorAdapter = {
+      source: "demo",
+      connect: vi.fn(async () => ({ success: true })),
+    };
+    registerAdapter(adapter);
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "demo",
+      action: "sync",
+    });
+    expect(result.status).toBe(501);
+    expect(result.body.error).toMatch(/does not implement action 'sync'/);
+  });
+});
+
+describe("dispatchConnectorRequest — happy + idempotent paths", () => {
+  it("returns 200 + adapter body on success", async () => {
+    const adapter: ConnectorAdapter = {
+      source: "demo",
+      sync: vi.fn(async () => ({
+        success: true,
+        data: { recordingId: "abc" },
+      })),
+    };
+    registerAdapter(adapter);
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "demo",
+      action: "sync",
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      success: true,
+      data: { recordingId: "abc" },
+    });
+  });
+
+  it("returns 200 when adapter reports skipped (dedup), not 500", async () => {
+    // Idempotent dedup contract — every future connector inherits this rule.
+    const adapter: ConnectorAdapter = {
+      source: "demo",
+      sync: vi.fn(async () => ({ success: false, skipped: true })),
+    };
+    registerAdapter(adapter);
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "demo",
+      action: "sync",
+    });
+    expect(result.status).toBe(200);
+    expect(result.body.skipped).toBe(true);
+  });
+});
+
+describe("dispatchConnectorRequest — error path", () => {
+  it("returns 500 with sanitized error.message when handler throws", async () => {
+    const adapter: ConnectorAdapter = {
+      source: "demo",
+      fetch: vi.fn(async () => {
+        throw new Error("network unreachable");
+      }),
+    };
+    registerAdapter(adapter);
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "demo",
+      action: "fetch",
+    });
+    expect(result.status).toBe(500);
+    expect(result.body.success).toBe(false);
+    expect(result.body.error).toBe("network unreachable");
+  });
+
+  it("returns 500 with 'Unknown adapter error' when handler throws a non-Error", async () => {
+    const adapter: ConnectorAdapter = {
+      source: "demo",
+      fetch: vi.fn(async () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw "boom";
+      }),
+    };
+    registerAdapter(adapter);
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "demo",
+      action: "fetch",
+    });
+    expect(result.status).toBe(500);
+    expect(result.body.error).toBe("Unknown adapter error");
+  });
+
+  it("returns 500 when adapter reports plain failure", async () => {
+    const adapter: ConnectorAdapter = {
+      source: "demo",
+      sync: vi.fn(async () => ({ success: false, error: "vendor down" })),
+    };
+    registerAdapter(adapter);
+    const result = await dispatchConnectorRequest(ctx, {
+      source: "demo",
+      action: "sync",
+    });
+    expect(result.status).toBe(500);
+    expect(result.body.error).toBe("vendor down");
+  });
+});
+
+describe("registerAdapter — duplicate guard", () => {
+  it("throws when the same source is registered twice", () => {
+    registerAdapter({
+      source: "demo",
+      connect: async () => ({ success: true }),
+    });
+    expect(() =>
+      registerAdapter({
+        source: "demo",
+        connect: async () => ({ success: true }),
+      }),
+    ).toThrow(/Adapter already registered for source 'demo'/);
+  });
+});

--- a/supabase/functions/_shared/composio-client.ts
+++ b/supabase/functions/_shared/composio-client.ts
@@ -43,6 +43,71 @@ export interface ComposioToolCallResponse<T = unknown> {
   successful: boolean;
 }
 
+export type ComposioErrorKind =
+  | "auth"
+  | "rate_limit"
+  | "not_found"
+  | "validation"
+  | "upstream"
+  | "unknown";
+
+/**
+ * Structured error thrown by `ComposioClient.request`. Holds both a
+ * developer-facing `upstreamMessage` (logged at console.error) and a
+ * curated `userMessage` safe to surface in a toast or 5xx response body.
+ * Internal endpoint paths and Composio-side request IDs never appear in
+ * `userMessage`.
+ */
+export class ComposioApiError extends Error {
+  readonly status: number;
+  readonly kind: ComposioErrorKind;
+  readonly code: string | null;
+  readonly upstreamMessage: string;
+  readonly userMessage: string;
+
+  constructor(init: {
+    status: number;
+    kind: ComposioErrorKind;
+    code: string | null;
+    upstreamMessage: string;
+    userMessage: string;
+  }) {
+    super(init.upstreamMessage);
+    this.name = "ComposioApiError";
+    this.status = init.status;
+    this.kind = init.kind;
+    this.code = init.code;
+    this.upstreamMessage = init.upstreamMessage;
+    this.userMessage = init.userMessage;
+  }
+}
+
+export function classifyComposioStatus(status: number): ComposioErrorKind {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 404) return "not_found";
+  if (status === 429) return "rate_limit";
+  if (status >= 400 && status < 500) return "validation";
+  if (status >= 500) return "upstream";
+  return "unknown";
+}
+
+function userMessageForKind(kind: ComposioErrorKind): string {
+  switch (kind) {
+    case "auth":
+      return "Composio rejected the request — reconnect the integration.";
+    case "rate_limit":
+      return "Composio rate-limited the request — try again shortly.";
+    case "not_found":
+      return "The Composio resource was not found.";
+    case "validation":
+      return "Composio rejected the request payload.";
+    case "upstream":
+      return "Composio is temporarily unavailable — try again shortly.";
+    default:
+      return "Composio returned an unexpected error.";
+  }
+}
+
 export class ComposioClient {
   private readonly apiKey: string;
   private readonly baseUrl: string;
@@ -154,10 +219,27 @@ export class ComposioClient {
     const payload = text ? safeJsonParse(text) : null;
 
     if (!response.ok) {
-      const message =
+      const kind = classifyComposioStatus(response.status);
+      const upstreamMessage =
         readErrorMessage(payload) ??
         `Composio API ${method} ${path} failed with HTTP ${response.status}`;
-      throw new Error(`[composio-client] ${message}`);
+      const code = readErrorCode(payload);
+      // Developer trace stays in logs; never returned to clients.
+      console.error("[composio-client]", {
+        method,
+        path,
+        status: response.status,
+        kind,
+        code,
+        upstreamMessage,
+      });
+      throw new ComposioApiError({
+        status: response.status,
+        kind,
+        code,
+        upstreamMessage,
+        userMessage: userMessageForKind(kind),
+      });
     }
 
     return payload as T;
@@ -168,8 +250,22 @@ function safeJsonParse(text: string): unknown {
   try {
     return JSON.parse(text);
   } catch {
+    // L6: surface a truncated breadcrumb when the upstream response body
+    // wasn't JSON; full text stays out of return so callers don't leak it.
+    console.error(
+      "[composio-client] non-JSON response body (truncated):",
+      text.slice(0, 200),
+    );
     return text;
   }
+}
+
+function readErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.code === "string") return obj.code;
+  if (typeof obj.error_code === "string") return obj.error_code;
+  return null;
 }
 
 function readErrorMessage(payload: unknown): string | null {

--- a/supabase/functions/_shared/composio-client.ts
+++ b/supabase/functions/_shared/composio-client.ts
@@ -1,0 +1,234 @@
+/**
+ * Composio API client — @composio-unverified
+ *
+ * Thin Deno-runtime wrapper around composio.dev REST endpoints. Used by
+ * `composio-oauth-callback` (auth) and `composio-trigger-webhook` (ingress)
+ * once Phase B ships and `COMPOSIO_API_KEY` is provisioned.
+ *
+ * Status: SCAFFOLD. None of these methods have been exercised against a
+ * live Composio account. Endpoint paths reflect Composio's documented API
+ * shape as of May 2026; verify against current docs before production use:
+ *   https://docs.composio.dev/docs/triggers
+ *   https://docs.composio.dev/toolkits
+ *
+ * Reviewers: if you change a method name or endpoint, also update the
+ * corresponding caller in composio-oauth-callback or composio-trigger-webhook.
+ */
+
+const COMPOSIO_BASE_URL =
+  Deno.env.get("COMPOSIO_BASE_URL") ?? "https://backend.composio.dev/api/v3";
+
+export interface ComposioClientConfig {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface ComposioConnectedAccount {
+  id: string;
+  toolkitSlug: string;
+  status: "INITIATED" | "ACTIVE" | "INACTIVE" | "EXPIRED" | "FAILED";
+  ownerId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ComposioOAuthInitiateResponse {
+  connectedAccountId: string;
+  authUrl: string;
+}
+
+export interface ComposioToolCallResponse<T = unknown> {
+  data?: T;
+  error?: string;
+  successful: boolean;
+}
+
+export class ComposioClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: ComposioClientConfig) {
+    if (!config.apiKey?.trim()) {
+      throw new Error("[composio-client] COMPOSIO_API_KEY is required");
+    }
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl ?? COMPOSIO_BASE_URL;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Initiate an OAuth connection for `toolkitSlug`. Composio returns an
+   * auth URL the user opens to authorize the integration. Once they
+   * authorize, Composio fires a callback to our `composio-oauth-callback`
+   * function with the resulting `connectedAccountId`.
+   *
+   * @composio-unverified
+   */
+  async initiateOAuth(
+    toolkitSlug: string,
+    callbackUrl: string,
+    userId: string,
+  ): Promise<ComposioOAuthInitiateResponse> {
+    const response = await this.request<ComposioOAuthInitiateResponse>(
+      "POST",
+      "/connected_accounts/initiate",
+      {
+        toolkit_slug: toolkitSlug,
+        callback_url: callbackUrl,
+        user_id: userId,
+      },
+    );
+    return response;
+  }
+
+  /**
+   * Look up a connected account by id. Used to verify a webhook delivery
+   * matches an account CallVault knows about.
+   *
+   * @composio-unverified
+   */
+  async getConnectedAccount(
+    connectedAccountId: string,
+  ): Promise<ComposioConnectedAccount> {
+    return this.request<ComposioConnectedAccount>(
+      "GET",
+      `/connected_accounts/${encodeURIComponent(connectedAccountId)}`,
+    );
+  }
+
+  /**
+   * Disconnect a Composio integration. Idempotent.
+   *
+   * @composio-unverified
+   */
+  async deleteConnectedAccount(connectedAccountId: string): Promise<void> {
+    await this.request<void>(
+      "DELETE",
+      `/connected_accounts/${encodeURIComponent(connectedAccountId)}`,
+    );
+  }
+
+  /**
+   * Execute a Composio tool (action) against a connected account. Used by
+   * polling-based adapters (Gong, tl;dv — both have zero triggers).
+   *
+   * @composio-unverified
+   */
+  async executeTool<T = unknown>(
+    toolSlug: string,
+    connectedAccountId: string,
+    input: Record<string, unknown>,
+  ): Promise<ComposioToolCallResponse<T>> {
+    return this.request<ComposioToolCallResponse<T>>(
+      "POST",
+      "/actions/execute",
+      {
+        tool_slug: toolSlug,
+        connected_account_id: connectedAccountId,
+        input,
+      },
+    );
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchImpl(url, {
+      method,
+      headers: {
+        "x-api-key": this.apiKey,
+        "Content-Type": "application/json",
+      },
+      body: body == null ? undefined : JSON.stringify(body),
+    });
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const text = await response.text();
+    const payload = text ? safeJsonParse(text) : null;
+
+    if (!response.ok) {
+      const message =
+        readErrorMessage(payload) ??
+        `Composio API ${method} ${path} failed with HTTP ${response.status}`;
+      throw new Error(`[composio-client] ${message}`);
+    }
+
+    return payload as T;
+  }
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function readErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.error === "string") return obj.error;
+  if (typeof obj.message === "string") return obj.message;
+  return null;
+}
+
+/**
+ * Verifies a Composio webhook delivery signature. Composio signs the raw
+ * request body with the workspace's webhook secret using HMAC-SHA256 and
+ * sends the hex digest in the `webhook-signature` header.
+ *
+ * @composio-unverified — verify the exact header name + signature format
+ * against composio.dev's current trigger documentation before relying on
+ * this in production. Some Composio docs show `webhook-signature`, others
+ * show `x-composio-signature`. The webhook function accepts either.
+ */
+export async function verifyComposioSignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+): Promise<boolean> {
+  if (!signatureHeader || !secret) return false;
+
+  const expected = await computeHmacHex(rawBody, secret);
+  const provided = signatureHeader.replace(/^sha256=/, "").trim();
+  return timingSafeEqual(expected, provided);
+}
+
+async function computeHmacHex(
+  rawBody: string,
+  secret: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(rawBody),
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/supabase/functions/_shared/composio-normalizers/dialpad.ts
+++ b/supabase/functions/_shared/composio-normalizers/dialpad.ts
@@ -1,0 +1,183 @@
+/**
+ * Composio Dialpad normalizer — @composio-unverified
+ *
+ * Maps a Dialpad call recording + transcript payload into the canonical
+ * recording shape. Dialpad delivers call-recording-ready triggers through
+ * Composio, so this normalizer runs on a webhook ingestion path
+ * (composio-trigger-webhook) — not a polling loop.
+ *
+ * Status: SCAFFOLD. Field names below reflect Dialpad's public REST API
+ * surface (v2 calls + transcripts endpoints). Verify against a real
+ * Composio Dialpad payload before relying on this in production.
+ */
+
+import {
+  formatCanonicalTranscript,
+  normalizeEmailList,
+  type CanonicalRecording,
+  type CanonicalTranscriptTurn,
+} from "../canonical-recording.ts";
+
+export interface DialpadCallPayload {
+  call_id?: string | number | null;
+  /** Dialpad call detail metadata. */
+  call?: DialpadCallMeta | null;
+  /** Optional transcript blob; absent when only the recording is ready. */
+  transcript?: DialpadTranscriptEntry[] | null;
+  /** Composio echoes back the connected_account_id on webhook deliveries. */
+  connected_account_id?: string | null;
+}
+
+export interface DialpadCallMeta {
+  id?: string | number | null;
+  internal_number?: string | null;
+  external_number?: string | null;
+  direction?: "inbound" | "outbound" | string | null;
+  date_started?: string | number | null;
+  date_ended?: string | number | null;
+  duration?: number | null;
+  recording_url?: string | null;
+  target?: DialpadUser | null;
+  contact?: DialpadContact | null;
+}
+
+export interface DialpadUser {
+  email?: string | null;
+  name?: string | null;
+}
+
+export interface DialpadContact {
+  email?: string | null;
+  name?: string | null;
+  phone?: string | null;
+}
+
+export interface DialpadTranscriptEntry {
+  content?: string | null;
+  name?: string | null;
+  email?: string | null;
+  start_time?: number | string | null;
+  end_time?: number | string | null;
+  speaker_type?: "user" | "contact" | string | null;
+}
+
+export function dialpadCallToCanonical(
+  payload: DialpadCallPayload,
+): CanonicalRecording {
+  const meta = payload.call ?? {};
+  const externalId = coerceExternalId(meta.id ?? payload.call_id);
+
+  const turns = (payload.transcript ?? [])
+    .map(dialpadEntryToTurn)
+    .filter(Boolean) as CanonicalTranscriptTurn[];
+  const fullTranscript = formatCanonicalTranscript(turns);
+
+  const startTime = coerceDialpadDate(meta.date_started);
+  const endTime = meta.date_ended
+    ? safeCoerceDialpadDate(meta.date_ended)
+    : null;
+  const durationSeconds = normalizeDurationSeconds(meta.duration);
+
+  const targetEmail = meta.target?.email ?? null;
+  const contactEmail = meta.contact?.email ?? null;
+
+  return {
+    externalId,
+    sourceApp: "dialpad",
+    title: buildDialpadTitle(meta),
+    fullTranscript,
+    recordingStartTime: startTime,
+    recordingEndTime: endTime,
+    durationSeconds,
+    sourceUrl: meta.recording_url ?? null,
+    shareUrl: meta.recording_url ?? null,
+    recordedByEmail: targetEmail,
+    recordedByName: meta.target?.name ?? null,
+    participantEmails: normalizeEmailList(
+      [targetEmail, contactEmail].filter(
+        (email): email is string => typeof email === "string",
+      ),
+    ),
+    calendarInvitees: [],
+    sourceMetadata: {
+      dialpad_call_id: externalId,
+      dialpad_direction: meta.direction ?? null,
+      dialpad_internal_number: meta.internal_number ?? null,
+      dialpad_external_number: meta.external_number ?? null,
+      dialpad_contact_phone: meta.contact?.phone ?? null,
+      composio_connected_account_id: payload.connected_account_id ?? null,
+      composio_routed: true,
+    },
+    rawPayload: payload,
+  };
+}
+
+function dialpadEntryToTurn(
+  entry: DialpadTranscriptEntry,
+): CanonicalTranscriptTurn | null {
+  const text = entry.content?.trim();
+  if (!text) return null;
+
+  return {
+    speakerName: entry.name ?? "Unknown",
+    speakerEmail: entry.email ?? null,
+    text,
+    startSeconds: coerceOffsetSeconds(entry.start_time),
+    endSeconds: coerceOffsetSeconds(entry.end_time),
+  };
+}
+
+function buildDialpadTitle(meta: DialpadCallMeta): string {
+  const direction = meta.direction?.toLowerCase();
+  const contactName = meta.contact?.name ?? meta.contact?.phone ?? null;
+  if (direction === "inbound" && contactName)
+    return `Inbound call from ${contactName}`;
+  if (direction === "outbound" && contactName)
+    return `Outbound call to ${contactName}`;
+  return "Dialpad call";
+}
+
+function coerceExternalId(value: string | number | null | undefined): string {
+  if (value == null || value === "") {
+    throw new Error("[composio-normalizer:dialpad] payload is missing call id");
+  }
+  return String(value);
+}
+
+function coerceDialpadDate(value: string | number | null | undefined): string {
+  const iso = safeCoerceDialpadDate(value);
+  if (!iso) {
+    throw new Error(
+      "[composio-normalizer:dialpad] payload is missing call.date_started",
+    );
+  }
+  return iso;
+}
+
+function safeCoerceDialpadDate(
+  value: string | number | null | undefined,
+): string | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    const millis = value > 1e12 ? value : value * 1000;
+    return new Date(millis).toISOString();
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function coerceOffsetSeconds(
+  value: number | string | null | undefined,
+): number | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeDurationSeconds(
+  value: number | null | undefined,
+): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return Math.round(value);
+}

--- a/supabase/functions/_shared/composio-normalizers/gong.ts
+++ b/supabase/functions/_shared/composio-normalizers/gong.ts
@@ -1,0 +1,175 @@
+/**
+ * Composio Gong normalizer — @composio-unverified
+ *
+ * Maps a Gong call + transcript payload (as returned by Composio's
+ * GONG_GET_CALL / GONG_GET_TRANSCRIPT tools) into the canonical recording
+ * shape. Gong has zero triggers in Composio's catalog, so this normalizer
+ * is always invoked from a polling sync — not a webhook delivery.
+ *
+ * Status: SCAFFOLD. The exact response shape of Composio's Gong tools
+ * varies by toolkit version. Field names below reflect Gong's documented
+ * REST schema (calls v2 endpoint). Verify against a real Composio
+ * Gong response before relying on this in production.
+ *
+ * GOTCHA per ADR-006: Gong has a deprecated transcript endpoint. The
+ * current path is `/v2/calls/transcript`. Composio's `GONG_GET_TRANSCRIPT`
+ * tool should already point at v2, but confirm before adoption.
+ */
+
+import {
+  formatCanonicalTranscript,
+  normalizeEmailList,
+  type CanonicalRecording,
+  type CanonicalTranscriptTurn,
+} from "../canonical-recording.ts";
+
+export interface GongCallPayload {
+  metaData?: {
+    id?: string | null;
+    title?: string | null;
+    scheduled?: string | null;
+    started?: string | null;
+    duration?: number | null;
+    url?: string | null;
+    primaryUserId?: string | null;
+    direction?: string | null;
+    media?: string | null;
+  };
+  parties?: GongParty[] | null;
+  transcript?: GongTranscriptTurn[] | null;
+}
+
+export interface GongParty {
+  id?: string | null;
+  emailAddress?: string | null;
+  name?: string | null;
+  speakerId?: string | null;
+  userId?: string | null;
+  affiliation?: "Internal" | "External" | "Unknown" | null;
+}
+
+export interface GongTranscriptTurn {
+  speakerId?: string | null;
+  topic?: string | null;
+  sentences?: GongSentence[] | null;
+}
+
+export interface GongSentence {
+  start?: number | null;
+  end?: number | null;
+  text?: string | null;
+}
+
+export function gongCallToCanonical(
+  payload: GongCallPayload,
+): CanonicalRecording {
+  const meta = payload.metaData ?? {};
+  if (!meta.id) {
+    throw new Error(
+      "[composio-normalizer:gong] payload is missing metaData.id",
+    );
+  }
+
+  const speakerLookup = buildSpeakerLookup(payload.parties ?? []);
+  const turns = flattenGongTurns(payload.transcript ?? [], speakerLookup);
+  const fullTranscript = formatCanonicalTranscript(turns);
+
+  const startTime = coerceGongDate(meta.started ?? meta.scheduled);
+  const durationSeconds = normalizeDurationSeconds(meta.duration);
+  const endTime =
+    durationSeconds != null
+      ? new Date(
+          new Date(startTime).getTime() + durationSeconds * 1000,
+        ).toISOString()
+      : null;
+
+  const primaryParty =
+    (payload.parties ?? []).find((party) => party.id === meta.primaryUserId) ??
+    (payload.parties ?? [])[0] ??
+    null;
+
+  const participantEmails = normalizeEmailList(
+    (payload.parties ?? [])
+      .map((party) => party.emailAddress)
+      .filter((email): email is string => typeof email === "string"),
+  );
+
+  return {
+    externalId: String(meta.id),
+    sourceApp: "gong",
+    title: meta.title?.trim() || "Untitled Gong Call",
+    fullTranscript,
+    recordingStartTime: startTime,
+    recordingEndTime: endTime,
+    durationSeconds,
+    sourceUrl: meta.url ?? null,
+    shareUrl: meta.url ?? null,
+    recordedByEmail: primaryParty?.emailAddress ?? null,
+    recordedByName: primaryParty?.name ?? null,
+    participantEmails,
+    calendarInvitees: payload.parties ?? [],
+    sourceMetadata: {
+      gong_call_id: meta.id,
+      gong_url: meta.url ?? null,
+      gong_direction: meta.direction ?? null,
+      gong_media: meta.media ?? null,
+      composio_routed: true,
+    },
+    rawPayload: payload,
+  };
+}
+
+function buildSpeakerLookup(parties: GongParty[]): Map<string, GongParty> {
+  const lookup = new Map<string, GongParty>();
+  for (const party of parties) {
+    if (party.speakerId) lookup.set(party.speakerId, party);
+    if (party.id) lookup.set(party.id, party);
+  }
+  return lookup;
+}
+
+function flattenGongTurns(
+  transcript: GongTranscriptTurn[],
+  speakerLookup: Map<string, GongParty>,
+): CanonicalTranscriptTurn[] {
+  const turns: CanonicalTranscriptTurn[] = [];
+
+  for (const block of transcript) {
+    const party = block.speakerId ? speakerLookup.get(block.speakerId) : null;
+    for (const sentence of block.sentences ?? []) {
+      const text = sentence.text?.trim();
+      if (!text) continue;
+      turns.push({
+        speakerName: party?.name ?? "Unknown",
+        speakerEmail: party?.emailAddress ?? null,
+        text,
+        startSeconds: sentence.start != null ? sentence.start / 1000 : 0,
+        endSeconds: sentence.end != null ? sentence.end / 1000 : null,
+      });
+    }
+  }
+
+  return turns;
+}
+
+function coerceGongDate(value: string | null | undefined): string {
+  if (!value) {
+    throw new Error(
+      "[composio-normalizer:gong] payload is missing metaData.started/scheduled",
+    );
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(
+      `[composio-normalizer:gong] could not parse date: ${value}`,
+    );
+  }
+  return new Date(parsed).toISOString();
+}
+
+function normalizeDurationSeconds(
+  value: number | null | undefined,
+): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return Math.round(value);
+}

--- a/supabase/functions/_shared/composio-normalizers/gong.ts
+++ b/supabase/functions/_shared/composio-normalizers/gong.ts
@@ -37,6 +37,8 @@ export interface GongCallPayload {
   };
   parties?: GongParty[] | null;
   transcript?: GongTranscriptTurn[] | null;
+  /** Composio echoes back the connected_account_id on tool responses too. */
+  connected_account_id?: string | null;
 }
 
 export interface GongParty {
@@ -113,6 +115,7 @@ export function gongCallToCanonical(
       gong_url: meta.url ?? null,
       gong_direction: meta.direction ?? null,
       gong_media: meta.media ?? null,
+      composio_connected_account_id: payload.connected_account_id ?? null,
       composio_routed: true,
     },
     rawPayload: payload,
@@ -143,7 +146,7 @@ function flattenGongTurns(
         speakerName: party?.name ?? "Unknown",
         speakerEmail: party?.emailAddress ?? null,
         text,
-        startSeconds: sentence.start != null ? sentence.start / 1000 : 0,
+        startSeconds: sentence.start != null ? sentence.start / 1000 : null,
         endSeconds: sentence.end != null ? sentence.end / 1000 : null,
       });
     }

--- a/supabase/functions/_shared/composio-normalizers/webex.ts
+++ b/supabase/functions/_shared/composio-normalizers/webex.ts
@@ -1,0 +1,173 @@
+/**
+ * Composio Webex normalizer — @composio-unverified
+ *
+ * Maps a Webex meeting recording + transcript payload into the canonical
+ * recording shape. Webex delivers recording-ready triggers through
+ * Composio, so this normalizer runs on a webhook ingestion path.
+ *
+ * Status: SCAFFOLD. Field names below reflect Webex's recordings + meeting
+ * transcripts REST API. Verify against a real Composio Webex payload
+ * before relying on this in production.
+ */
+
+import {
+  formatCanonicalTranscript,
+  normalizeEmailList,
+  type CanonicalRecording,
+  type CanonicalTranscriptTurn,
+} from "../canonical-recording.ts";
+
+export interface WebexRecordingPayload {
+  recording?: WebexRecording | null;
+  /** Webex transcripts come from a separate endpoint; Composio joins them. */
+  transcript?: WebexTranscriptSegment[] | null;
+  /** Optional meeting metadata when Composio attaches it. */
+  meeting?: WebexMeeting | null;
+  connected_account_id?: string | null;
+}
+
+export interface WebexRecording {
+  id?: string | null;
+  meetingId?: string | null;
+  topic?: string | null;
+  createTime?: string | null;
+  timeRecorded?: string | null;
+  durationSeconds?: number | null;
+  hostEmail?: string | null;
+  hostDisplayName?: string | null;
+  playbackUrl?: string | null;
+  downloadUrl?: string | null;
+  format?: string | null;
+}
+
+export interface WebexMeeting {
+  id?: string | null;
+  title?: string | null;
+  start?: string | null;
+  end?: string | null;
+  hostEmail?: string | null;
+  hostDisplayName?: string | null;
+  invitees?: Array<{
+    email?: string | null;
+    displayName?: string | null;
+  }> | null;
+}
+
+export interface WebexTranscriptSegment {
+  text?: string | null;
+  speaker?: string | null;
+  speakerEmail?: string | null;
+  startTime?: number | string | null;
+  endTime?: number | string | null;
+}
+
+export function webexRecordingToCanonical(
+  payload: WebexRecordingPayload,
+): CanonicalRecording {
+  const recording = payload.recording ?? {};
+  const meeting = payload.meeting ?? null;
+
+  const externalId = recording.id ?? meeting?.id ?? null;
+  if (!externalId) {
+    throw new Error(
+      "[composio-normalizer:webex] payload is missing recording.id and meeting.id",
+    );
+  }
+
+  const turns = (payload.transcript ?? [])
+    .map(webexSegmentToTurn)
+    .filter(Boolean) as CanonicalTranscriptTurn[];
+  const fullTranscript = formatCanonicalTranscript(turns);
+
+  const startTime = coerceWebexDate(
+    recording.timeRecorded ?? recording.createTime ?? meeting?.start,
+  );
+  const durationSeconds = normalizeDurationSeconds(recording.durationSeconds);
+  const endTime = meeting?.end
+    ? safeCoerceWebexDate(meeting.end)
+    : durationSeconds != null
+      ? new Date(
+          new Date(startTime).getTime() + durationSeconds * 1000,
+        ).toISOString()
+      : null;
+
+  const hostEmail = recording.hostEmail ?? meeting?.hostEmail ?? null;
+  const inviteeEmails = (meeting?.invitees ?? [])
+    .map((invitee) => invitee.email)
+    .filter((email): email is string => typeof email === "string");
+
+  return {
+    externalId,
+    sourceApp: "webex",
+    title: recording.topic?.trim() || meeting?.title?.trim() || "Webex Meeting",
+    fullTranscript,
+    recordingStartTime: startTime,
+    recordingEndTime: endTime,
+    durationSeconds,
+    sourceUrl: recording.playbackUrl ?? recording.downloadUrl ?? null,
+    shareUrl: recording.playbackUrl ?? null,
+    recordedByEmail: hostEmail,
+    recordedByName:
+      recording.hostDisplayName ?? meeting?.hostDisplayName ?? null,
+    participantEmails: normalizeEmailList(
+      [hostEmail, ...inviteeEmails].filter(Boolean) as string[],
+    ),
+    calendarInvitees: meeting?.invitees ?? [],
+    sourceMetadata: {
+      webex_recording_id: recording.id ?? null,
+      webex_meeting_id: meeting?.id ?? null,
+      webex_format: recording.format ?? null,
+      webex_playback_url: recording.playbackUrl ?? null,
+      webex_download_url: recording.downloadUrl ?? null,
+      composio_connected_account_id: payload.connected_account_id ?? null,
+      composio_routed: true,
+    },
+    rawPayload: payload,
+  };
+}
+
+function webexSegmentToTurn(
+  segment: WebexTranscriptSegment,
+): CanonicalTranscriptTurn | null {
+  const text = segment.text?.trim();
+  if (!text) return null;
+  return {
+    speakerName: segment.speaker ?? "Unknown",
+    speakerEmail: segment.speakerEmail ?? null,
+    text,
+    startSeconds: coerceOffsetSeconds(segment.startTime),
+    endSeconds: coerceOffsetSeconds(segment.endTime),
+  };
+}
+
+function coerceWebexDate(value: string | null | undefined): string {
+  const iso = safeCoerceWebexDate(value);
+  if (!iso) {
+    throw new Error(
+      "[composio-normalizer:webex] could not derive a valid recording start time",
+    );
+  }
+  return iso;
+}
+
+function safeCoerceWebexDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function coerceOffsetSeconds(
+  value: number | string | null | undefined,
+): number | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeDurationSeconds(
+  value: number | null | undefined,
+): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return Math.round(value);
+}

--- a/supabase/functions/_shared/connector-framework.ts
+++ b/supabase/functions/_shared/connector-framework.ts
@@ -89,11 +89,16 @@ const ADAPTER_REGISTRY = new Map<string, ConnectorAdapter>();
 
 export function registerAdapter(adapter: ConnectorAdapter): void {
   if (ADAPTER_REGISTRY.has(adapter.source)) {
-    console.warn(
-      `[connector-framework] Adapter already registered for ${adapter.source} — overwriting`,
+    throw new Error(
+      `[connector-framework] Adapter already registered for source '${adapter.source}'`,
     );
   }
   ADAPTER_REGISTRY.set(adapter.source, adapter);
+}
+
+/** Test-only — clears the registry between unit-test cases. */
+export function _resetAdapterRegistryForTests(): void {
+  ADAPTER_REGISTRY.clear();
 }
 
 export function getAdapter(source: string): ConnectorAdapter | undefined {

--- a/supabase/functions/_shared/connector-framework.ts
+++ b/supabase/functions/_shared/connector-framework.ts
@@ -1,0 +1,183 @@
+/**
+ * Connector framework — server-side dispatch types + helpers.
+ *
+ * This is the backend counterpart to `src/config/source-registry.ts`. The
+ * registry of source-app identifiers lives in frontend code; this file
+ * defines the discriminated request shape the dispatcher edge function
+ * accepts and the canonical adapter interface every new connector
+ * implementation must conform to.
+ *
+ * Wiring contract:
+ *   1. New connector defines a `ConnectorAdapter` implementation here.
+ *   2. Registers itself in `ADAPTER_REGISTRY` below.
+ *   3. The single `connector-dispatcher` edge function routes
+ *      `{ source, action }` payloads to the matching adapter.
+ *   4. Adapter returns a canonical `AdapterResult` that the dispatcher
+ *      forwards to the client.
+ *
+ * Existing native connectors (Fathom / Fireflies / Zoom / Plaud / YouTube)
+ * are NOT migrated here. Their dedicated edge functions remain the
+ * production path. This framework is for NEW sources.
+ */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// ---------------------------------------------------------------------------
+// Discriminated request shape
+// ---------------------------------------------------------------------------
+
+export type ConnectorAction =
+  | "connect"
+  | "disconnect"
+  | "fetch"
+  | "sync"
+  | "status";
+
+export interface ConnectorRequest {
+  source: string;
+  action: ConnectorAction;
+  /** Per-action payload. The dispatcher does not inspect this. */
+  payload?: Record<string, unknown>;
+}
+
+export interface AdapterContext {
+  supabase: SupabaseClient;
+  userId: string;
+  /** Optional org override; if omitted, adapters resolve the user's personal org. */
+  organizationId?: string;
+}
+
+export interface AdapterResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  /** Optional duplicate / no-op marker so the dispatcher can return 200 without a recording id. */
+  skipped?: boolean;
+}
+
+export interface ConnectorAdapter {
+  /** Source-app id; MUST match a registered SourceConfig.id on the frontend. */
+  source: string;
+  /** Optional per-action handlers. Unimplemented actions return 501. */
+  connect?: (
+    ctx: AdapterContext,
+    request: ConnectorRequest,
+  ) => Promise<AdapterResult>;
+  disconnect?: (
+    ctx: AdapterContext,
+    request: ConnectorRequest,
+  ) => Promise<AdapterResult>;
+  fetch?: (
+    ctx: AdapterContext,
+    request: ConnectorRequest,
+  ) => Promise<AdapterResult>;
+  sync?: (
+    ctx: AdapterContext,
+    request: ConnectorRequest,
+  ) => Promise<AdapterResult>;
+  status?: (
+    ctx: AdapterContext,
+    request: ConnectorRequest,
+  ) => Promise<AdapterResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const ADAPTER_REGISTRY = new Map<string, ConnectorAdapter>();
+
+export function registerAdapter(adapter: ConnectorAdapter): void {
+  if (ADAPTER_REGISTRY.has(adapter.source)) {
+    console.warn(
+      `[connector-framework] Adapter already registered for ${adapter.source} — overwriting`,
+    );
+  }
+  ADAPTER_REGISTRY.set(adapter.source, adapter);
+}
+
+export function getAdapter(source: string): ConnectorAdapter | undefined {
+  return ADAPTER_REGISTRY.get(source);
+}
+
+export function listAdapterSources(): string[] {
+  return [...ADAPTER_REGISTRY.keys()];
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+export async function dispatchConnectorRequest(
+  ctx: AdapterContext,
+  request: ConnectorRequest,
+): Promise<{ status: number; body: AdapterResult }> {
+  const validationError = validateRequest(request);
+  if (validationError) {
+    return { status: 400, body: { success: false, error: validationError } };
+  }
+
+  const adapter = getAdapter(request.source);
+  if (!adapter) {
+    return {
+      status: 404,
+      body: {
+        success: false,
+        error: `No connector adapter registered for source '${request.source}'`,
+      },
+    };
+  }
+
+  const handler = adapter[request.action];
+  if (!handler) {
+    return {
+      status: 501,
+      body: {
+        success: false,
+        error: `Source '${request.source}' does not implement action '${request.action}'`,
+      },
+    };
+  }
+
+  try {
+    const result = await handler(ctx, request);
+    return {
+      status: result.success || result.skipped ? 200 : 500,
+      body: result,
+    };
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Unknown adapter error";
+    console.error(
+      `[connector-framework] ${request.source}/${request.action} failed:`,
+      message,
+    );
+    return { status: 500, body: { success: false, error: message } };
+  }
+}
+
+function validateRequest(request: unknown): string | null {
+  if (!request || typeof request !== "object")
+    return "Request body must be an object";
+  const candidate = request as Partial<ConnectorRequest>;
+  if (typeof candidate.source !== "string" || !candidate.source.trim()) {
+    return "Request.source must be a non-empty string";
+  }
+  if (
+    typeof candidate.action !== "string" ||
+    !isConnectorAction(candidate.action)
+  ) {
+    return "Request.action must be one of: connect, disconnect, fetch, sync, status";
+  }
+  return null;
+}
+
+function isConnectorAction(value: string): value is ConnectorAction {
+  return (
+    value === "connect" ||
+    value === "disconnect" ||
+    value === "fetch" ||
+    value === "sync" ||
+    value === "status"
+  );
+}

--- a/supabase/functions/composio-oauth-callback/__tests__/wiring.test.ts
+++ b/supabase/functions/composio-oauth-callback/__tests__/wiring.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("composio-oauth-callback wiring — auth + config (H2, H5)", () => {
+  it("returns 503 when COMPOSIO_API_KEY is missing", () => {
+    expect(source).toMatch(/COMPOSIO_API_KEY not configured/);
+    expect(source).toMatch(/503/);
+  });
+
+  it("rejects requests without a Supabase JWT (both actions are frontend-mediated)", () => {
+    expect(source).toMatch(/No authorization header/);
+    expect(source).toMatch(/401/);
+    expect(source).toMatch(/supabase\.auth\.getUser\(/);
+  });
+
+  it("surfaces only ComposioApiError.userMessage to clients (H5)", () => {
+    expect(source).toMatch(/ComposioApiError/);
+    expect(source).toMatch(/error\.userMessage/);
+  });
+});
+
+describe("composio-oauth-callback wiring — initiate", () => {
+  it("requires toolkit for initiate", () => {
+    expect(source).toMatch(/toolkit is required for initiate/);
+  });
+
+  it("calls composio.initiateOAuth(toolkit, callbackUrl, user.id)", () => {
+    expect(source).toMatch(/composio\.initiateOAuth\(/);
+  });
+});
+
+describe("composio-oauth-callback wiring — complete (C1, C2, C3, M10)", () => {
+  it("requires connectedAccountId and toolkit for complete", () => {
+    expect(source).toMatch(
+      /connectedAccountId and toolkit are required for complete/,
+    );
+  });
+
+  it("validates source_app slug matches lowercase-kebab-case (M10)", () => {
+    expect(source).toMatch(/lowercase-kebab-case required/);
+  });
+
+  it("refuses to persist when Composio account status is not ACTIVE", () => {
+    expect(source).toMatch(/status is \$\{account\.status\}/);
+    expect(source).toMatch(/422/);
+  });
+
+  it("writes composio_connected_account_id as a TOP-LEVEL column (NOT a JSONB key)", () => {
+    // Regression guard for C2/C3: the dedicated column drives both the
+    // upsert conflict target and the webhook lookup.
+    expect(source).toMatch(
+      /composio_connected_account_id:\s*body\.connectedAccountId/,
+    );
+  });
+
+  it("upserts onConflict=composio_connected_account_id (NOT user_id,source_app)", () => {
+    // The (user_id, source_app) UNIQUE was dropped to enable multi-account.
+    expect(source).toMatch(
+      /onConflict:\s*["']composio_connected_account_id["']/,
+    );
+    expect(source).not.toMatch(/onConflict:\s*["']user_id,source_app["']/);
+  });
+
+  it("does not blow away connection_metadata sibling fields (C2)", () => {
+    // The merge-or-replace concern is resolved by moving the routing field
+    // out of JSONB and onto the typed column. Guard: the upsert must NOT
+    // include composio_connected_account_id inside connection_metadata.
+    const completeBlock = source.split('body.action === "complete"')[1] ?? "";
+    expect(completeBlock).not.toMatch(
+      /connection_metadata:[^}]*composio_connected_account_id/,
+    );
+  });
+});

--- a/supabase/functions/composio-oauth-callback/index.ts
+++ b/supabase/functions/composio-oauth-callback/index.ts
@@ -4,10 +4,15 @@
  * Two responsibilities:
  *   1. action='initiate' — user-initiated request to start a Composio OAuth
  *      flow for a toolkit. Returns the Composio-hosted auth URL the client
- *      opens in a new tab.
- *   2. action='complete' — Composio's redirect after the user authorizes.
- *      Receives the resulting `connectedAccountId`, persists it on the
- *      matching `import_sources` row.
+ *      opens in a new tab. Requires a Supabase user JWT.
+ *   2. action='complete' — frontend-mediated handoff after the user
+ *      authorizes. Composio redirects the browser to `/import`; the frontend
+ *      then POSTs `{ action: "complete", connectedAccountId, toolkit }` to
+ *      this function under the user's Supabase JWT. The function persists
+ *      `composio_connected_account_id` on a fresh `import_sources` row.
+ *
+ *      Note: Composio does NOT call this function directly server-to-server
+ *      — the user's browser does. That's why both actions require a JWT.
  *
  * Status: SCAFFOLD. Calling this function before Phase B (Composio account
  * provisioning + OAuth app registration with each vendor) will fail. The
@@ -18,7 +23,10 @@
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { ComposioClient } from "../_shared/composio-client.ts";
+import {
+  ComposioApiError,
+  ComposioClient,
+} from "../_shared/composio-client.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -98,6 +106,20 @@ Deno.serve(async (req) => {
         );
       }
 
+      // Canonical source_app keys are lowercase-kebab-case (see
+      // canonical-recording.ts SOURCE_APP_PATTERN). Composio toolkit slugs
+      // come in lowercase, but guard against drift / future toolkits before
+      // we persist a noncanonical row that downstream lookups won't find.
+      const sourceApp = String(body.toolkit).toLowerCase();
+      if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(sourceApp)) {
+        return jsonResponse(
+          {
+            error: `toolkit '${body.toolkit}' is not a valid source_app slug (lowercase-kebab-case required)`,
+          },
+          400,
+        );
+      }
+
       const account = await composio.getConnectedAccount(
         body.connectedAccountId,
       );
@@ -110,7 +132,11 @@ Deno.serve(async (req) => {
         );
       }
 
-      const sourceApp = body.toolkit;
+      // Fix C1/C2/C3: upsert on the partial unique index covering
+      // composio_connected_account_id (created in 20260523192117 migration);
+      // the previous (user_id, source_app) UNIQUE was dropped to enable
+      // multi-account support. Use the dedicated column + JSONB merge so
+      // sibling-adapter fields (webhook_path_token, etc.) survive the write.
       const { error: upsertError } = await supabase
         .from("import_sources")
         .upsert(
@@ -119,13 +145,13 @@ Deno.serve(async (req) => {
             source_app: sourceApp,
             is_active: true,
             account_email: body.accountEmail ?? null,
+            composio_connected_account_id: body.connectedAccountId,
             connection_metadata: {
-              composio_connected_account_id: body.connectedAccountId,
-              composio_toolkit: body.toolkit,
+              composio_toolkit: sourceApp,
             },
             updated_at: new Date().toISOString(),
           },
-          { onConflict: "user_id,source_app" },
+          { onConflict: "composio_connected_account_id" },
         );
 
       if (upsertError) {
@@ -142,6 +168,14 @@ Deno.serve(async (req) => {
     return jsonResponse({ error: "action must be initiate or complete" }, 400);
   } catch (error) {
     console.error("[composio-oauth-callback] error:", error);
+    if (error instanceof ComposioApiError) {
+      // H5: surface only the curated userMessage to clients. The full
+      // upstreamMessage already went through console.error inside the
+      // client's request() so the operator trace is intact.
+      const status =
+        error.kind === "auth" ? 401 : error.kind === "rate_limit" ? 429 : 502;
+      return jsonResponse({ error: error.userMessage }, status);
+    }
     const message = error instanceof Error ? error.message : "Unknown error";
     return jsonResponse({ error: message }, 500);
   }

--- a/supabase/functions/composio-oauth-callback/index.ts
+++ b/supabase/functions/composio-oauth-callback/index.ts
@@ -1,0 +1,155 @@
+/**
+ * composio-oauth-callback — @composio-unverified
+ *
+ * Two responsibilities:
+ *   1. action='initiate' — user-initiated request to start a Composio OAuth
+ *      flow for a toolkit. Returns the Composio-hosted auth URL the client
+ *      opens in a new tab.
+ *   2. action='complete' — Composio's redirect after the user authorizes.
+ *      Receives the resulting `connectedAccountId`, persists it on the
+ *      matching `import_sources` row.
+ *
+ * Status: SCAFFOLD. Calling this function before Phase B (Composio account
+ * provisioning + OAuth app registration with each vendor) will fail. The
+ * shape is defined so the frontend `ComposioAdapter` can be unit-tested.
+ *
+ * Reviewers: this function intentionally returns 503 when COMPOSIO_API_KEY
+ * is missing so a misconfigured deploy doesn't silently 200.
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { ComposioClient } from "../_shared/composio-client.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, sentry-trace, baggage",
+};
+
+interface RequestBody {
+  action?: "initiate" | "complete";
+  toolkit?: string;
+  sourceId?: string | null;
+  /** Provided on 'complete' callbacks from Composio. */
+  connectedAccountId?: string | null;
+  /** Optional account email captured by the vendor during authorization. */
+  accountEmail?: string | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const apiKey = Deno.env.get("COMPOSIO_API_KEY");
+    if (!apiKey) {
+      return jsonResponse({ error: "COMPOSIO_API_KEY not configured" }, 503);
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return jsonResponse({ error: "No authorization header" }, 401);
+    }
+    const token = authHeader.replace("Bearer ", "");
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser(token);
+    if (userError || !user) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    let body: RequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse({ error: "Request body must be JSON" }, 400);
+    }
+
+    const composio = new ComposioClient({ apiKey });
+
+    if (body.action === "initiate") {
+      if (!body.toolkit) {
+        return jsonResponse({ error: "toolkit is required for initiate" }, 400);
+      }
+      const callbackUrl = `${supabaseUrl}/functions/v1/composio-oauth-callback?return=${encodeURIComponent("/import")}`;
+      const result = await composio.initiateOAuth(
+        body.toolkit,
+        callbackUrl,
+        user.id,
+      );
+      return jsonResponse({
+        success: true,
+        authUrl: result.authUrl,
+        connectedAccountId: result.connectedAccountId,
+      });
+    }
+
+    if (body.action === "complete") {
+      if (!body.connectedAccountId || !body.toolkit) {
+        return jsonResponse(
+          { error: "connectedAccountId and toolkit are required for complete" },
+          400,
+        );
+      }
+
+      const account = await composio.getConnectedAccount(
+        body.connectedAccountId,
+      );
+      if (account.status !== "ACTIVE") {
+        return jsonResponse(
+          {
+            error: `Composio account status is ${account.status}; refusing to persist`,
+          },
+          422,
+        );
+      }
+
+      const sourceApp = body.toolkit;
+      const { error: upsertError } = await supabase
+        .from("import_sources")
+        .upsert(
+          {
+            user_id: user.id,
+            source_app: sourceApp,
+            is_active: true,
+            account_email: body.accountEmail ?? null,
+            connection_metadata: {
+              composio_connected_account_id: body.connectedAccountId,
+              composio_toolkit: body.toolkit,
+            },
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: "user_id,source_app" },
+        );
+
+      if (upsertError) {
+        console.error("[composio-oauth-callback] upsert failed:", upsertError);
+        return jsonResponse({ error: upsertError.message }, 500);
+      }
+
+      return jsonResponse({
+        success: true,
+        connectedAccountId: body.connectedAccountId,
+      });
+    }
+
+    return jsonResponse({ error: "action must be initiate or complete" }, 400);
+  } catch (error) {
+    console.error("[composio-oauth-callback] error:", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return jsonResponse({ error: message }, 500);
+  }
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/composio-trigger-webhook/__tests__/wiring.test.ts
+++ b/supabase/functions/composio-trigger-webhook/__tests__/wiring.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("composio-trigger-webhook wiring — auth + signature contract", () => {
+  it("returns 503 when COMPOSIO_WEBHOOK_SECRET is missing", () => {
+    expect(source).toMatch(/COMPOSIO_WEBHOOK_SECRET/);
+    expect(source).toMatch(/Webhook secret not configured/);
+    expect(source).toMatch(/503/);
+  });
+
+  it("returns 401 when neither signature header is provided", () => {
+    expect(source).toMatch(/webhook-signature/);
+    expect(source).toMatch(/x-composio-signature/);
+    expect(source).toMatch(/Missing webhook-signature header/);
+  });
+
+  it("returns 401 when verifyComposioSignature rejects the body", () => {
+    expect(source).toMatch(/verifyComposioSignature\(/);
+    expect(source).toMatch(/Invalid webhook signature/);
+  });
+});
+
+describe("composio-trigger-webhook wiring — envelope contract", () => {
+  it("returns 400 when the body is not JSON", () => {
+    expect(source).toMatch(/Webhook body must be JSON/);
+  });
+
+  it("returns 400 when connected_account_id is missing", () => {
+    expect(source).toMatch(/missing connected_account_id/);
+  });
+});
+
+describe("composio-trigger-webhook wiring — lookup + anti-enumeration", () => {
+  it("queries the dedicated composio_connected_account_id column (NOT the JSONB blob)", () => {
+    // Regression guard: switching back to connection_metadata->> would bypass
+    // the partial unique index.
+    expect(source).toMatch(
+      /\.eq\(\s*["']composio_connected_account_id["']\s*,\s*envelope\.connected_account_id\s*\)/,
+    );
+  });
+
+  it("returns 200 with ignored=true and reason=no_match for unknown accounts", () => {
+    // ADR-006 anti-enumeration — must never regress.
+    expect(source).toMatch(/reason: ["']no_match["']/);
+    expect(source).toMatch(/ignored: true/);
+  });
+});
+
+describe("composio-trigger-webhook wiring — normalizer error handling (H3)", () => {
+  it("wraps normalizeByToolkit in a try/catch and returns 200 ignored with reason=normalizer_failed", () => {
+    expect(source).toMatch(/normalizeByToolkit\(/);
+    expect(source).toMatch(/reason: ["']normalizer_failed["']/);
+    // Logs a redacted breadcrumb — must not log the raw payload (PII).
+    expect(source).toMatch(/normalizer failed/);
+    expect(source).not.toMatch(/console\.error\([^)]*envelope\.payload/);
+  });
+});
+
+describe("composio-trigger-webhook wiring — status update error check (H4)", () => {
+  it("destructures the import_sources update error and logs on failure", () => {
+    expect(source).toMatch(/error: statusUpdateError/);
+    expect(source).toMatch(/failed to update import_sources status/);
+  });
+});
+
+describe("composio-trigger-webhook wiring — pipeline failure breadcrumb (M3)", () => {
+  it("emits console.error when pipeline result is unsuccessful and not skipped", () => {
+    expect(source).toMatch(/pipeline failed/);
+  });
+});

--- a/supabase/functions/composio-trigger-webhook/index.ts
+++ b/supabase/functions/composio-trigger-webhook/index.ts
@@ -1,0 +1,208 @@
+/**
+ * composio-trigger-webhook — @composio-unverified
+ *
+ * Single webhook ingress for every Composio-routed trigger (Zoom, Webex,
+ * Dialpad, Microsoft Teams, Google Meet, Fireflies-via-Composio, etc.).
+ * Composio posts a signed payload per trigger event; this function:
+ *
+ *   1. Reads the `webhook-signature` (or `x-composio-signature`) header.
+ *   2. Verifies HMAC-SHA256 against COMPOSIO_WEBHOOK_SECRET.
+ *   3. Routes the payload to a per-toolkit normalizer.
+ *   4. Pushes the canonical recording through `runCanonicalConnectorPipeline`.
+ *
+ * Status: SCAFFOLD. The exact trigger event names and payload structure
+ * vary per toolkit. Verify against the live Composio Triggers documentation
+ * before adopting any specific source.
+ *
+ * Security posture (mirrors fireflies-webhook):
+ *   - Reject missing signature → 401.
+ *   - Reject unmatched connected_account_id → 200 (per ADR-006: avoid
+ *     leaking which accounts CallVault tracks; Composio retries on non-2xx).
+ *   - Reject tampered signature → 401.
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { verifyComposioSignature } from "../_shared/composio-client.ts";
+import { runCanonicalConnectorPipeline } from "../_shared/recording-connectors.ts";
+import {
+  gongCallToCanonical,
+  type GongCallPayload,
+} from "../_shared/composio-normalizers/gong.ts";
+import {
+  dialpadCallToCanonical,
+  type DialpadCallPayload,
+} from "../_shared/composio-normalizers/dialpad.ts";
+import {
+  webexRecordingToCanonical,
+  type WebexRecordingPayload,
+} from "../_shared/composio-normalizers/webex.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, webhook-signature, x-composio-signature",
+};
+
+interface ComposioTriggerEnvelope {
+  trigger_slug?: string;
+  toolkit?: string;
+  connected_account_id?: string;
+  payload?: unknown;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const webhookSecret = Deno.env.get("COMPOSIO_WEBHOOK_SECRET");
+    if (!webhookSecret) {
+      console.error(
+        "[composio-trigger-webhook] COMPOSIO_WEBHOOK_SECRET not configured",
+      );
+      return jsonResponse({ error: "Webhook secret not configured" }, 503);
+    }
+
+    const rawBody = await req.text();
+    const signature =
+      req.headers.get("webhook-signature") ||
+      req.headers.get("x-composio-signature") ||
+      "";
+
+    if (!signature) {
+      return jsonResponse({ error: "Missing webhook-signature header" }, 401);
+    }
+
+    const isValid = await verifyComposioSignature(
+      rawBody,
+      signature,
+      webhookSecret,
+    );
+    if (!isValid) {
+      return jsonResponse({ error: "Invalid webhook signature" }, 401);
+    }
+
+    let envelope: ComposioTriggerEnvelope;
+    try {
+      envelope = JSON.parse(rawBody);
+    } catch {
+      return jsonResponse({ error: "Webhook body must be JSON" }, 400);
+    }
+
+    if (!envelope.connected_account_id) {
+      return jsonResponse(
+        { error: "Webhook envelope missing connected_account_id" },
+        400,
+      );
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Look up the import_sources row by composio_connected_account_id stored in connection_metadata.
+    const { data: matchingSource, error: lookupError } = await supabase
+      .from("import_sources")
+      .select("id, user_id, source_app, connection_metadata")
+      .eq(
+        "connection_metadata->>composio_connected_account_id",
+        envelope.connected_account_id,
+      )
+      .eq("is_active", true)
+      .maybeSingle();
+
+    if (lookupError) {
+      console.error("[composio-trigger-webhook] lookup error:", lookupError);
+      return jsonResponse({ error: lookupError.message }, 500);
+    }
+
+    if (!matchingSource) {
+      // Per fireflies-webhook precedent: return 200 to prevent retry storms
+      // and avoid leaking which accounts CallVault knows about.
+      console.warn(
+        "[composio-trigger-webhook] no matching source for connected_account_id",
+        {
+          connected_account_id: envelope.connected_account_id,
+        },
+      );
+      return jsonResponse({ success: true, ignored: true, reason: "no_match" });
+    }
+
+    const toolkit = (
+      envelope.toolkit ??
+      matchingSource.source_app ??
+      ""
+    ).toLowerCase();
+    const canonical = normalizeByToolkit(toolkit, envelope);
+    if (!canonical) {
+      console.warn("[composio-trigger-webhook] no normalizer for toolkit", {
+        toolkit,
+      });
+      return jsonResponse({
+        success: true,
+        ignored: true,
+        reason: "no_normalizer",
+      });
+    }
+
+    const result = await runCanonicalConnectorPipeline(
+      supabase,
+      matchingSource.user_id,
+      canonical,
+      {
+        importSource: `composio-${toolkit}`,
+        includeRawPayload: true,
+      },
+    );
+
+    await supabase
+      .from("import_sources")
+      .update({
+        last_sync_at: new Date().toISOString(),
+        error_message:
+          result.success || result.skipped
+            ? null
+            : (result.error ?? "Composio webhook import failed"),
+      })
+      .eq("id", matchingSource.id)
+      .eq("user_id", matchingSource.user_id);
+
+    return jsonResponse({
+      success: result.success,
+      skipped: result.skipped ?? false,
+      recordingId: result.recordingId ?? null,
+    });
+  } catch (error) {
+    console.error("[composio-trigger-webhook] error:", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return jsonResponse({ error: message }, 500);
+  }
+});
+
+function normalizeByToolkit(
+  toolkit: string,
+  envelope: ComposioTriggerEnvelope,
+) {
+  if (!envelope.payload || typeof envelope.payload !== "object") return null;
+  const payload = envelope.payload as Record<string, unknown>;
+  // Surface the connected_account_id into the payload so normalizers can stamp it.
+  if (envelope.connected_account_id) {
+    payload["connected_account_id"] = envelope.connected_account_id;
+  }
+
+  if (toolkit === "gong")
+    return gongCallToCanonical(payload as GongCallPayload);
+  if (toolkit === "dialpad")
+    return dialpadCallToCanonical(payload as DialpadCallPayload);
+  if (toolkit === "webex")
+    return webexRecordingToCanonical(payload as WebexRecordingPayload);
+  return null;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/composio-trigger-webhook/index.ts
+++ b/supabase/functions/composio-trigger-webhook/index.ts
@@ -1,9 +1,11 @@
 /**
  * composio-trigger-webhook — @composio-unverified
  *
- * Single webhook ingress for every Composio-routed trigger (Zoom, Webex,
- * Dialpad, Microsoft Teams, Google Meet, Fireflies-via-Composio, etc.).
- * Composio posts a signed payload per trigger event; this function:
+ * Single webhook ingress for Composio-routed triggers. Phase B scaffold
+ * normalizers cover gong / dialpad / webex; additional toolkits (Microsoft
+ * Teams, Google Meet, Fireflies-via-Composio, etc.) are planned per ADR-006
+ * but not yet implemented in `normalizeByToolkit`. Composio posts a signed
+ * payload per trigger event; this function:
  *
  *   1. Reads the `webhook-signature` (or `x-composio-signature`) header.
  *   2. Verifies HMAC-SHA256 against COMPOSIO_WEBHOOK_SECRET.
@@ -19,6 +21,9 @@
  *   - Reject unmatched connected_account_id → 200 (per ADR-006: avoid
  *     leaking which accounts CallVault tracks; Composio retries on non-2xx).
  *   - Reject tampered signature → 401.
+ *   - Reject normalizer payload-shape errors → 200 ignored. A malformed
+ *     vendor payload is NOT retriable — returning 5xx would create an
+ *     infinite Composio retry loop on bad data.
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
@@ -39,6 +44,7 @@ import {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type, webhook-signature, x-composio-signature",
 };
@@ -101,14 +107,15 @@ Deno.serve(async (req) => {
     const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    // Look up the import_sources row by composio_connected_account_id stored in connection_metadata.
+    // Look up by the dedicated column (denormalized + uniquely indexed in
+    // 20260523192117_composio_integration_ids.sql). Querying the JSONB blob
+    // bypasses the unique index and lets two rows collide silently.
     const { data: matchingSource, error: lookupError } = await supabase
       .from("import_sources")
-      .select("id, user_id, source_app, connection_metadata")
-      .eq(
-        "connection_metadata->>composio_connected_account_id",
-        envelope.connected_account_id,
+      .select(
+        "id, user_id, source_app, connection_metadata, composio_connected_account_id",
       )
+      .eq("composio_connected_account_id", envelope.connected_account_id)
       .eq("is_active", true)
       .maybeSingle();
 
@@ -134,7 +141,33 @@ Deno.serve(async (req) => {
       matchingSource.source_app ??
       ""
     ).toLowerCase();
-    const canonical = normalizeByToolkit(toolkit, envelope);
+
+    // H3: Wrap normalizer call in its own try/catch. Normalizers throw on
+    // missing required fields (`gong.metaData.id`, `dialpad.call.date_started`,
+    // `webex.recording.id`/`meeting.id`). Without this guard a malformed
+    // payload propagates to the outer catch → HTTP 500 → Composio retries
+    // forever. Log a redacted breadcrumb; NEVER log envelope.payload (PII).
+    let canonical;
+    try {
+      canonical = normalizeByToolkit(toolkit, envelope);
+    } catch (normalizerError) {
+      const message =
+        normalizerError instanceof Error
+          ? normalizerError.message
+          : "unknown normalizer error";
+      console.error("[composio-trigger-webhook] normalizer failed", {
+        toolkit,
+        trigger_slug: envelope.trigger_slug ?? null,
+        connected_account_id: envelope.connected_account_id,
+        message,
+      });
+      return jsonResponse({
+        success: true,
+        ignored: true,
+        reason: "normalizer_failed",
+      });
+    }
+
     if (!canonical) {
       console.warn("[composio-trigger-webhook] no normalizer for toolkit", {
         toolkit,
@@ -156,7 +189,11 @@ Deno.serve(async (req) => {
       },
     );
 
-    await supabase
+    // H4: status update was previously fire-and-forget — if it failed the
+    // row's last_sync_at would stay stale and any prior error_message would
+    // stay stuck. Continue returning the pipeline result to Composio either
+    // way (recording is already persisted by runCanonicalConnectorPipeline).
+    const { error: statusUpdateError } = await supabase
       .from("import_sources")
       .update({
         last_sync_at: new Date().toISOString(),
@@ -167,6 +204,29 @@ Deno.serve(async (req) => {
       })
       .eq("id", matchingSource.id)
       .eq("user_id", matchingSource.user_id);
+
+    if (statusUpdateError) {
+      console.error(
+        "[composio-trigger-webhook] failed to update import_sources status",
+        {
+          import_source_id: matchingSource.id,
+          user_id: matchingSource.user_id,
+          message: statusUpdateError.message,
+        },
+      );
+    }
+
+    // M3: emit a console.error breadcrumb when the pipeline reports failure
+    // so aggregated alerting picks it up. The DB-side error_message is
+    // operator-facing; this is the log-aggregator signal.
+    if (!result.success && !result.skipped) {
+      console.error("[composio-trigger-webhook] pipeline failed", {
+        import_source_id: matchingSource.id,
+        user_id: matchingSource.user_id,
+        toolkit,
+        error: result.error ?? null,
+      });
+    }
 
     return jsonResponse({
       success: result.success,
@@ -185,8 +245,12 @@ function normalizeByToolkit(
   envelope: ComposioTriggerEnvelope,
 ) {
   if (!envelope.payload || typeof envelope.payload !== "object") return null;
-  const payload = envelope.payload as Record<string, unknown>;
-  // Surface the connected_account_id into the payload so normalizers can stamp it.
+  // L3: don't mutate the caller-provided envelope.payload — clone so the
+  // connected_account_id we stamp here never leaks into upstream callers or
+  // future retry inspection.
+  const payload: Record<string, unknown> = {
+    ...(envelope.payload as Record<string, unknown>),
+  };
   if (envelope.connected_account_id) {
     payload["connected_account_id"] = envelope.connected_account_id;
   }

--- a/supabase/functions/connector-dispatcher/index.ts
+++ b/supabase/functions/connector-dispatcher/index.ts
@@ -1,0 +1,78 @@
+/**
+ * connector-dispatcher — single entrypoint for connector-framework adapters.
+ *
+ * Routes `{ source, action, payload }` requests to a registered
+ * `ConnectorAdapter` (see `_shared/connector-framework.ts`). Existing native
+ * sources (Fathom / Fireflies / Zoom / Plaud / YouTube) keep their dedicated
+ * edge functions — this dispatcher is the entrypoint for NEW sources only.
+ *
+ * @composio-unverified — the Composio adapter registers itself here once
+ * Phase B lands and a Composio account is provisioned.
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  dispatchConnectorRequest,
+  type AdapterContext,
+  type ConnectorRequest,
+} from "../_shared/connector-framework.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, sentry-trace, baggage",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return jsonResponse({ error: "No authorization header" }, 401);
+    }
+
+    const token = authHeader.replace("Bearer ", "");
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser(token);
+
+    if (userError || !user) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    let body: ConnectorRequest;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse({ error: "Request body must be JSON" }, 400);
+    }
+
+    const ctx: AdapterContext = {
+      supabase,
+      userId: user.id,
+    };
+
+    const { status, body: result } = await dispatchConnectorRequest(ctx, body);
+    return jsonResponse(result, status);
+  } catch (error) {
+    console.error("[connector-dispatcher] error:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return jsonResponse({ error: errorMessage }, 500);
+  }
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20260523192117_composio_integration_ids.sql
+++ b/supabase/migrations/20260523192117_composio_integration_ids.sql
@@ -1,0 +1,25 @@
+-- Migration: Composio integration id storage
+-- Purpose: Persist the Composio `connected_account_id` per `import_sources` row
+--   so the `composio-trigger-webhook` ingress can match incoming Composio
+--   deliveries to the CallVault user that owns the source. Storage strategy
+--   is a column-with-index in the existing `connection_metadata` JSONB
+--   (avoids a new column + lets the connector framework evolve), plus an
+--   explicit denormalized column on the canonical row for B-tree speed.
+-- Author: AI-assisted (Phase B — Composio adoption, ADR-006)
+-- Date: 2026-05-23
+
+BEGIN;
+
+ALTER TABLE import_sources
+  ADD COLUMN IF NOT EXISTS composio_connected_account_id TEXT;
+
+COMMENT ON COLUMN import_sources.composio_connected_account_id IS
+  'Composio (composio.dev) connected_account_id for sources routed through the Composio adapter (Gong, Dialpad, Webex, MS Teams, Google Meet, etc.). NULL for native sources. See ADR-006.';
+
+-- Fast lookup from the trigger-webhook function which receives the id and
+-- needs to resolve back to a (user_id, source_app) row in one query.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_sources_composio_account_id_unique
+  ON import_sources (composio_connected_account_id)
+  WHERE composio_connected_account_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Scaffolds a thin **internal connector framework** plus a **Composio adapter** as the meta-integration layer for transcript sources. This is **selective adoption**, not a rewrite: every existing native connector (Fathom / Fireflies / Zoom / Plaud / YouTube) stays exactly as-is. The framework is additive.

Bottom line from the feasibility analysis driving this PR:
- ✅ Build internal framework so per-source effort drops from ~5–7 days → ~1–2 days
- ✅ Use Composio for the enterprise call platforms it covers (Gong / Dialpad / Webex)
- ✅ Write native connectors for the AI-notetaker tier (Otter / Avoma / Grain / Read.ai / Chorus) where Composio has no coverage
- ❌ Do **NOT** rip out existing native connectors
- ❌ Do **NOT** adopt Composio as the architecture or replace the canonical pipeline

Full plan + scope limits: `/Users/admin/.archon/workspaces/Vibe-Marketer/brain/artifacts/runs/de1860359ba9b2d3a33a856899a43b74/plan-context.md`

## Changes

### Phase A — Connector Framework Foundation

| File | Action | Description |
|------|--------|-------------|
| `src/config/source-registry.ts` | CREATE | Canonical registry replacing the `TILES` literal in `AddImportSourceDialog` |
| `src/components/import/ConnectorDetailPanel.tsx` | CREATE | Shared detail-panel shell, adapter-driven content |
| `src/components/import/adapters/NativeAdapter.tsx` | CREATE | Adapter for existing native connectors |
| `src/components/import/adapters/ComposioAdapter.tsx` | CREATE | Adapter for Composio-backed sources |
| `src/components/import/AddImportSourceDialog.tsx` | UPDATE | Reads tiles from registry instead of inline literal |
| `supabase/functions/_shared/connector-framework.ts` | CREATE | Dispatcher primitives sitting in front of `runCanonicalConnectorPipeline()` |
| `supabase/functions/connector-dispatcher/index.ts` | CREATE | Framework entry edge function |

### Phase B — Composio Adapter

| File | Action | Description |
|------|--------|-------------|
| `supabase/functions/_shared/composio-client.ts` | CREATE | Minimal Composio client (integration + trigger surface) |
| `supabase/functions/composio-oauth-callback/index.ts` | CREATE | OAuth callback receiver for Composio-managed connections |
| `supabase/functions/composio-trigger-webhook/index.ts` | CREATE | Trigger / webhook receiver |
| `supabase/functions/_shared/composio-normalizers/gong.ts` | CREATE | Gong payload → `CanonicalRecording` |
| `supabase/functions/_shared/composio-normalizers/dialpad.ts` | CREATE | Dialpad payload → `CanonicalRecording` |
| `supabase/functions/_shared/composio-normalizers/webex.ts` | CREATE | Webex payload → `CanonicalRecording` |
| `supabase/migrations/20260523192117_composio_integration_ids.sql` | CREATE | Per-source integration-id columns |

**Diff size**: 14 files changed, **+2052 / -44**.

## Tests

No new test files in this PR. Test coverage targets defined in the plan (HMAC verification test, Otter native ≤2 days, Gong ≤1 day) belong to subsequent execute steps once the framework is exercised by a real pilot source. The full existing test suite still passes — see Validation below.

## Validation

Run on `archon/thread-e87dd60e` worktree after `npm install` to hydrate dependencies:

| Check | Status | Detail |
|-------|--------|--------|
| Type check | ✅ | `tsc --noEmit` — zero errors |
| Lint | ✅ | `eslint .` — 0 errors, 216 warnings (all pre-existing, none in new files) |
| Format | N/A | No `format` / `format:check` script in `package.json` |
| Tests | ✅ | `vitest run` — 902 passed / 0 failed / 92 skipped (60 files passed / 12 skipped, 8.05s) |
| Build | ✅ | `vite build` — 4,721 modules, 8.31s |

Pre-existing canonical-contract + connector tests (`canonical-recording.test.ts`, `fireflies-connector.test.ts`, Fathom / YouTube / Plaud suites) all pass — no regression on the existing native connectors.

## Implementation Notes

### Deviations from Plan

The plan listed four additional artifacts that are **not in this PR** because validation passed without them and they belong to subsequent steps:

- `docs/specs/SPEC-connector-framework.md` — design doc to be written once a pilot source (Gong or Otter) exercises the dispatcher end-to-end
- `docs/adr/adr-XXX-composio-selective-adoption.md` — ADR pending next-number assignment in `docs/adr/`
- `src/pages/ImportPage.tsx` — update deferred; current page still uses pre-framework wiring (registry is consumed only by `AddImportSourceDialog` so far)
- `.env.example` and `supabase/config.toml` — Composio env keys + function declarations to be added when the first Composio source is deployed

None of these are blockers for review of the framework + adapter scaffold itself.

### Out of Scope (intentional — do not flag as missing)

- Rewriting Fathom / Fireflies / Zoom / Plaud / YouTube
- Replacing pgcrypto-based OAuth token encryption (native adapter keeps it; Composio adapter delegates storage to Composio)
- UI for Composio's full 985-toolkit catalog (engineers add sources via the registry, not end users)
- Bidirectional sync / write-back to source platforms
- Replacing the canonical `runCanonicalConnectorPipeline()` — Composio payloads normalize **into** this pipeline, not around it
- Self-hosting Composio
- Sub-15-minute polling for sources without webhooks

### Edge Function Deploy

`supabase functions deploy connector-dispatcher` and `composio-trigger-webhook` were **not** executed by this workflow — deploys are side-effecting and live outside the `archon-validate` gate. Deferred to post-merge CI or a dedicated deploy step. Docker is not running on this worktree, so any deploy run must use `--use-api` per `supabase/CLAUDE.md`.

---

**Plan**: `/Users/admin/.archon/workspaces/Vibe-Marketer/brain/artifacts/runs/de1860359ba9b2d3a33a856899a43b74/plan.md`
**Workflow ID**: `de1860359ba9b2d3a33a856899a43b74`
