### PR TITLE
feat(connectors): Phase 1 of unified connector primitive — additive, zero-risk

### DIFF
--- a/src/components/connectors/__tests__/deriveConnectorStatus.test.ts
+++ b/src/components/connectors/__tests__/deriveConnectorStatus.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for deriveConnectorStatus.
+ *
+ * Pure function — no Supabase, no React. The whole point of factoring out
+ * the derive function is so we can exhaustively test the divergence cases
+ * that bit us today (issue #283 background).
+ */
+
+import { describe, expect, it } from "vitest";
+import { deriveConnectorStatus } from "../hooks/useConnector";
+import type { ConnectorRow } from "../registry/types";
+
+const NOW = 1_780_000_000_000; // ~2026-05-29 UTC, used as the deterministic clock
+
+function row(overrides: Partial<ConnectorRow> = {}): ConnectorRow {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    user_id: "22222222-2222-2222-2222-222222222222",
+    source_app: "fathom",
+    is_active: true,
+    account_email: "user@example.com",
+    last_sync_at: null,
+    error_message: null,
+    oauth_token_expires: NOW + 60 * 60 * 1000, // 1h from NOW
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-23T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("deriveConnectorStatus — Fathom", () => {
+  it("active row with future-expiry token → connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "fathom",
+      rows: [row()],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.tokenExpired).toBe(false);
+    expect(status.sourceId).toBe("11111111-1111-1111-1111-111111111111");
+    expect(status.accountEmail).toBe("user@example.com");
+  });
+
+  it("active row with EXPIRED token but legacy fathom_api_key set → still connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "fathom",
+      rows: [row({ oauth_token_expires: NOW - 60_000, is_active: true })],
+      userSettings: {
+        fathom_api_key: "key_abc",
+        oauth_token_expires: null,
+        zoom_oauth_token_expires: null,
+      },
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.tokenExpired).toBe(true);
+  });
+
+  it("no rows + no legacy → not connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "fathom",
+      rows: [],
+      userSettings: {
+        fathom_api_key: null,
+        oauth_token_expires: null,
+        zoom_oauth_token_expires: null,
+      },
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(false);
+    expect(status.hasEverConnected).toBe(false);
+    expect(status.sourceId).toBeNull();
+  });
+
+  it("empty pending row (failed OAuth) + no other rows → not connected", () => {
+    // The stuck-row pattern from today's incident: fathom-oauth-url created
+    // a row but the callback failed, leaving is_active=false + token nulls.
+    const status = deriveConnectorStatus({
+      sourceApp: "fathom",
+      rows: [
+        row({
+          is_active: false,
+          oauth_token_expires: null,
+          account_email: null,
+        }),
+      ],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(false);
+    expect(status.hasEverConnected).toBe(true);
+  });
+
+  it("error_message on a row surfaces as errorMessage", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "fathom",
+      rows: [row({ error_message: "OAuth refresh failed" })],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.errorMessage).toBe("OAuth refresh failed");
+  });
+});
+
+describe("deriveConnectorStatus — Zoom legacy path", () => {
+  it("no import_sources row but zoom_oauth_token_expires is future → connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "zoom",
+      rows: [],
+      userSettings: {
+        fathom_api_key: null,
+        oauth_token_expires: null,
+        zoom_oauth_token_expires: NOW + 60_000,
+      },
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(true);
+  });
+
+  it("zoom_oauth_token_expires in the past → not connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "zoom",
+      rows: [],
+      userSettings: {
+        fathom_api_key: null,
+        oauth_token_expires: null,
+        zoom_oauth_token_expires: NOW - 60_000,
+      },
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(false);
+  });
+});
+
+describe("deriveConnectorStatus — always-available sources", () => {
+  it("youtube has no auth → always connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "youtube",
+      rows: [],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.hasEverConnected).toBe(true);
+  });
+
+  it("file-upload has no auth → always connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "file-upload",
+      rows: [],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(true);
+  });
+});
+
+describe("deriveConnectorStatus — multi-account Fathom", () => {
+  it("first row in array is the 'primary' (caller orders by updated_at DESC)", () => {
+    const newer = row({
+      id: "33333333-3333-3333-3333-333333333333",
+      account_email: "newer@example.com",
+      updated_at: "2026-05-22T22:46:50Z",
+    });
+    const older = row({
+      id: "44444444-4444-4444-4444-444444444444",
+      account_email: "older@example.com",
+      updated_at: "2026-04-17T20:10:52Z",
+    });
+
+    const status = deriveConnectorStatus({
+      sourceApp: "fathom",
+      rows: [newer, older],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.sourceId).toBe("33333333-3333-3333-3333-333333333333");
+    expect(status.accountEmail).toBe("newer@example.com");
+    expect(status.allRows).toHaveLength(2);
+  });
+});

--- a/src/components/connectors/hooks/useConnector.ts
+++ b/src/components/connectors/hooks/useConnector.ts
@@ -1,0 +1,162 @@
+/**
+ * useConnector — canonical status hook for any integration.
+ *
+ * Issue #283 — Phase 1. This is the SINGLE source of truth that every
+ * consumer surface uses (Settings, Import dashboard, Import detail, Setup
+ * Wizard, anywhere else). It collapses the two divergent paths today
+ * (`useIntegrationSync` reading user_settings vs. `useImportSources`
+ * reading import_sources) into one canonical answer.
+ *
+ * It reads:
+ *   - import_sources rows for this user + source_app (multi-account-aware)
+ *   - user_settings.fathom_api_key + oauth_token_expires (legacy fallback)
+ *
+ * It returns ConnectorStatus with a single `connected: boolean` that every
+ * surface can trust.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { getSafeUser } from "@/lib/auth-utils";
+import type {
+  ConnectorRow,
+  ConnectorSourceApp,
+  ConnectorStatus,
+} from "../registry/types";
+
+/**
+ * Query key. Exported so callers can invalidate after connect/disconnect
+ * without re-fetching directly. Per-source so disconnecting Fathom doesn't
+ * invalidate Zoom.
+ */
+export function connectorQueryKey(
+  sourceApp: ConnectorSourceApp,
+): readonly unknown[] {
+  return ["connector", sourceApp] as const;
+}
+
+interface UserSettingsRow {
+  fathom_api_key: string | null;
+  oauth_token_expires: number | null;
+  zoom_oauth_token_expires: number | null;
+}
+
+/**
+ * Synchronously interpret the rows + settings into ConnectorStatus.
+ * Pure function — testable without React.
+ */
+export function deriveConnectorStatus(args: {
+  sourceApp: ConnectorSourceApp;
+  rows: ConnectorRow[];
+  userSettings: UserSettingsRow | null;
+  now?: number;
+}): ConnectorStatus {
+  const { sourceApp, rows, userSettings } = args;
+  const now = args.now ?? Date.now();
+
+  const activeRows = rows.filter((r) => r.is_active);
+  const primary = activeRows[0] ?? null;
+
+  const tokenExpiresMs = primary?.oauth_token_expires ?? null;
+  const tokenExpired = tokenExpiresMs !== null && tokenExpiresMs < now;
+
+  // Legacy user_settings fallback — Fathom can be "connected" via a
+  // user_settings.fathom_api_key even if no import_sources row exists yet.
+  // Same model for Zoom OAuth (legacy zoom_oauth_token_expires path).
+  let legacyConnected = false;
+  if (userSettings) {
+    if (sourceApp === "fathom") {
+      legacyConnected = Boolean(
+        userSettings.fathom_api_key ||
+        (userSettings.oauth_token_expires &&
+          userSettings.oauth_token_expires > now),
+      );
+    } else if (sourceApp === "zoom") {
+      legacyConnected = Boolean(
+        userSettings.zoom_oauth_token_expires &&
+        userSettings.zoom_oauth_token_expires > now,
+      );
+    }
+  }
+
+  // YouTube + file-upload are always "available" — no auth required.
+  const alwaysAvailable =
+    sourceApp === "youtube" || sourceApp === "file-upload";
+
+  const connected =
+    alwaysAvailable || (Boolean(primary) && !tokenExpired) || legacyConnected;
+
+  const errorRow = rows.find((r) => r.error_message);
+
+  return {
+    sourceApp,
+    connected,
+    hasEverConnected: rows.length > 0 || legacyConnected || alwaysAvailable,
+    accountEmail: primary?.account_email ?? null,
+    lastSyncAt: primary?.last_sync_at ?? null,
+    tokenExpiresMs,
+    tokenExpired,
+    errorMessage: errorRow?.error_message ?? null,
+    sourceId: primary?.id ?? null,
+    allRows: rows,
+  };
+}
+
+/**
+ * React hook. Returns ConnectorStatus + a refresh fn. Polls every 30s by
+ * default — same cadence the existing useIntegrationSync uses.
+ */
+export function useConnector(sourceApp: ConnectorSourceApp) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<ConnectorStatus>({
+    queryKey: connectorQueryKey(sourceApp),
+    queryFn: async () => {
+      const { user, error: authError } = await getSafeUser();
+      if (authError || !user) {
+        return deriveConnectorStatus({
+          sourceApp,
+          rows: [],
+          userSettings: null,
+        });
+      }
+
+      // Multi-account aware: fetch every row for this user + source_app,
+      // not just the first.
+      const { data: rowData, error: rowError } = await supabase
+        .from("import_sources")
+        .select(
+          "id, user_id, source_app, is_active, account_email, last_sync_at, error_message, oauth_token_expires, created_at, updated_at",
+        )
+        .eq("user_id", user.id)
+        .eq("source_app", sourceApp)
+        .order("updated_at", { ascending: false });
+
+      if (rowError) throw new Error(rowError.message);
+
+      const { data: settingsData } = await supabase
+        .from("user_settings")
+        .select("fathom_api_key, oauth_token_expires, zoom_oauth_token_expires")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      return deriveConnectorStatus({
+        sourceApp,
+        rows: (rowData ?? []) as ConnectorRow[],
+        userSettings: (settingsData as UserSettingsRow | null) ?? null,
+      });
+    },
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  });
+
+  return {
+    status: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error.message : null,
+    refresh: () =>
+      queryClient.invalidateQueries({
+        queryKey: connectorQueryKey(sourceApp),
+      }),
+  };
+}

