### PR TITLE
fix(fireflies): RPC type signatures — UUID, not BIGINT (post-merge hotfix for #278)

### DIFF
--- a/supabase/migrations/20260524010000_fix_fireflies_rpc_uuid_types.sql
+++ b/supabase/migrations/20260524010000_fix_fireflies_rpc_uuid_types.sql
@@ -1,0 +1,205 @@
+-- Migration: Fix Fireflies RPC type signatures (UUID, not BIGINT)
+-- Purpose:   Hotfix for #278 (Fireflies cleanup). All four Fireflies RPCs in
+--            20260524000000 were declared with `BIGINT` for the id column,
+--            but `import_sources.id` is UUID (defined 2026-02-28). Every
+--            Fireflies read or write call returns:
+--
+--              42804: Returned type uuid does not match expected type bigint
+--                     in column 1. structure of query does not match function
+--                     result type.
+--
+--            This is the SAME class of bug that broke Fathom OAuth for two
+--            weeks (see 20260522180000_fix_oauth_rpc_uuid_types.sql). Both
+--            shipped with security hardening that wasn't end-to-end tested
+--            against the real schema. Recurrent pattern; addressed by
+--            dropping and recreating with the correct type.
+--
+-- Scope:     Four functions in the Fireflies pipeline:
+--              1. get_decrypted_fireflies_source_for_user
+--              2. get_decrypted_fireflies_source_by_path_token
+--              3. list_decrypted_active_fireflies_sources
+--              4. store_encrypted_fireflies_credentials
+--
+-- Safety:    DDL only. No data is read, written, or migrated. Existing
+--            plaintext credential rows in import_sources stay untouched.
+--            The backfill (`encrypt_existing_fireflies_credentials`) does
+--            not have this bug and is unchanged.
+-- Date:      2026-05-23
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS get_decrypted_fireflies_source_for_user(UUID, TEXT);
+DROP FUNCTION IF EXISTS get_decrypted_fireflies_source_by_path_token(TEXT, TEXT);
+DROP FUNCTION IF EXISTS list_decrypted_active_fireflies_sources(TEXT);
+DROP FUNCTION IF EXISTS store_encrypted_fireflies_credentials(BIGINT, UUID, TEXT, TEXT, TEXT, TEXT, TEXT);
+
+-- ============================================================================
+-- 1. get_decrypted_fireflies_source_for_user — id is UUID
+-- ============================================================================
+CREATE OR REPLACE FUNCTION get_decrypted_fireflies_source_for_user(
+  p_user_id UUID,
+  p_encryption_key TEXT
+)
+RETURNS TABLE(
+  id UUID,
+  user_id UUID,
+  api_key TEXT,
+  webhook_signing_secret TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    s.id,
+    s.user_id,
+    decrypt_token(s.api_key, p_encryption_key) AS api_key,
+    decrypt_token(s.webhook_signing_secret, p_encryption_key) AS webhook_signing_secret
+  FROM import_sources s
+  WHERE s.user_id = p_user_id
+    AND s.source_app = 'fireflies'
+    AND s.is_active = TRUE
+  ORDER BY s.updated_at DESC
+  LIMIT 1;
+END;
+$$;
+
+COMMENT ON FUNCTION get_decrypted_fireflies_source_for_user IS
+'Returns the active Fireflies source for a user with credentials decrypted. id is UUID (fixed 2026-05-23 from BIGINT typo).';
+
+-- ============================================================================
+-- 2. get_decrypted_fireflies_source_by_path_token — id is UUID
+-- ============================================================================
+CREATE OR REPLACE FUNCTION get_decrypted_fireflies_source_by_path_token(
+  p_path_token TEXT,
+  p_encryption_key TEXT
+)
+RETURNS TABLE(
+  id UUID,
+  user_id UUID,
+  api_key TEXT,
+  webhook_signing_secret TEXT,
+  webhook_path_token TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    s.id,
+    s.user_id,
+    decrypt_token(s.api_key, p_encryption_key) AS api_key,
+    decrypt_token(s.webhook_signing_secret, p_encryption_key) AS webhook_signing_secret,
+    s.webhook_path_token
+  FROM import_sources s
+  WHERE s.source_app = 'fireflies'
+    AND s.is_active = TRUE
+    AND s.webhook_path_token = p_path_token
+  LIMIT 1;
+END;
+$$;
+
+COMMENT ON FUNCTION get_decrypted_fireflies_source_by_path_token IS
+'Resolves an active Fireflies source by webhook_path_token with credentials decrypted. id is UUID (fixed 2026-05-23 from BIGINT typo).';
+
+-- ============================================================================
+-- 3. list_decrypted_active_fireflies_sources — id is UUID
+-- ============================================================================
+CREATE OR REPLACE FUNCTION list_decrypted_active_fireflies_sources(
+  p_encryption_key TEXT
+)
+RETURNS TABLE(
+  id UUID,
+  user_id UUID,
+  api_key TEXT,
+  webhook_signing_secret TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    s.id,
+    s.user_id,
+    decrypt_token(s.api_key, p_encryption_key) AS api_key,
+    decrypt_token(s.webhook_signing_secret, p_encryption_key) AS webhook_signing_secret
+  FROM import_sources s
+  WHERE s.source_app = 'fireflies'
+    AND s.is_active = TRUE
+    AND s.webhook_signing_secret IS NOT NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION list_decrypted_active_fireflies_sources IS
+'Lists active Fireflies sources with credentials decrypted. id is UUID (fixed 2026-05-23 from BIGINT typo).';
+
+-- ============================================================================
+-- 4. store_encrypted_fireflies_credentials — p_source_id, RETURNS, v_id all UUID
+-- ============================================================================
+CREATE OR REPLACE FUNCTION store_encrypted_fireflies_credentials(
+  p_source_id UUID,
+  p_user_id UUID,
+  p_account_email TEXT,
+  p_api_key TEXT,
+  p_webhook_signing_secret TEXT,
+  p_webhook_path_token TEXT,
+  p_encryption_key TEXT
+)
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_id UUID;
+BEGIN
+  IF p_source_id IS NOT NULL THEN
+    UPDATE import_sources
+    SET
+      account_email = p_account_email,
+      api_key = encrypt_token(p_api_key, p_encryption_key),
+      webhook_signing_secret = encrypt_token(p_webhook_signing_secret, p_encryption_key),
+      webhook_path_token = p_webhook_path_token,
+      is_active = TRUE,
+      error_message = NULL,
+      updated_at = NOW()
+    WHERE id = p_source_id
+      AND user_id = p_user_id
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'Fireflies source % not found for user %', p_source_id, p_user_id
+        USING ERRCODE = 'no_data_found';
+    END IF;
+  ELSE
+    INSERT INTO import_sources (
+      user_id,
+      source_app,
+      account_email,
+      api_key,
+      webhook_signing_secret,
+      webhook_path_token,
+      is_active,
+      error_message,
+      updated_at
+    )
+    VALUES (
+      p_user_id,
+      'fireflies',
+      p_account_email,
+      encrypt_token(p_api_key, p_encryption_key),
+      encrypt_token(p_webhook_signing_secret, p_encryption_key),
+      p_webhook_path_token,
+      TRUE,
+      NULL,
+      NOW()
+    )
+    RETURNING id INTO v_id;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION store_encrypted_fireflies_credentials IS
+'Upserts a Fireflies import_sources row with credentials encrypted at rest. p_source_id, return type, and v_id are UUID (fixed 2026-05-23 from BIGINT typo).';
+
+COMMIT;


### PR DESCRIPTION
## Hotfix — second occurrence of the BIGINT-vs-UUID bug in 24 hours

#278 (Fireflies cleanup) merged 12 minutes ago shipped 5 new RPCs. **Four of them declared `import_sources.id` as BIGINT, but it's UUID.** Every Fireflies read OR write call was throwing `42804` in production until this hotfix landed.

### Live error before fix

```json
{
  "code": "42804",
  "message": "structure of query does not match function result type",
  "details": "Returned type uuid does not match expected type bigint in column 1."
}
```

### Scope

| RPC | Bug |
|-----|-----|
| `get_decrypted_fireflies_source_for_user` | `RETURNS TABLE(id BIGINT, ...)` |
| `get_decrypted_fireflies_source_by_path_token` | `RETURNS TABLE(id BIGINT, ...)` |
| `list_decrypted_active_fireflies_sources` | `RETURNS TABLE(id BIGINT, ...)` |
| `store_encrypted_fireflies_credentials` | `p_source_id BIGINT`, `RETURNS BIGINT`, `v_id BIGINT` |

The backfill `encrypt_existing_fireflies_credentials` does not use the id type — unaffected.

### Production state

- Migration applied via `psql` at ~19:35 ET (couldn't `supabase db push` from this branch because the parent migration is already in prod with a recorded version)
- All 4 RPCs now report UUID id columns in `pg_get_function_result`
- Smoke test on `get_decrypted_fireflies_source_for_user` against real user UUID returns HTTP 200 with proper id
- **Backfill ran cleanly:** 2 plaintext Fireflies credential rows encrypted at rest. `fireflies_credential_encryption_status`: plaintext `2 → 0`, encrypted `0 → 2`

### Pattern — third strike (2 in 24 hours)

This is the **same root cause** as the Fathom OAuth bug (#268, fixed yesterday). Both shipped from security-hardening PRs that weren't end-to-end tested against the real schema:

| Date | PR | Functions | Time to detect |
|------|----|----|----|
| 2026-05-09 | 0c2ca73f | 2 Fathom OAuth RPCs | 13 days (blocked all new connects) |
| 2026-05-23 | #278 | 4 Fireflies RPCs | 12 minutes (would have blocked every Fireflies user) |

**Recommendation as separate follow-up:** add a regression test that calls every `SECURITY DEFINER` RPC under `public` schema against the real schema with realistic inputs, fails CI if any returns a non-2xx. This class of bug is invisible to type-check and unit tests (the migrations `CREATE FUNCTION` succeeds, the function silently fails at runtime when called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Don