### PR TITLE
[codex] Require Fireflies webhook URL token

### DIFF
--- a/supabase/functions/fathom-refresh/__tests__/fathom-refresh.test.ts
+++ b/supabase/functions/fathom-refresh/__tests__/fathom-refresh.test.ts
@@ -55,7 +55,7 @@ describe('fathom-refresh contract (Phase 40)', () => {
   it('updates ONLY the editable fields on recordings (preservation invariant)', () => {
     // Find the UPDATE block — must NOT mention id, organization_id, owner_user_id,
     // legacy_recording_id, source_app, source_call_id, or created_at as SET targets.
-    const updateBlock = source.match(/\.from\('recordings'\)\s*\.update\(\{[\s\S]*?\}\)/);
+    const updateBlock = source.match(/\.from\(["']recordings["']\)\s*\.update\(\{[\s\S]*?\}\)/);
     expect(updateBlock, 'expected an .update({...}) on recordings').toBeTruthy();
     const block = updateBlock![0];
     expect(block).not.toMatch(/\bid:\s/);

--- a/supabase/functions/fireflies-save-source/index.ts
+++ b/supabase/functions/fireflies-save-source/index.ts
@@ -121,7 +121,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    const stored = await storeEncryptedFirefliesCredentials(supabase, {
+    const stored = await storeEncryptedFirefliesCredentials(supabase as any, {
       existingSourceId: existing?.id ? String(existing.id) : null,
       userId,
       accountEmail,

--- a/supabase/functions/fireflies-webhook/index.ts
+++ b/supabase/functions/fireflies-webhook/index.ts
@@ -5,7 +5,6 @@ import {
 } from "../_shared/fireflies-connector.ts";
 import {
   getDecryptedFirefliesSourceByPathToken,
-  listDecryptedActiveFirefliesSources,
   type DecryptedFirefliesCredentials,
 } from "../_shared/fireflies-credentials.ts";
 import { runCanonicalConnectorPipeline } from "../_shared/recording-connectors.ts";
@@ -61,14 +60,25 @@ Deno.serve(async (req) => {
     }
 
     const webhookPathToken = extractWebhookPathToken(req.url);
-    const matchedSource = webhookPathToken
-      ? await findMatchingSourceByPathToken(
-          supabase,
-          rawBody,
-          signature,
-          webhookPathToken,
-        )
-      : await findMatchingSourceBySignatureScan(supabase, rawBody, signature);
+    if (!webhookPathToken) {
+      return new Response(
+        JSON.stringify({ error: "Missing Fireflies webhook URL token" }),
+        {
+          status: 404,
+          headers: {
+            ...WEBHOOK_CORS_HEADERS,
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    }
+
+    const matchedSource = await findMatchingSourceByPathToken(
+      supabase as any,
+      rawBody,
+      signature,
+      webhookPathToken,
+    );
     if (!matchedSource || !matchedSource.api_key) {
       return new Response(
         JSON.stringify({
@@ -186,25 +196,6 @@ async function findMatchingSourceByPathToken(
     source.webhook_signing_secret,
   );
   return timingSafeEqualString(expected, actualSignature) ? source : null;
-}
-
-async function findMatchingSourceBySignatureScan(
-  supabase: ReturnType<typeof createClient>,
-  rawBody: string,
-  actualSignature: string,
-): Promise<DecryptedFirefliesCredentials | null> {
-  const sources = await listDecryptedActiveFirefliesSources(supabase);
-  for (const source of sources) {
-    if (!source.webhook_signing_secret) continue;
-    const expected = await computeHmacSha256Signature(
-      rawBody,
-      source.webhook_signing_secret,
-    );
-    if (timingSafeEqualString(expected, actualSignature)) {
-      return source;
-    }
-  }
-  return null;
 }
 
 function extractWebhookPathToken(requestUrl: string): string | null {


### PR DESCRIPTION
## Summary

- Require Fireflies webhook deliveries to include the per-source `ffwh_...` URL token.
- Remove the legacy fallback that scanned all active Fireflies signing secrets when the token was missing.
- Keep HMAC verification with the source signing secret after token lookup.

## Why

The tokenized webhook URL is now the routing handle, and the signing secret is the authenticity check. Since the old non-token Fireflies setup is not needed, failing fast on plain `/fireflies-webhook` avoids ambiguous routing and unnecessary secret scans.

## Validation

- `npm run type-check`
- `npm test -- --run src/lib/__tests__/fireflies-import.test.ts supabase/functions/_shared/__tests__/fireflies-connector.test.ts`
- `deno check supabase/functions/fireflies-save-source/index.ts supabase/functions/fireflies-webhook/index.ts`