--- a/src/components/connectors/registry/adapters/fathom.ts
+++ b/src/components/connectors/registry/adapters/fathom.ts
@@ -1,0 +1,66 @@
+/**
+ * Fathom connector adapter.
+ *
+ * Issue #283 — Phase 1. This file is the SINGLE place future per-source
+ * additions are made. UI shells (ConnectorPanel) read from the registry,
+ * so adding a new source means writing one of these files.
+ */
+
+import { RiMicLine } from "@remixicon/react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ConnectorAdapter } from "../types";
+
+export const fathomAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "fathom",
+    label: "Fathom",
+    description: "AI meeting recorder",
+    icon: RiMicLine,
+    brandColor: "#0A84FF",
+    authMethods: ["oauth", "api_key"],
+    order: 10,
+  },
+
+  async getOAuthAuthUrl() {
+    const { data, error } = await supabase.functions.invoke("fathom-oauth-url");
+    if (error) throw new Error(error.message);
+    if (!data?.authUrl)
+      throw new Error("No authUrl returned from fathom-oauth-url");
+    return {
+      authUrl: data.authUrl as string,
+      sourceId: data.sourceId as string | undefined,
+    };
+  },
+
+  async saveApiKeyCredentials({ apiKey, webhookSecret }) {
+    if (!webhookSecret?.startsWith("whsec_")) {
+      throw new Error("Webhook secret must start with whsec_");
+    }
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) throw new Error("Not authenticated");
+
+    const { error } = await supabase.from("user_settings").upsert(
+      {
+        user_id: user.id,
+        fathom_api_key: apiKey.trim(),
+        webhook_secret: webhookSecret.trim(),
+      },
+      { onConflict: "user_id" },
+    );
+    if (error) throw new Error(error.message);
+
+    return { sourceId: user.id };
+  },
+
+  async disconnect(sourceId) {
+    const { error } = await supabase
+      .from("import_sources")
+      .update({ is_active: false })
+      .eq("id", sourceId)
+      .eq("source_app", "fathom");
+    if (error) throw new Error(error.message);
+  },
+};

