### PR TITLE
fix(import): restore missing import_sources.webhook_path_token column

### DIFF
--- a/supabase/migrations/20260524030000_restore_webhook_path_token_column.sql
+++ b/supabase/migrations/20260524030000_restore_webhook_path_token_column.sql
@@ -1,0 +1,52 @@
+-- Migration: Restore missing import_sources.webhook_path_token column
+-- Purpose:   The 2026-05-23 migration `add_generic_source_auth_fields`
+--            (20260523130000) was recorded as applied in
+--            supabase_migrations.schema_migrations, but only TWO of its
+--            three new columns actually exist in production:
+--
+--              api_key                 ✓ present
+--              webhook_signing_secret  ✓ present
+--              webhook_path_token      ✗ MISSING
+--
+--            Frontend code in `src/services/import-sources.service.ts`
+--            references webhook_path_token in its SELECT, causing
+--            `getImportSources()` to fail with:
+--
+--              {"code":"42703","message":"column
+--                import_sources.webhook_path_token does not exist"}
+--
+--            Cascading consequence:
+--              - useImportSources() throws and returns empty
+--              - ImportOverviewDashboard renders 0 rows
+--              - deriveSourceStatus returns "setup-needed" for EVERY source
+--              - Every connected platform (Fathom, Fireflies, Zoom, Plaud)
+--                falsely shows "Setup needed" on the Import page even
+--                though Settings → Integrations correctly shows "Connected"
+--
+--            How a partial apply happened is unknown — the parent
+--            migration uses one atomic ALTER TABLE with three ADD COLUMN
+--            IF NOT EXISTS clauses, which should be all-or-none. Possible
+--            causes: supabase-cli statement-splitting bug at the time,
+--            manual DROP COLUMN that wasn't recorded, or a partial rollback
+--            during an earlier deploy.
+--
+--            This migration is idempotent — it uses ADD COLUMN IF NOT
+--            EXISTS so re-application on databases that already have the
+--            column (e.g. fresh dev environments seeded from the parent
+--            migration) is a no-op.
+--
+-- Date:      2026-05-23
+
+BEGIN;
+
+ALTER TABLE import_sources
+  ADD COLUMN IF NOT EXISTS webhook_path_token TEXT;
+
+COMMENT ON COLUMN import_sources.webhook_path_token IS
+'Opaque URL token used to route incoming source webhooks to a specific import_sources row before signature verification.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_sources_webhook_path_token_unique
+  ON import_sources (webhook_path_token)
+  WHERE webhook_path_token IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## What happened

Production database was missing the `webhook_path_token` column on `import_sources` even though the parent migration (`20260523130000_add_generic_source_auth_fields`) was recorded as applied. The two sibling columns from the same ALTER TABLE (`api_key`, `webhook_signing_secret`) were correctly present.

## Symptom

Frontend service `src/services/import-sources.service.ts` selects `webhook_path_token` in `getImportSources()`. Without the column the query threw:

```
{"code":"42703","message":"column import_sources.webhook_path_token does not exist"}
```

Cascading consequence:
1. `useImportSources()` errored → returned empty array
2. `ImportOverviewDashboard` rendered zero rows
3. `deriveSourceStatus()` returned `'setup-needed'` for every source
4. **Every connected platform falsely showed "Setup needed" on the Import page** even though Settings → Integrations correctly showed "Connected" (different code path — reads `user_settings` not `import_sources`)

## Root cause of the partial apply

Unknown — the parent migration uses one atomic ALTER with three ADD COLUMN IF NOT EXISTS clauses, which should be all-or-none. Likely culprits:
- supabase-cli statement-splitting bug at the time of original apply
- A manual DROP COLUMN that wasn't recorded
- Partial rollback during a prior deploy

## Fix

One idempotent migration:

```sql
ALTER TABLE import_sources
  ADD COLUMN IF NOT EXISTS webhook_path_token TEXT;

CREATE UNIQUE INDEX IF NOT EXISTS idx_import_sources_webhook_path_token_unique
  ON import_sources (webhook_path_token)
  WHERE webhook_path_token IS NOT NULL;
```

## Production state

- Column added to `vltmrnjsubfzrgrtdqey` via direct `psql` at 2026-05-23 ~20:38 ET
- Migration recorded in `supabase_migrations.schema_migrations` as version `20260524030000`
- **Verified live:** `app.callvaultai.com/import` now shows Fathom (Connected — 100 calls imported), Fireflies (Connected), YouTube (Connected), File Upload (Connected). Sidebar green dots restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Don