--- a/src/components/connectors/registry/adapters/file-upload.ts
+++ b/src/components/connectors/registry/adapters/file-upload.ts
@@ -1,0 +1,20 @@
+/**
+ * File Upload connector adapter. Issue #283 — Phase 1.
+ *
+ * Direct file upload — no auth, no remote sync. Always available.
+ */
+
+import { RiUploadCloud2Line } from "@remixicon/react";
+import type { ConnectorAdapter } from "../types";
+
+export const fileUploadAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "file-upload",
+    label: "File Upload",
+    description: "Direct upload",
+    icon: RiUploadCloud2Line,
+    brandColor: "#6B7280",
+    authMethods: ["none"],
+    order: 60,
+  },
+};

--- a/src/components/connectors/registry/adapters/fireflies.ts
+++ b/src/components/connectors/registry/adapters/fireflies.ts
@@ -1,0 +1,50 @@
+/**
+ * Fireflies connector adapter. Issue #283 — Phase 1.
+ *
+ * Fireflies is API-key + webhook only (no OAuth). The save flow calls the
+ * `fireflies-save-source` edge function which writes an encrypted row via
+ * `store_encrypted_fireflies_credentials`.
+ */
+
+import { RiFireLine } from "@remixicon/react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ConnectorAdapter } from "../types";
+
+export const firefliesAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "fireflies",
+    label: "Fireflies",
+    description: "Transcript API import",
+    icon: RiFireLine,
+    brandColor: "#F25C54",
+    authMethods: ["api_key", "webhook_only"],
+    order: 30,
+  },
+
+  async saveApiKeyCredentials({ apiKey, webhookSecret, accountEmail }) {
+    const { data, error } = await supabase.functions.invoke(
+      "fireflies-save-source",
+      {
+        body: {
+          apiKey: apiKey.trim(),
+          webhookSigningSecret: webhookSecret?.trim() ?? null,
+          accountEmail: accountEmail?.trim() ?? null,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if (!data?.sourceId) {
+      throw new Error("fireflies-save-source returned no sourceId");
+    }
+    return { sourceId: data.sourceId as string };
+  },
+
+  async disconnect(sourceId) {
+    const { error } = await supabase
+      .from("import_sources")
+      .update({ is_active: false })
+      .eq("id", sourceId)
+      .eq("source_app", "fireflies");
+    if (error) throw new Error(error.message);
+  },
+};

--- a/src/components/connectors/registry/adapters/plaud.ts
+++ b/src/components/connectors/registry/adapters/plaud.ts
@@ -1,0 +1,48 @@
+/**
+ * Plaud connector adapter. Issue #283 — Phase 1.
+ *
+ * Plaud uses a durable access token (web-scraped from the user's session).
+ * See plaud-connect-token + plaud-sync-recordings edge functions.
+ */
+
+import { RiVoiceprintLine } from "@remixicon/react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ConnectorAdapter } from "../types";
+
+export const plaudAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "plaud",
+    label: "Plaud",
+    description: "AI voice recorder",
+    icon: RiVoiceprintLine,
+    brandColor: "#7C3AED",
+    authMethods: ["api_key"],
+    order: 40,
+  },
+
+  async saveApiKeyCredentials({ apiKey, accountEmail }) {
+    const { data, error } = await supabase.functions.invoke(
+      "plaud-connect-token",
+      {
+        body: {
+          accessToken: apiKey.trim(),
+          accountEmail: accountEmail?.trim() ?? null,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if (!data?.sourceId) {
+      throw new Error("plaud-connect-token returned no sourceId");
+    }
+    return { sourceId: data.sourceId as string };
+  },
+
+  async disconnect(sourceId) {
+    const { error } = await supabase
+      .from("import_sources")
+      .update({ is_active: false })
+      .eq("id", sourceId)
+      .eq("source_app", "plaud");
+    if (error) throw new Error(error.message);
+  },
+};

--- a/src/components/connectors/registry/adapters/youtube.ts
+++ b/src/components/connectors/registry/adapters/youtube.ts
@@ -1,0 +1,22 @@
+/**
+ * YouTube connector adapter. Issue #283 — Phase 1.
+ *
+ * YouTube imports are URL-driven — no auth needed beyond the user being
+ * signed into CallVault. The "Connected" state is permanently true.
+ */
+
+import { RiYoutubeLine } from "@remixicon/react";
+import type { ConnectorAdapter } from "../types";
+
+export const youtubeAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "youtube",
+    label: "YouTube",
+    description: "Video imports",
+    icon: RiYoutubeLine,
+    brandColor: "#FF0000",
+    authMethods: ["none"],
+    order: 50,
+  },
+  // No OAuth, no API key, no disconnect — always available.
+};

--- a/src/components/connectors/registry/adapters/zoom.ts
+++ b/src/components/connectors/registry/adapters/zoom.ts
@@ -1,0 +1,39 @@
+/**
+ * Zoom connector adapter. Issue #283 — Phase 1.
+ */
+
+import { RiVideoLine } from "@remixicon/react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ConnectorAdapter } from "../types";
+
+export const zoomAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "zoom",
+    label: "Zoom",
+    description: "Cloud recordings",
+    icon: RiVideoLine,
+    brandColor: "#2D8CFF",
+    authMethods: ["oauth"],
+    order: 20,
+  },
+
+  async getOAuthAuthUrl() {
+    const { data, error } = await supabase.functions.invoke("zoom-oauth-url");
+    if (error) throw new Error(error.message);
+    if (!data?.authUrl)
+      throw new Error("No authUrl returned from zoom-oauth-url");
+    return {
+      authUrl: data.authUrl as string,
+      sourceId: data.sourceId as string | undefined,
+    };
+  },
+
+  async disconnect(sourceId) {
+    const { error } = await supabase
+      .from("import_sources")
+      .update({ is_active: false })
+      .eq("id", sourceId)
+      .eq("source_app", "zoom");
+    if (error) throw new Error(error.message);
+  },
+};

--- a/src/components/connectors/registry/connectorRegistry.ts
+++ b/src/components/connectors/registry/connectorRegistry.ts
@@ -1,0 +1,76 @@
+/**
+ * Connector Registry — single source of truth for every integration in the app.
+ *
+ * Issue #283. To add a new source (Otter, Gong, Granola, etc.):
+ *   1. Write `src/components/connectors/registry/adapters/<name>.ts`
+ *      (one file, ~30 lines, follow fathom.ts / fireflies.ts as templates).
+ *   2. Import it here and append to ALL_ADAPTERS.
+ *   3. The new source automatically appears in every surface that consumes
+ *      <ConnectorPanel /> (Settings, Import dashboard, Import detail, Setup
+ *      Wizard). Zero changes to existing UI components.
+ *
+ * Target per issue #283 acceptance criteria:
+ *   - Otter native ≤ 2 days
+ *   - Gong Composio ≤ 1 day
+ */
+
+import { fathomAdapter } from "./adapters/fathom";
+import { zoomAdapter } from "./adapters/zoom";
+import { firefliesAdapter } from "./adapters/fireflies";
+import { plaudAdapter } from "./adapters/plaud";
+import { youtubeAdapter } from "./adapters/youtube";
+import { fileUploadAdapter } from "./adapters/file-upload";
+import type {
+  ConnectorAdapter,
+  ConnectorMetadata,
+  ConnectorSourceApp,
+} from "./types";
+
+const ALL_ADAPTERS: readonly ConnectorAdapter[] = [
+  fathomAdapter,
+  zoomAdapter,
+  firefliesAdapter,
+  plaudAdapter,
+  youtubeAdapter,
+  fileUploadAdapter,
+];
+
+const ADAPTER_BY_SOURCE_APP: Record<ConnectorSourceApp, ConnectorAdapter> =
+  Object.fromEntries(
+    ALL_ADAPTERS.map((a) => [a.metadata.sourceApp, a]),
+  ) as Record<ConnectorSourceApp, ConnectorAdapter>;
+
+/**
+ * Look up an adapter by source_app. Throws if the source is unknown — better
+ * to fail loudly at consumer time than to render an empty card silently.
+ */
+export function getConnectorAdapter(
+  sourceApp: ConnectorSourceApp,
+): ConnectorAdapter {
+  const adapter = ADAPTER_BY_SOURCE_APP[sourceApp];
+  if (!adapter) {
+    throw new Error(
+      `[connectorRegistry] no adapter registered for source_app="${sourceApp}". ` +
+        `Add an adapter at src/components/connectors/registry/adapters/${sourceApp}.ts ` +
+        `and register it in connectorRegistry.ts.`,
+    );
+  }
+  return adapter;
+}
+
+/** All registered adapters, ordered by ConnectorMetadata.order. */
+export function listConnectorAdapters(): readonly ConnectorAdapter[] {
+  return [...ALL_ADAPTERS].sort((a, b) => a.metadata.order - b.metadata.order);
+}
+
+/** All metadata only, for surfaces that don't need adapter actions. */
+export function listConnectorMetadata(): readonly ConnectorMetadata[] {
+  return listConnectorAdapters().map((a) => a.metadata);
+}
+
+/** Type guard for narrowing arbitrary strings to a known source. */
+export function isKnownSourceApp(value: string): value is ConnectorSourceApp {
+  return value in ADAPTER_BY_SOURCE_APP;
+}
+
+export type { ConnectorAdapter, ConnectorMetadata, ConnectorSourceApp };

--- a/src/components/connectors/registry/types.ts
+++ b/src/components/connectors/registry/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Connector Registry — type definitions.
+ *
+ * See `connectorRegistry.ts` for the runtime registry. Each adapter under
+ * `./adapters/` registers itself with a `ConnectorAdapter` describing how to
+ * authenticate, fetch status, and render per-source details.
+ *
+ * Issue #283 tracks the full UI unification this enables.
+ */
+
+/** A canonical source identifier used everywhere in the app. */
+export type ConnectorSourceApp =
+  | "fathom"
+  | "zoom"
+  | "fireflies"
+  | "plaud"
+  | "youtube"
+  | "file-upload";
+
+/** Auth methods supported by a connector. A connector can advertise multiple. */
+export type ConnectorAuthMethod = "oauth" | "api_key" | "webhook_only" | "none";
+
+/** What the UI shell needs to render a connector consistently. */
+export interface ConnectorMetadata {
+  /** Stable id used in URLs, DB rows, route params. */
+  sourceApp: ConnectorSourceApp;
+  /** Human-readable label rendered in cards, headers, settings rows. */
+  label: string;
+  /** One-line description rendered under the label. */
+  description: string;
+  /** Icon component (Remix or lucide). Caller renders it. */
+  icon: React.ComponentType<{ className?: string; size?: number }>;
+  /** Brand color hex for the icon background ring (optional). */
+  brandColor?: string;
+  /** Auth methods this connector advertises. UI shows the right button set. */
+  authMethods: readonly ConnectorAuthMethod[];
+  /** Order in lists. Lower = first. */
+  order: number;
+  /** True if the connector is feature-flagged off / pre-launch. UI dims it. */
+  comingSoon?: boolean;
+}
+
+/**
+ * Per-source plumbing. Each adapter owns:
+ *   - oauth URL construction (for sources that support OAuth)
+ *   - credential save handler (for sources that support API key)
+ *   - connection delete handler
+ *   - any source-specific status interpretation
+ */
+export interface ConnectorAdapter {
+  metadata: ConnectorMetadata;
+
+  /**
+   * Build the OAuth authorize URL by invoking the appropriate edge function.
+   * Returns { authUrl, sourceId } or throws.
+   *
+   * Implementations call edge functions like `fathom-oauth-url`, `zoom-oauth-url`.
+   * Sources without OAuth (file-upload) leave this undefined.
+   */
+  getOAuthAuthUrl?: () => Promise<{ authUrl: string; sourceId?: string }>;
+
+  /**
+   * Save API-key style credentials. For Fathom + Fireflies this writes an
+   * encrypted row via the per-source `*-save-source` edge function.
+   *
+   * Sources without API-key support leave this undefined.
+   */
+  saveApiKeyCredentials?: (params: {
+    apiKey: string;
+    webhookSecret?: string;
+    accountEmail?: string;
+  }) => Promise<{ sourceId: string }>;
+
+  /** Disconnect a source. Calls the per-source disconnect edge function. */
+  disconnect?: (sourceId: string) => Promise<void>;
+}
+
+/** The canonical status shape returned by `useConnector`. */
+export interface ConnectorStatus {
+  sourceApp: ConnectorSourceApp;
+  /** True if the connector has at least one active row and a valid credential. */
+  connected: boolean;
+  /** True if the connector has any row at all (even disconnected). */
+  hasEverConnected: boolean;
+  /** Account email for the active row, if known. */
+  accountEmail: string | null;
+  /** Last sync timestamp (ISO 8601) if recorded. */
+  lastSyncAt: string | null;
+  /** Token expiry (ms since epoch) if this is an OAuth connector. */
+  tokenExpiresMs: number | null;
+  /** True if there's an oauth_token_expires in the past. */
+  tokenExpired: boolean;
+  /** Last error message, if any. Surfaced as 'Connection error' state. */
+  errorMessage: string | null;
+  /** The active import_sources row id, if connected. */
+  sourceId: string | null;
+  /** Raw rows for advanced consumers (multi-account, debugging). */
+  allRows: ConnectorRow[];
+}
+
+/** Subset of `import_sources` columns the hook reads. */
+export interface ConnectorRow {
+  id: string;
+  user_id: string;
+  source_app: ConnectorSourceApp;
+  is_active: boolean;
+  account_email: string | null;
+  last_sync_at: string | null;
+  error_message: string | null;
+  oauth_token_expires: number | null;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
Phase 1 of issue #283. See commit message for full detail.

## Tl;dr

- 9 new files under `src/components/connectors/`
- 0 existing files modified
- 10 unit tests, all passing
- Type-check clean
- Production behavior unchanged

## Files

| File | Purpose |
|---|---|
| `registry/types.ts` | ConnectorMetadata, ConnectorAdapter, ConnectorStatus, ConnectorRow |
| `registry/connectorRegistry.ts` | ALL_ADAPTERS + getConnectorAdapter() + listConnectorAdapters() |
| `registry/adapters/fathom.ts` | OAuth + API-key adapter |
| `registry/adapters/zoom.ts` | OAuth adapter |
| `registry/adapters/fireflies.ts` | API-key + webhook adapter |
| `registry/adapters/plaud.ts` | Durable-token adapter |
| `registry/adapters/youtube.ts` | No-auth (always available) |
| `registry/adapters/file-upload.ts` | No-auth (always available) |
| `hooks/useConnector.ts` | Canonical status hook + pure deriveConnectorStatus() |
| `__tests__/deriveConnectorStatus.test.ts` | 10 tests covering today's incident patterns |

## Why this is safe to merge

This PR doesn't change any existing component. No consumer imports the new code yet. If the primitives are wrong, no production surface is affected — we fix them in Phase 2 before any consumer adopts.

The migration phases (3-7) each touch ONE consumer at a time. If any phase breaks something, revert just that phase.

## What's next (separate PRs per issue #283)

- [ ] **Phase 2** — `ConnectorPanel.tsx` UI shell with 4 layout variants
- [ ] **Phase 3** — migrate Settings IntegrationsTab
- [ ] **Phase 4** — migrate Import dashboard cards
- [ ] **Phase 5** — migrate Import detail panes
- [ ] **Phase 6** — migrate setup wizards
- [ ] **Phase 7** — delete the 14 dead components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Don