### PR TITLE
fix(fathom): sweep — decrypt OAuth tokens at read time in 3 more functions

### DIFF
--- a/supabase/functions/fathom-reconcile/index.ts
+++ b/supabase/functions/fathom-reconcile/index.ts
@@ -19,11 +19,15 @@
  *   - OAUTH_ENCRYPTION_KEY (optional; if set, reads tokens via decrypt RPC)
  */
 
-import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { FathomClient } from '../_shared/fathom-client.ts';
-import { getCorsHeaders } from '../_shared/cors.ts';
-import { runPipeline } from '../_shared/connector-pipeline.ts';
-import { authenticateRequest } from '../_shared/auth.ts';
+import {
+  createClient,
+  type SupabaseClient,
+} from "https://esm.sh/@supabase/supabase-js@2";
+import { FathomClient } from "../_shared/fathom-client.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import { runPipeline } from "../_shared/connector-pipeline.ts";
+import { authenticateRequest } from "../_shared/auth.ts";
+import { getDecryptedOAuthTokens } from "../_shared/oauth-encrypt.ts";
 
 interface ReconcileResult {
   synced: number;
@@ -48,37 +52,26 @@ async function resolveCredentials(
   sourceId: string,
   userId: string,
 ): Promise<ResolvedCreds> {
-  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
-
-  if (encryptionKey) {
-    const { data, error } = await supabase.rpc('decrypt_oauth_tokens', {
-      p_source_id: sourceId,
-      p_user_id: userId,
-      p_encryption_key: encryptionKey,
-    });
-    if (!error && data) {
-      return {
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token,
-        expiresAt: data.token_expires,
-        apiKey: data.fathom_api_key,
-      };
-    }
-  }
-
+  // Phase 28-03 fix (#294): previous code called `decrypt_oauth_tokens`
+  // RPC which doesn't exist in prod (only `get_decrypted_oauth_tokens`),
+  // then fell back to a raw oauth_access_token SELECT — which returns
+  // PGP-armored ciphertext for encrypted rows and got 401 from Fathom.
+  // Route through the canonical helper instead; it uses the correct RPC
+  // name and has plaintext-fallback baked in for older rows.
+  const decrypted = await getDecryptedOAuthTokens(supabase, sourceId, userId);
   const { data: src, error } = await supabase
-    .from('import_sources')
-    .select('oauth_access_token, oauth_refresh_token, oauth_token_expires, fathom_api_key')
-    .eq('id', sourceId)
-    .eq('user_id', userId)
+    .from("import_sources")
+    .select("fathom_api_key")
+    .eq("id", sourceId)
+    .eq("user_id", userId)
     .maybeSingle();
-  if (error || !src) throw new Error('Source not found or credentials missing');
+  if (error) throw new Error("Source not found or credentials missing");
 
   return {
-    accessToken: src.oauth_access_token,
-    refreshToken: src.oauth_refresh_token,
-    expiresAt: src.oauth_token_expires,
-    apiKey: src.fathom_api_key,
+    accessToken: decrypted.access_token,
+    refreshToken: decrypted.refresh_token,
+    expiresAt: decrypted.token_expires,
+    apiKey: src?.fathom_api_key ?? null,
   };
 }
 
@@ -93,22 +86,25 @@ async function refreshIfExpired(
     return creds.accessToken;
   }
   if (!creds.refreshToken) {
-    if (creds.apiKey) return '';
-    throw new Error('Token expired and no refresh token; reconnect required');
+    if (creds.apiKey) return "";
+    throw new Error("Token expired and no refresh token; reconnect required");
   }
 
-  const clientId = Deno.env.get('FATHOM_OAUTH_CLIENT_ID')!;
-  const clientSecret = Deno.env.get('FATHOM_OAUTH_CLIENT_SECRET')!;
-  const tokenResponse = await fetch('https://fathom.video/external/v1/oauth2/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: creds.refreshToken,
-      client_id: clientId,
-      client_secret: clientSecret,
-    }),
-  });
+  const clientId = Deno.env.get("FATHOM_OAUTH_CLIENT_ID")!;
+  const clientSecret = Deno.env.get("FATHOM_OAUTH_CLIENT_SECRET")!;
+  const tokenResponse = await fetch(
+    "https://fathom.video/external/v1/oauth2/token",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: creds.refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    },
+  );
   if (!tokenResponse.ok) {
     throw new Error(`Token refresh failed: ${tokenResponse.status}`);
   }
@@ -116,13 +112,13 @@ async function refreshIfExpired(
   const expiresAt = Date.now() + tokens.expires_in * 1000;
 
   await supabase
-    .from('import_sources')
+    .from("import_sources")
     .update({
       oauth_access_token: tokens.access_token,
       oauth_refresh_token: tokens.refresh_token,
       oauth_token_expires: expiresAt,
     })
-    .eq('id', sourceId);
+    .eq("id", sourceId);
 
   return tokens.access_token;
 }
@@ -138,11 +134,11 @@ async function syncOneMeeting(
   userId: string,
   sourceId: string,
   meeting: Record<string, unknown>,
-): Promise<'synced' | 'skipped' | 'failed'> {
+): Promise<"synced" | "skipped" | "failed"> {
   try {
     const recordingId = Number(meeting.recording_id);
     const externalId = String(recordingId);
-    const title = (meeting.title as string) || 'Untitled Call';
+    const title = (meeting.title as string) || "Untitled Call";
 
     const transcript = (meeting.transcript as FathomTranscriptSegment[]) || [];
     const consolidated: string[] = [];
@@ -150,31 +146,42 @@ async function syncOneMeeting(
     let curTs: string | null = null;
     let curTexts: string[] = [];
     transcript.forEach((seg, idx) => {
-      const name = seg.speaker?.display_name || 'Unknown';
+      const name = seg.speaker?.display_name || "Unknown";
       if (name !== curSpeaker) {
         if (curSpeaker && curTexts.length) {
-          consolidated.push(`[${curTs || '00:00:00'}] ${curSpeaker}: ${curTexts.join(' ')}`);
+          consolidated.push(
+            `[${curTs || "00:00:00"}] ${curSpeaker}: ${curTexts.join(" ")}`,
+          );
         }
         curSpeaker = name;
-        curTs = seg.timestamp || '00:00:00';
-        curTexts = [seg.text || ''];
+        curTs = seg.timestamp || "00:00:00";
+        curTexts = [seg.text || ""];
       } else {
-        curTexts.push(seg.text || '');
+        curTexts.push(seg.text || "");
       }
       if (idx === transcript.length - 1 && curTexts.length) {
-        consolidated.push(`[${curTs || '00:00:00'}] ${curSpeaker}: ${curTexts.join(' ')}`);
+        consolidated.push(
+          `[${curTs || "00:00:00"}] ${curSpeaker}: ${curTexts.join(" ")}`,
+        );
       }
     });
-    const fullTranscript = consolidated.join('\n\n');
+    const fullTranscript = consolidated.join("\n\n");
 
     const summaryText =
-      (meeting.default_summary as { markdown_formatted?: string } | undefined)?.markdown_formatted || null;
+      (meeting.default_summary as { markdown_formatted?: string } | undefined)
+        ?.markdown_formatted || null;
 
     const start = new Date(meeting.recording_start_time as string);
-    const end = meeting.recording_end_time ? new Date(meeting.recording_end_time as string) : null;
-    const durationSec = end ? Math.floor((end.getTime() - start.getTime()) / 1000) : undefined;
+    const end = meeting.recording_end_time
+      ? new Date(meeting.recording_end_time as string)
+      : null;
+    const durationSec = end
+      ? Math.floor((end.getTime() - start.getTime()) / 1000)
+      : undefined;
 
-    const recordedBy = meeting.recorded_by as { name?: string; email?: string } | undefined;
+    const recordedBy = meeting.recorded_by as
+      | { name?: string; email?: string }
+      | undefined;
 
     const sourceMetadata = {
       fathom_call_id: recordingId,
@@ -184,13 +191,13 @@ async function syncOneMeeting(
       recorded_by_email: recordedBy?.email || null,
       calendar_invitees: meeting.calendar_invitees || [],
       summary: summaryText,
-      import_source: 'fathom-reconcile',
+      import_source: "fathom-reconcile",
       synced_at: new Date().toISOString(),
     };
 
     const result = await runPipeline(supabase, userId, {
       external_id: externalId,
-      source_app: 'fathom',
+      source_app: "fathom",
       title,
       full_transcript: fullTranscript,
       summary: summaryText,
@@ -200,40 +207,42 @@ async function syncOneMeeting(
     });
 
     if (!result.success) {
-      if (result.skipped) return 'skipped';
-      throw new Error(result.error || 'Pipeline failed');
+      if (result.skipped) return "skipped";
+      throw new Error(result.error || "Pipeline failed");
     }
 
-    const { error: rawErr } = await supabase
-      .from('fathom_raw_calls')
-      .upsert(
-        {
-          recording_id: recordingId,
-          user_id: userId,
-          import_source_id: sourceId,
-          mirror_version: 1,
-          canonical_recording_id: result.recordingId,
-          title,
-          created_at: (meeting.created_at as string) || new Date().toISOString(),
-          recording_start_time: meeting.recording_start_time as string,
-          recording_end_time: (meeting.recording_end_time as string) || null,
-          url: (meeting.url as string) || null,
-          share_url: (meeting.share_url as string) || null,
-          full_transcript: fullTranscript,
-          summary: summaryText,
-          recorded_by_name: recordedBy?.name || null,
-          recorded_by_email: recordedBy?.email || null,
-          calendar_invitees: meeting.calendar_invitees || null,
-          synced_at: new Date().toISOString(),
-        },
-        { onConflict: 'recording_id,user_id' },
+    const { error: rawErr } = await supabase.from("fathom_raw_calls").upsert(
+      {
+        recording_id: recordingId,
+        user_id: userId,
+        import_source_id: sourceId,
+        mirror_version: 1,
+        canonical_recording_id: result.recordingId,
+        title,
+        created_at: (meeting.created_at as string) || new Date().toISOString(),
+        recording_start_time: meeting.recording_start_time as string,
+        recording_end_time: (meeting.recording_end_time as string) || null,
+        url: (meeting.url as string) || null,
+        share_url: (meeting.share_url as string) || null,
+        full_transcript: fullTranscript,
+        summary: summaryText,
+        recorded_by_name: recordedBy?.name || null,
+        recorded_by_email: recordedBy?.email || null,
+        calendar_invitees: meeting.calendar_invitees || null,
+        synced_at: new Date().toISOString(),
+      },
+      { onConflict: "recording_id,user_id" },
+    );
+    if (rawErr)
+      console.error(
+        "[fathom-reconcile] raw upsert error (non-blocking):",
+        rawErr,
       );
-    if (rawErr) console.error('[fathom-reconcile] raw upsert error (non-blocking):', rawErr);
 
-    return 'synced';
+    return "synced";
   } catch (err) {
-    console.error('[fathom-reconcile] syncOneMeeting failed:', err);
-    return 'failed';
+    console.error("[fathom-reconcile] syncOneMeeting failed:", err);
+    return "failed";
   }
 }
 
@@ -243,25 +252,33 @@ async function paginateSource(
   sourceId: string,
   options: { createdAfter?: string; maxPages?: number },
 ): Promise<ReconcileResult> {
-  const result: ReconcileResult = { synced: 0, skipped: 0, errored: 0, pages: 0 };
+  const result: ReconcileResult = {
+    synced: 0,
+    skipped: 0,
+    errored: 0,
+    pages: 0,
+  };
 
   const creds = await resolveCredentials(supabase, sourceId, userId);
   const accessToken = await refreshIfExpired(supabase, sourceId, creds);
-  const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (accessToken) authHeaders['Authorization'] = `Bearer ${accessToken}`;
-  else if (creds.apiKey) authHeaders['X-Api-Key'] = creds.apiKey;
+  const authHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (accessToken) authHeaders["Authorization"] = `Bearer ${accessToken}`;
+  else if (creds.apiKey) authHeaders["X-Api-Key"] = creds.apiKey;
 
   let cursor: string | undefined;
   const maxPages = options.maxPages ?? 100;
 
   for (let i = 0; i < maxPages; i++) {
     await throttle();
-    const url = new URL('https://api.fathom.ai/external/v1/meetings');
-    url.searchParams.append('limit', '50');
-    url.searchParams.append('include_transcript', 'true');
-    url.searchParams.append('include_summary', 'true');
-    if (options.createdAfter) url.searchParams.append('created_after', options.createdAfter);
-    if (cursor) url.searchParams.append('cursor', cursor);
+    const url = new URL("https://api.fathom.ai/external/v1/meetings");
+    url.searchParams.append("limit", "50");
+    url.searchParams.append("include_transcript", "true");
+    url.searchParams.append("include_summary", "true");
+    if (options.createdAfter)
+      url.searchParams.append("created_after", options.createdAfter);
+    if (cursor) url.searchParams.append("cursor", cursor);
 
     const response = await FathomClient.fetchWithRetry(url.toString(), {
       headers: authHeaders,
@@ -279,7 +296,7 @@ async function paginateSource(
 
     for (const meeting of items) {
       const status = await syncOneMeeting(supabase, userId, sourceId, meeting);
-      result[status === 'failed' ? 'errored' : status]++;
+      result[status === "failed" ? "errored" : status]++;
     }
 
     result.pages++;
@@ -301,24 +318,34 @@ async function runBackfill(
 async function runDailyReconcile(
   supabase: SupabaseClient,
 ): Promise<{ sources: number; results: ReconcileResult[] }> {
-  const createdAfter = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const createdAfter = new Date(
+    Date.now() - 30 * 24 * 60 * 60 * 1000,
+  ).toISOString();
   const { data: sources, error } = await supabase
-    .from('import_sources')
-    .select('id, user_id')
-    .eq('source_app', 'fathom')
-    .eq('is_active', true);
+    .from("import_sources")
+    .select("id, user_id")
+    .eq("source_app", "fathom")
+    .eq("is_active", true);
   if (error) throw error;
 
   const results: ReconcileResult[] = [];
   for (const src of sources ?? []) {
     try {
-      const r = await paginateSource(supabase, src.user_id as string, src.id as string, {
-        createdAfter,
-        maxPages: 20,
-      });
+      const r = await paginateSource(
+        supabase,
+        src.user_id as string,
+        src.id as string,
+        {
+          createdAfter,
+          maxPages: 20,
+        },
+      );
       results.push(r);
     } catch (err) {
-      console.error(`[fathom-reconcile] reconcile source ${src.id} failed:`, err);
+      console.error(
+        `[fathom-reconcile] reconcile source ${src.id} failed:`,
+        err,
+      );
       results.push({ synced: 0, skipped: 0, errored: 1, pages: 0 });
     }
   }
@@ -326,33 +353,33 @@ async function runDailyReconcile(
 }
 
 Deno.serve(async (req) => {
-  const origin = req.headers.get('Origin');
+  const origin = req.headers.get("Origin");
   const corsHeaders = getCorsHeaders(origin);
-  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method === "OPTIONS")
+    return new Response(null, { headers: corsHeaders });
 
   try {
     const supabase = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
 
     const body = await req.json().catch(() => ({}));
-    const mode = body.mode || 'backfill';
+    const mode = body.mode || "backfill";
 
-    if (mode === 'reconcile') {
-      const secret = req.headers.get('X-Reconcile-Secret') || body.secret;
-      const expected = Deno.env.get('RECONCILE_SECRET');
+    if (mode === "reconcile") {
+      const secret = req.headers.get("X-Reconcile-Secret") || body.secret;
+      const expected = Deno.env.get("RECONCILE_SECRET");
       if (!expected || secret !== expected) {
-        return new Response(
-          JSON.stringify({ error: 'Unauthorized' }),
-          { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-        );
+        return new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
       }
       const result = await runDailyReconcile(supabase);
-      return new Response(
-        JSON.stringify({ success: true, mode, ...result }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-      );
+      return new Response(JSON.stringify({ success: true, mode, ...result }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     // Backfill mode — JWT auth required
@@ -363,35 +390,41 @@ Deno.serve(async (req) => {
     const sourceId = body.sourceId as string;
     if (!sourceId) {
       return new Response(
-        JSON.stringify({ error: 'sourceId required for backfill' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        JSON.stringify({ error: "sourceId required for backfill" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
     const { data: src, error: srcErr } = await supabase
-      .from('import_sources')
-      .select('id, user_id')
-      .eq('id', sourceId)
-      .eq('user_id', userId)
+      .from("import_sources")
+      .select("id, user_id")
+      .eq("id", sourceId)
+      .eq("user_id", userId)
       .maybeSingle();
     if (srcErr || !src) {
       return new Response(
-        JSON.stringify({ error: 'Source not found or not owned by caller' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        JSON.stringify({ error: "Source not found or not owned by caller" }),
+        {
+          status: 404,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
     const result = await runBackfill(supabase, userId, sourceId);
     return new Response(
       JSON.stringify({ success: true, mode, sourceId, ...result }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
   } catch (error) {
-    console.error('[fathom-reconcile] handler error:', error);
-    const msg = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(
-      JSON.stringify({ success: false, error: msg }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-    );
+    console.error("[fathom-reconcile] handler error:", error);
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    return new Response(JSON.stringify({ success: false, error: msg }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 });

--- a/supabase/functions/fathom-refresh/index.ts
+++ b/supabase/functions/fathom-refresh/index.ts
@@ -25,10 +25,14 @@
  *   - 500 INTERNAL — anything else
  */
 
-import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { FathomClient } from '../_shared/fathom-client.ts';
-import { getCorsHeaders } from '../_shared/cors.ts';
-import { authenticateRequest } from '../_shared/auth.ts';
+import {
+  createClient,
+  type SupabaseClient,
+} from "https://esm.sh/@supabase/supabase-js@2";
+import { FathomClient } from "../_shared/fathom-client.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import { authenticateRequest } from "../_shared/auth.ts";
+import { getDecryptedOAuthTokens } from "../_shared/oauth-encrypt.ts";
 
 interface ResolvedCreds {
   accessToken: string;
@@ -49,12 +53,12 @@ async function findFathomSource(
   userId: string,
 ): Promise<{ sourceId: string } | null> {
   const { data, error } = await supabase
-    .from('import_sources')
-    .select('id')
-    .eq('user_id', userId)
-    .eq('source_app', 'fathom')
-    .eq('is_active', true)
-    .order('created_at', { ascending: false })
+    .from("import_sources")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("source_app", "fathom")
+    .eq("is_active", true)
+    .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle();
   if (error || !data) return null;
@@ -66,38 +70,26 @@ async function resolveCredentials(
   sourceId: string,
   userId: string,
 ): Promise<ResolvedCreds> {
-  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
-
-  if (encryptionKey) {
-    const { data, error } = await supabase.rpc('decrypt_oauth_tokens', {
-      p_source_id: sourceId,
-      p_user_id: userId,
-      p_encryption_key: encryptionKey,
-    });
-    if (!error && data) {
-      return {
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token,
-        expiresAt: data.token_expires,
-        apiKey: data.fathom_api_key,
-        sourceId,
-      };
-    }
-  }
-
+  // Phase 28-03 fix (#294): previous code called `decrypt_oauth_tokens`
+  // RPC which doesn't exist in prod (only `get_decrypted_oauth_tokens`),
+  // then fell back to a raw oauth_access_token SELECT — which returns
+  // PGP-armored ciphertext for encrypted rows and got 401 from Fathom.
+  // Route through the canonical helper instead; it uses the correct RPC
+  // name and has plaintext-fallback baked in for older rows.
+  const decrypted = await getDecryptedOAuthTokens(supabase, sourceId, userId);
   const { data: src, error } = await supabase
-    .from('import_sources')
-    .select('oauth_access_token, oauth_refresh_token, oauth_token_expires, fathom_api_key')
-    .eq('id', sourceId)
-    .eq('user_id', userId)
+    .from("import_sources")
+    .select("fathom_api_key")
+    .eq("id", sourceId)
+    .eq("user_id", userId)
     .maybeSingle();
-  if (error || !src) throw new Error('Source credentials missing');
+  if (error) throw new Error("Source credentials missing");
 
   return {
-    accessToken: src.oauth_access_token,
-    refreshToken: src.oauth_refresh_token,
-    expiresAt: src.oauth_token_expires,
-    apiKey: src.fathom_api_key,
+    accessToken: decrypted.access_token,
+    refreshToken: decrypted.refresh_token,
+    expiresAt: decrypted.token_expires,
+    apiKey: src?.fathom_api_key ?? null,
     sourceId,
   };
 }
@@ -113,36 +105,39 @@ async function refreshIfExpired(
     return creds.accessToken;
   }
   if (!creds.refreshToken) {
-    if (creds.apiKey) return '';
-    throw new Error('FATHOM_AUTH_EXPIRED');
+    if (creds.apiKey) return "";
+    throw new Error("FATHOM_AUTH_EXPIRED");
   }
 
-  const clientId = Deno.env.get('FATHOM_OAUTH_CLIENT_ID')!;
-  const clientSecret = Deno.env.get('FATHOM_OAUTH_CLIENT_SECRET')!;
-  const tokenResponse = await fetch('https://fathom.video/external/v1/oauth2/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: creds.refreshToken,
-      client_id: clientId,
-      client_secret: clientSecret,
-    }),
-  });
+  const clientId = Deno.env.get("FATHOM_OAUTH_CLIENT_ID")!;
+  const clientSecret = Deno.env.get("FATHOM_OAUTH_CLIENT_SECRET")!;
+  const tokenResponse = await fetch(
+    "https://fathom.video/external/v1/oauth2/token",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: creds.refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    },
+  );
   if (!tokenResponse.ok) {
-    throw new Error('FATHOM_AUTH_EXPIRED');
+    throw new Error("FATHOM_AUTH_EXPIRED");
   }
   const tokens = await tokenResponse.json();
   const expiresAt = Date.now() + tokens.expires_in * 1000;
 
   await supabase
-    .from('import_sources')
+    .from("import_sources")
     .update({
       oauth_access_token: tokens.access_token,
       oauth_refresh_token: tokens.refresh_token,
       oauth_token_expires: expiresAt,
     })
-    .eq('id', sourceId);
+    .eq("id", sourceId);
 
   return tokens.access_token;
 }
@@ -154,23 +149,25 @@ async function fetchMeetingByRecordingId(
 ): Promise<Record<string, unknown> | null> {
   // Strategy A: direct recording_id filter
   {
-    const url = new URL('https://api.fathom.ai/external/v1/meetings');
-    url.searchParams.append('limit', '1');
-    url.searchParams.append('include_transcript', 'true');
-    url.searchParams.append('include_summary', 'true');
-    url.searchParams.append('recording_id', String(legacyRecordingId));
+    const url = new URL("https://api.fathom.ai/external/v1/meetings");
+    url.searchParams.append("limit", "1");
+    url.searchParams.append("include_transcript", "true");
+    url.searchParams.append("include_summary", "true");
+    url.searchParams.append("recording_id", String(legacyRecordingId));
 
     const response = await FathomClient.fetchWithRetry(url.toString(), {
       headers: authHeaders,
       maxRetries: 3,
     });
     if (response.status === 429) {
-      throw new Error('FATHOM_RATE_LIMITED');
+      throw new Error("FATHOM_RATE_LIMITED");
     }
     if (response.ok) {
       const data = await response.json();
       const items = (data.items as Array<Record<string, unknown>>) || [];
-      const match = items.find((m) => Number(m.recording_id) === legacyRecordingId);
+      const match = items.find(
+        (m) => Number(m.recording_id) === legacyRecordingId,
+      );
       if (match) return match;
     }
   }
@@ -178,30 +175,34 @@ async function fetchMeetingByRecordingId(
   // Strategy B: paginate around known start_time (fallback when API rejects recording_id filter)
   if (knownStartTime) {
     const start = new Date(knownStartTime);
-    const oneDayBefore = new Date(start.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    const oneDayBefore = new Date(
+      start.getTime() - 24 * 60 * 60 * 1000,
+    ).toISOString();
 
     let cursor: string | undefined;
     for (let page = 0; page < 5; page++) {
-      const url = new URL('https://api.fathom.ai/external/v1/meetings');
-      url.searchParams.append('limit', '50');
-      url.searchParams.append('include_transcript', 'true');
-      url.searchParams.append('include_summary', 'true');
-      url.searchParams.append('created_after', oneDayBefore);
-      if (cursor) url.searchParams.append('cursor', cursor);
+      const url = new URL("https://api.fathom.ai/external/v1/meetings");
+      url.searchParams.append("limit", "50");
+      url.searchParams.append("include_transcript", "true");
+      url.searchParams.append("include_summary", "true");
+      url.searchParams.append("created_after", oneDayBefore);
+      if (cursor) url.searchParams.append("cursor", cursor);
 
       const response = await FathomClient.fetchWithRetry(url.toString(), {
         headers: authHeaders,
         maxRetries: 3,
       });
       if (response.status === 429) {
-        throw new Error('FATHOM_RATE_LIMITED');
+        throw new Error("FATHOM_RATE_LIMITED");
       }
       if (!response.ok) {
         break;
       }
       const data = await response.json();
       const items = (data.items as Array<Record<string, unknown>>) || [];
-      const match = items.find((m) => Number(m.recording_id) === legacyRecordingId);
+      const match = items.find(
+        (m) => Number(m.recording_id) === legacyRecordingId,
+      );
       if (match) return match;
       cursor = data.next_cursor as string | undefined;
       if (!cursor) break;
@@ -224,38 +225,49 @@ function normalizeMeeting(meeting: Record<string, unknown>): {
   calendarInvitees: unknown;
   recordingStartTime: string;
 } {
-  const title = (meeting.title as string) || 'Untitled Call';
+  const title = (meeting.title as string) || "Untitled Call";
   const transcript = (meeting.transcript as FathomTranscriptSegment[]) || [];
   const consolidated: string[] = [];
   let curSpeaker: string | null = null;
   let curTs: string | null = null;
   let curTexts: string[] = [];
   transcript.forEach((seg, idx) => {
-    const name = seg.speaker?.display_name || 'Unknown';
+    const name = seg.speaker?.display_name || "Unknown";
     if (name !== curSpeaker) {
       if (curSpeaker && curTexts.length) {
-        consolidated.push(`[${curTs || '00:00:00'}] ${curSpeaker}: ${curTexts.join(' ')}`);
+        consolidated.push(
+          `[${curTs || "00:00:00"}] ${curSpeaker}: ${curTexts.join(" ")}`,
+        );
       }
       curSpeaker = name;
-      curTs = seg.timestamp || '00:00:00';
-      curTexts = [seg.text || ''];
+      curTs = seg.timestamp || "00:00:00";
+      curTexts = [seg.text || ""];
     } else {
-      curTexts.push(seg.text || '');
+      curTexts.push(seg.text || "");
     }
     if (idx === transcript.length - 1 && curTexts.length) {
-      consolidated.push(`[${curTs || '00:00:00'}] ${curSpeaker}: ${curTexts.join(' ')}`);
+      consolidated.push(
+        `[${curTs || "00:00:00"}] ${curSpeaker}: ${curTexts.join(" ")}`,
+      );
     }
   });
-  const fullTranscript = consolidated.join('\n\n');
+  const fullTranscript = consolidated.join("\n\n");
 
   const summary =
-    (meeting.default_summary as { markdown_formatted?: string } | undefined)?.markdown_formatted || null;
+    (meeting.default_summary as { markdown_formatted?: string } | undefined)
+      ?.markdown_formatted || null;
 
   const start = new Date(meeting.recording_start_time as string);
-  const end = meeting.recording_end_time ? new Date(meeting.recording_end_time as string) : null;
-  const durationSec = end ? Math.floor((end.getTime() - start.getTime()) / 1000) : undefined;
+  const end = meeting.recording_end_time
+    ? new Date(meeting.recording_end_time as string)
+    : null;
+  const durationSec = end
+    ? Math.floor((end.getTime() - start.getTime()) / 1000)
+    : undefined;
 
-  const recordedBy = meeting.recorded_by as { name?: string; email?: string } | undefined;
+  const recordedBy = meeting.recorded_by as
+    | { name?: string; email?: string }
+    | undefined;
 
   return {
     title,
@@ -288,31 +300,31 @@ async function refreshOne(
 ): Promise<RefreshResult> {
   // 1. Verify ownership + read existing row
   const { data: rec, error: recErr } = await supabase
-    .from('recordings')
+    .from("recordings")
     .select(
-      'id, legacy_recording_id, organization_id, owner_user_id, source_app, source_call_id, created_at, recording_start_time, source_metadata',
+      "id, legacy_recording_id, organization_id, owner_user_id, source_app, source_call_id, created_at, recording_start_time, source_metadata",
     )
-    .eq('id', recordingUuid)
+    .eq("id", recordingUuid)
     .maybeSingle();
-  if (recErr) throw new Error('INTERNAL');
+  if (recErr) throw new Error("INTERNAL");
   if (!rec) {
-    const e = new Error('RECORDING_NOT_FOUND');
+    const e = new Error("RECORDING_NOT_FOUND");
     (e as Error & { httpStatus?: number }).httpStatus = 404;
     throw e;
   }
   if (rec.owner_user_id !== userId) {
     // Match RLS behavior — 404 not 403 (prevents existence-leak)
-    const e = new Error('RECORDING_NOT_FOUND');
+    const e = new Error("RECORDING_NOT_FOUND");
     (e as Error & { httpStatus?: number }).httpStatus = 404;
     throw e;
   }
-  if (rec.source_app !== 'fathom') {
-    const e = new Error('NOT_A_FATHOM_CALL');
+  if (rec.source_app !== "fathom") {
+    const e = new Error("NOT_A_FATHOM_CALL");
     (e as Error & { httpStatus?: number }).httpStatus = 400;
     throw e;
   }
   if (!rec.legacy_recording_id) {
-    const e = new Error('FATHOM_NO_LEGACY_ID');
+    const e = new Error("FATHOM_NO_LEGACY_ID");
     (e as Error & { httpStatus?: number }).httpStatus = 400;
     throw e;
   }
@@ -320,7 +332,7 @@ async function refreshOne(
   // 2. Find user's active Fathom source
   const src = await findFathomSource(supabase, userId);
   if (!src) {
-    const e = new Error('NO_FATHOM_SOURCE');
+    const e = new Error("NO_FATHOM_SOURCE");
     (e as Error & { httpStatus?: number }).httpStatus = 404;
     throw e;
   }
@@ -328,9 +340,11 @@ async function refreshOne(
   // 3. Resolve + refresh OAuth tokens
   const creds = await resolveCredentials(supabase, src.sourceId, userId);
   const accessToken = await refreshIfExpired(supabase, src.sourceId, creds);
-  const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (accessToken) authHeaders['Authorization'] = `Bearer ${accessToken}`;
-  else if (creds.apiKey) authHeaders['X-Api-Key'] = creds.apiKey;
+  const authHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (accessToken) authHeaders["Authorization"] = `Bearer ${accessToken}`;
+  else if (creds.apiKey) authHeaders["X-Api-Key"] = creds.apiKey;
 
   // 4. Fetch latest meeting from Fathom
   const meeting = await fetchMeetingByRecordingId(
@@ -339,7 +353,7 @@ async function refreshOne(
     rec.recording_start_time as string | null,
   );
   if (!meeting) {
-    const e = new Error('FATHOM_CALL_NOT_FOUND');
+    const e = new Error("FATHOM_CALL_NOT_FOUND");
     (e as Error & { httpStatus?: number }).httpStatus = 404;
     throw e;
   }
@@ -359,13 +373,13 @@ async function refreshOne(
     recorded_by_email: n.recordedByEmail,
     calendar_invitees: n.calendarInvitees,
     summary: n.summary,
-    import_source: 'fathom-refresh',
+    import_source: "fathom-refresh",
     synced_at: syncedAt,
   };
 
   // 7. UPDATE recordings — preservation invariants enforced by NOT setting those columns
   const { error: upErr } = await supabase
-    .from('recordings')
+    .from("recordings")
     .update({
       title: n.title,
       full_transcript: n.fullTranscript,
@@ -375,15 +389,15 @@ async function refreshOne(
       synced_at: syncedAt,
       source_metadata: mergedMeta,
     })
-    .eq('id', recordingUuid)
-    .eq('owner_user_id', userId);
+    .eq("id", recordingUuid)
+    .eq("owner_user_id", userId);
   if (upErr) {
-    console.error('[fathom-refresh] update failed:', upErr);
-    throw new Error('INTERNAL');
+    console.error("[fathom-refresh] update failed:", upErr);
+    throw new Error("INTERNAL");
   }
 
   // 8. Re-upsert mirror
-  const { error: rawErr } = await supabase.from('fathom_raw_calls').upsert(
+  const { error: rawErr } = await supabase.from("fathom_raw_calls").upsert(
     {
       recording_id: rec.legacy_recording_id,
       user_id: userId,
@@ -403,10 +417,13 @@ async function refreshOne(
       calendar_invitees: n.calendarInvitees,
       synced_at: syncedAt,
     },
-    { onConflict: 'recording_id,user_id' },
+    { onConflict: "recording_id,user_id" },
   );
   if (rawErr) {
-    console.error('[fathom-refresh] mirror upsert error (non-blocking):', rawErr);
+    console.error(
+      "[fathom-refresh] mirror upsert error (non-blocking):",
+      rawErr,
+    );
   }
 
   return {
@@ -420,14 +437,15 @@ async function refreshOne(
 }
 
 Deno.serve(async (req) => {
-  const origin = req.headers.get('Origin');
+  const origin = req.headers.get("Origin");
   const corsHeaders = getCorsHeaders(origin);
-  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method === "OPTIONS")
+    return new Response(null, { headers: corsHeaders });
 
   try {
     const supabase = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
 
     // Auth
@@ -438,34 +456,43 @@ Deno.serve(async (req) => {
     // Parse body
     const body = await req.json().catch(() => ({}));
     const recordingId = body.recording_id as string | undefined;
-    if (!recordingId || typeof recordingId !== 'string') {
+    if (!recordingId || typeof recordingId !== "string") {
       return new Response(
-        JSON.stringify({ error: 'BAD_REQUEST', message: 'recording_id (uuid) required' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        JSON.stringify({
+          error: "BAD_REQUEST",
+          message: "recording_id (uuid) required",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
     const result = await refreshOne(supabase, userId, recordingId);
     return new Response(JSON.stringify(result), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'INTERNAL';
+    const msg = error instanceof Error ? error.message : "INTERNAL";
     const httpStatus =
       (error as Error & { httpStatus?: number }).httpStatus ??
-      (msg === 'FATHOM_RATE_LIMITED'
+      (msg === "FATHOM_RATE_LIMITED"
         ? 429
-        : msg === 'FATHOM_AUTH_EXPIRED'
+        : msg === "FATHOM_AUTH_EXPIRED"
           ? 401
-          : msg === 'FATHOM_CALL_NOT_FOUND'
+          : msg === "FATHOM_CALL_NOT_FOUND"
             ? 404
             : 500);
-    console.error('[fathom-refresh] handler error:', error);
+    console.error("[fathom-refresh] handler error:", error);
     const headers: Record<string, string> = {
       ...corsHeaders,
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     };
-    if (httpStatus === 429) headers['Retry-After'] = '30';
-    return new Response(JSON.stringify({ error: msg }), { status: httpStatus, headers });
+    if (httpStatus === 429) headers["Retry-After"] = "30";
+    return new Response(JSON.stringify({ error: msg }), {
+      status: httpStatus,
+      headers,
+    });
   }
 });

--- a/supabase/functions/sync-meetings/index.ts
+++ b/supabase/functions/sync-meetings/index.ts
@@ -1,8 +1,9 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { FathomClient } from '../_shared/fathom-client.ts';
-import { getCorsHeaders } from '../_shared/cors.ts';
-import { runPipeline } from '../_shared/connector-pipeline.ts';
-import { authenticateRequest } from '../_shared/auth.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { FathomClient } from "../_shared/fathom-client.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import { runPipeline } from "../_shared/connector-pipeline.ts";
+import { authenticateRequest } from "../_shared/auth.ts";
+import { getDecryptedOAuthTokens } from "../_shared/oauth-encrypt.ts";
 
 // Rate limiter for API calls - conservative to avoid 429 errors
 class RateLimiter {
@@ -23,7 +24,7 @@ class RateLimiter {
     if (this.requestCount >= this.maxRequests) {
       const waitTime = this.windowMs - elapsed;
       console.log(`Rate limit prevention: waiting ${waitTime}ms...`);
-      await new Promise(resolve => setTimeout(resolve, waitTime));
+      await new Promise((resolve) => setTimeout(resolve, waitTime));
       this.requestCount = 0;
       this.windowStart = Date.now();
     }
@@ -57,7 +58,7 @@ async function syncMeeting(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   meeting: any,
   workspaceId?: string | null,
-): Promise<'synced' | 'skipped' | 'failed'> {
+): Promise<"synced" | "skipped" | "failed"> {
   try {
     console.log(`Syncing meeting ${recordingId}: ${meeting.title}`);
 
@@ -72,19 +73,19 @@ async function syncMeeting(
     let currentTexts: string[] = [];
 
     transcript.forEach((seg: TranscriptSegment, index: number) => {
-      const speakerName = seg.speaker?.display_name || 'Unknown';
+      const speakerName = seg.speaker?.display_name || "Unknown";
 
       if (speakerName !== currentSpeaker) {
         // Speaker changed - save previous speaker's consolidated text
         if (currentSpeaker !== null && currentTexts.length > 0) {
           consolidatedSegments.push(
-            `[${currentTimestamp || '00:00:00'}] ${currentSpeaker}: ${currentTexts.join(' ')}`
+            `[${currentTimestamp || "00:00:00"}] ${currentSpeaker}: ${currentTexts.join(" ")}`,
           );
         }
 
         // Start new speaker turn
         currentSpeaker = speakerName;
-        currentTimestamp = seg.timestamp || '00:00:00';
+        currentTimestamp = seg.timestamp || "00:00:00";
         currentTexts = [seg.text];
       } else {
         // Same speaker - append text
@@ -94,26 +95,30 @@ async function syncMeeting(
       // Handle last segment
       if (index === transcript.length - 1 && currentTexts.length > 0) {
         consolidatedSegments.push(
-          `[${currentTimestamp || '00:00:00'}] ${currentSpeaker}: ${currentTexts.join(' ')}`
+          `[${currentTimestamp || "00:00:00"}] ${currentSpeaker}: ${currentTexts.join(" ")}`,
         );
       }
     });
 
-    const fullTranscript = consolidatedSegments.join('\n\n');
+    const fullTranscript = consolidatedSegments.join("\n\n");
 
     // Extract summary
     const summaryText = meeting.default_summary?.markdown_formatted || null;
 
     // Calculate duration from start/end times
     const startTime = new Date(meeting.recording_start_time);
-    const endTime = meeting.recording_end_time ? new Date(meeting.recording_end_time) : null;
+    const endTime = meeting.recording_end_time
+      ? new Date(meeting.recording_end_time)
+      : null;
     const durationSeconds = endTime
       ? Math.floor((endTime.getTime() - startTime.getTime()) / 1000)
       : undefined;
 
     // Extract participant emails from calendar_invitees
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const participantEmails = (meeting.calendar_invitees || []).map((inv: any) => inv.email).filter(Boolean);
+    const participantEmails = (meeting.calendar_invitees || [])
+      .map((inv: any) => inv.email)
+      .filter(Boolean);
 
     // Build source_metadata
     const sourceMetadata = {
@@ -125,14 +130,14 @@ async function syncMeeting(
       calendar_invitees: meeting.calendar_invitees || [],
       participant_emails: participantEmails,
       summary: summaryText,
-      import_source: 'sync-meetings',
+      import_source: "sync-meetings",
       synced_at: new Date().toISOString(),
     };
 
     // Stage 5 — Run through pipeline (Dedup -> Routing -> Insert)
     const result = await runPipeline(supabase, userId, {
       external_id: externalId,
-      source_app: 'fathom',
+      source_app: "fathom",
       title: meeting.title,
       full_transcript: fullTranscript,
       summary: summaryText,
@@ -147,114 +152,149 @@ async function syncMeeting(
 
     if (!result.success) {
       if (result.skipped) {
-        console.log(`Fathom meeting ${recordingId} already exists (pipeline skipped)`);
-        return 'skipped';
+        console.log(
+          `Fathom meeting ${recordingId} already exists (pipeline skipped)`,
+        );
+        return "skipped";
       }
-      throw new Error(result.error || 'Pipeline failed');
+      throw new Error(result.error || "Pipeline failed");
     }
 
-    console.log(`Successfully synced Fathom meeting ${recordingId} as recording ${result.recordingId}`);
+    console.log(
+      `Successfully synced Fathom meeting ${recordingId} as recording ${result.recordingId}`,
+    );
 
     // Write to fathom_raw_calls for source-specific detail
     try {
       const { error: rawError } = await supabase
-        .from('fathom_raw_calls')
-        .upsert({
-          recording_id: recordingId,
-          user_id: userId,
-          canonical_recording_id: result.recordingId,
-          title: meeting.title,
-          created_at: meeting.created_at,
-          recording_start_time: meeting.recording_start_time,
-          recording_end_time: meeting.recording_end_time || null,
-          url: meeting.url || null,
-          share_url: meeting.share_url || null,
-          full_transcript: fullTranscript,
-          summary: summaryText,
-          recorded_by_name: meeting.recorded_by?.name || null,
-          recorded_by_email: meeting.recorded_by?.email || null,
-          calendar_invitees: meeting.calendar_invitees || null,
-          synced_at: new Date().toISOString(),
-        }, {
-          onConflict: 'recording_id,user_id'
-        });
+        .from("fathom_raw_calls")
+        .upsert(
+          {
+            recording_id: recordingId,
+            user_id: userId,
+            canonical_recording_id: result.recordingId,
+            title: meeting.title,
+            created_at: meeting.created_at,
+            recording_start_time: meeting.recording_start_time,
+            recording_end_time: meeting.recording_end_time || null,
+            url: meeting.url || null,
+            share_url: meeting.share_url || null,
+            full_transcript: fullTranscript,
+            summary: summaryText,
+            recorded_by_name: meeting.recorded_by?.name || null,
+            recorded_by_email: meeting.recorded_by?.email || null,
+            calendar_invitees: meeting.calendar_invitees || null,
+            synced_at: new Date().toISOString(),
+          },
+          {
+            onConflict: "recording_id,user_id",
+          },
+        );
 
       if (rawError) {
-        console.error(`Error inserting fathom_raw_calls for ${recordingId} (non-blocking):`, rawError);
+        console.error(
+          `Error inserting fathom_raw_calls for ${recordingId} (non-blocking):`,
+          rawError,
+        );
       }
     } catch (rawErr) {
-      console.error(`Error writing fathom_raw_calls for ${recordingId} (non-blocking):`, rawErr);
+      console.error(
+        `Error writing fathom_raw_calls for ${recordingId} (non-blocking):`,
+        rawErr,
+      );
     }
 
     // Insert transcript segments into fathom_raw_transcripts for backward compat
     if (meeting.transcript && meeting.transcript.length > 0) {
-      const transcriptRows = meeting.transcript.map((segment: TranscriptSegment) => {
-        let speakerEmail = segment.speaker.matched_calendar_invitee_email;
+      const transcriptRows = meeting.transcript.map(
+        (segment: TranscriptSegment) => {
+          let speakerEmail = segment.speaker.matched_calendar_invitee_email;
 
-        if (!speakerEmail && meeting.calendar_invitees) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const matchedInvitee = meeting.calendar_invitees.find((inv: any) =>
-            inv.matched_speaker_display_name === segment.speaker.display_name ||
-            inv.name === segment.speaker.display_name
-          );
-          if (matchedInvitee) {
-            speakerEmail = matchedInvitee.email;
+          if (!speakerEmail && meeting.calendar_invitees) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const matchedInvitee = meeting.calendar_invitees.find(
+              (inv: any) =>
+                inv.matched_speaker_display_name ===
+                  segment.speaker.display_name ||
+                inv.name === segment.speaker.display_name,
+            );
+            if (matchedInvitee) {
+              speakerEmail = matchedInvitee.email;
+            }
           }
-        }
 
-        return {
-          recording_id: meeting.recording_id,
-          user_id: userId,
-          speaker_name: segment.speaker.display_name,
-          speaker_email: speakerEmail,
-          text: segment.text,
-          timestamp: segment.timestamp,
-        };
-      });
+          return {
+            recording_id: meeting.recording_id,
+            user_id: userId,
+            speaker_name: segment.speaker.display_name,
+            speaker_email: speakerEmail,
+            text: segment.text,
+            timestamp: segment.timestamp,
+          };
+        },
+      );
 
       const { error: transcriptError } = await supabase
-        .from('fathom_raw_transcripts')
+        .from("fathom_raw_transcripts")
         .insert(transcriptRows);
 
       if (transcriptError) {
         // Non-blocking — transcript table is supplementary; recording already committed
-        console.error(`Error inserting transcripts for ${recordingId} (non-blocking):`, transcriptError);
+        console.error(
+          `Error inserting transcripts for ${recordingId} (non-blocking):`,
+          transcriptError,
+        );
       } else {
-        console.log(`Synced ${transcriptRows.length} transcript segments for meeting ${recordingId}`);
+        console.log(
+          `Synced ${transcriptRows.length} transcript segments for meeting ${recordingId}`,
+        );
       }
     }
 
-    return 'synced';
+    return "synced";
   } catch (error) {
     console.error(`Failed to sync meeting ${recordingId}:`, error);
-    return 'failed';
+    return "failed";
   }
 }
 
 Deno.serve(async (req) => {
-  const origin = req.headers.get('Origin');
+  const origin = req.headers.get("Origin");
   const corsHeaders = getCorsHeaders(origin);
 
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
     // service-role required: cross-import fan-out — pulls from Fathom API + writes fathom_raw_calls + invokes generate-ai-titles + auto-tag-calls downstream.
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     // Parse request body FIRST
-    const { recordingIds = [], singleCallId, createdAfter, createdBefore, workspace_id, sourceId } = await req.json();
+    const {
+      recordingIds = [],
+      singleCallId,
+      createdAfter,
+      createdBefore,
+      workspace_id,
+      sourceId,
+    } = await req.json();
 
     // Support single recording retry
     const targetRecordingIds = singleCallId ? [singleCallId] : recordingIds;
 
     if (!Array.isArray(targetRecordingIds) || targetRecordingIds.length === 0) {
       return new Response(
-        JSON.stringify({ error: 'recordingIds must be an array or singleCallId must be provided' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({
+          error:
+            "recordingIds must be an array or singleCallId must be provided",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -266,7 +306,9 @@ Deno.serve(async (req) => {
 
     // We still need the raw JWT for forwarding to downstream edge functions
     // (generate-ai-titles, auto-tag-calls) so they authenticate as the same user.
-    const jwt = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '').trim();
+    const jwt = (req.headers.get("Authorization") || "")
+      .replace(/^Bearer\s+/i, "")
+      .trim();
 
     // ── Resolve Fathom credentials ──────────────────────────────────────────
     // Priority: import_sources (per-account) → user_settings (legacy fallback)
@@ -277,45 +319,62 @@ Deno.serve(async (req) => {
       fathom_api_key: string | null;
     } | null = null;
     let credSourceId: string | null = sourceId ?? null;
-    const credSourceTable: 'import_sources' | 'user_settings' = sourceId ? 'import_sources' : 'import_sources';
+    const credSourceTable: "import_sources" | "user_settings" = sourceId
+      ? "import_sources"
+      : "import_sources";
+
+    // Phase 28-03 fix (#294): route OAuth token reads through the canonical
+    // helper. Direct selects on oauth_access_token were returning PGP-armored
+    // ciphertext for encrypted rows and getting 401 from Fathom.
+    const loadCredsFromSource = async (rowId: string) => {
+      const decrypted = await getDecryptedOAuthTokens(supabase, rowId, userId);
+      const { data: apiKeyRow } = await supabase
+        .from("import_sources")
+        .select("fathom_api_key")
+        .eq("id", rowId)
+        .eq("user_id", userId)
+        .maybeSingle();
+      return {
+        oauth_access_token: decrypted.access_token,
+        oauth_refresh_token: decrypted.refresh_token,
+        oauth_token_expires: decrypted.token_expires,
+        fathom_api_key: apiKeyRow?.fathom_api_key ?? null,
+      };
+    };
 
     if (sourceId) {
-      // Read tokens from the specific import_sources row
-      const { data: srcRow, error: srcErr } = await supabase
-        .from('import_sources')
-        .select('oauth_access_token, oauth_refresh_token, oauth_token_expires, fathom_api_key')
-        .eq('id', sourceId)
-        .eq('user_id', userId)
-        .maybeSingle();
-
-      if (srcErr) throw srcErr;
-      creds = srcRow;
+      creds = await loadCredsFromSource(sourceId);
     }
 
     // If no sourceId or source row has no tokens, try first active fathom source
     if (!creds?.oauth_access_token && !creds?.fathom_api_key) {
       const { data: firstSource } = await supabase
-        .from('import_sources')
-        .select('id, oauth_access_token, oauth_refresh_token, oauth_token_expires, fathom_api_key')
-        .eq('user_id', userId)
-        .eq('source_app', 'fathom')
-        .eq('is_active', true)
-        .order('updated_at', { ascending: false })
+        .from("import_sources")
+        .select("id")
+        .eq("user_id", userId)
+        .eq("source_app", "fathom")
+        .eq("is_active", true)
+        .order("updated_at", { ascending: false })
         .limit(1)
         .maybeSingle();
 
-      if (firstSource?.oauth_access_token || firstSource?.fathom_api_key) {
-        creds = firstSource;
-        credSourceId = firstSource.id;
+      if (firstSource?.id) {
+        const fallback = await loadCredsFromSource(firstSource.id);
+        if (fallback.oauth_access_token || fallback.fathom_api_key) {
+          creds = fallback;
+          credSourceId = firstSource.id;
+        }
       }
     }
 
     // Final fallback: user_settings (legacy)
     if (!creds?.oauth_access_token && !creds?.fathom_api_key) {
       const { data: settings, error: configError } = await supabase
-        .from('user_settings')
-        .select('fathom_api_key, oauth_access_token, oauth_token_expires, oauth_refresh_token')
-        .eq('user_id', userId)
+        .from("user_settings")
+        .select(
+          "fathom_api_key, oauth_access_token, oauth_token_expires, oauth_refresh_token",
+        )
+        .eq("user_id", userId)
         .maybeSingle();
 
       if (configError) throw configError;
@@ -323,148 +382,176 @@ Deno.serve(async (req) => {
     }
 
     if (!creds?.fathom_api_key && !creds?.oauth_access_token) {
-      throw new Error('Fathom credentials not configured. Please add them in Settings.');
+      throw new Error(
+        "Fathom credentials not configured. Please add them in Settings.",
+      );
     }
 
     // Determine authentication method - prefer OAuth if available and valid
     const authHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     };
 
     // Check if OAuth token is available and not expired
-    const oauthTokenExpires = creds.oauth_token_expires ? new Date(creds.oauth_token_expires) : null;
-    const isOAuthValid = creds.oauth_access_token && oauthTokenExpires && oauthTokenExpires > new Date();
+    const oauthTokenExpires = creds.oauth_token_expires
+      ? new Date(creds.oauth_token_expires)
+      : null;
+    const isOAuthValid =
+      creds.oauth_access_token &&
+      oauthTokenExpires &&
+      oauthTokenExpires > new Date();
 
     if (isOAuthValid) {
-      authHeaders['Authorization'] = `Bearer ${creds.oauth_access_token}`;
-      console.log('Using OAuth Bearer token authentication for sync-meetings');
+      authHeaders["Authorization"] = `Bearer ${creds.oauth_access_token}`;
+      console.log("Using OAuth Bearer token authentication for sync-meetings");
     } else if (creds.oauth_access_token && creds.oauth_refresh_token) {
       // OAuth token expired but we have a refresh token - try to refresh
-      console.log('OAuth token expired, attempting refresh...');
+      console.log("OAuth token expired, attempting refresh...");
       try {
-        const clientId = Deno.env.get('FATHOM_OAUTH_CLIENT_ID');
-        const clientSecret = Deno.env.get('FATHOM_OAUTH_CLIENT_SECRET');
+        const clientId = Deno.env.get("FATHOM_OAUTH_CLIENT_ID");
+        const clientSecret = Deno.env.get("FATHOM_OAUTH_CLIENT_SECRET");
 
         if (!clientId || !clientSecret) {
-          throw new Error('OAuth not configured on server');
+          throw new Error("OAuth not configured on server");
         }
 
-        const tokenResponse = await fetch('https://fathom.video/external/v1/oauth2/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: new URLSearchParams({
-            grant_type: 'refresh_token',
-            refresh_token: creds.oauth_refresh_token,
-            client_id: clientId,
-            client_secret: clientSecret,
-          }),
-        });
+        const tokenResponse = await fetch(
+          "https://fathom.video/external/v1/oauth2/token",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+              grant_type: "refresh_token",
+              refresh_token: creds.oauth_refresh_token,
+              client_id: clientId,
+              client_secret: clientSecret,
+            }),
+          },
+        );
 
         if (!tokenResponse.ok) {
           const errorText = await tokenResponse.text();
-          console.error('Token refresh failed:', tokenResponse.status, errorText);
+          console.error(
+            "Token refresh failed:",
+            tokenResponse.status,
+            errorText,
+          );
 
           if (tokenResponse.status >= 400 && tokenResponse.status < 500) {
             // Clear invalid tokens from whichever table they came from
             if (credSourceId) {
               await supabase
-                .from('import_sources')
+                .from("import_sources")
                 .update({
                   oauth_access_token: null,
                   oauth_refresh_token: null,
                   oauth_token_expires: null,
                 })
-                .eq('id', credSourceId);
+                .eq("id", credSourceId);
             }
             await supabase
-              .from('user_settings')
+              .from("user_settings")
               .update({
                 oauth_access_token: null,
                 oauth_refresh_token: null,
                 oauth_token_expires: null,
               })
-              .eq('user_id', userId);
+              .eq("user_id", userId);
           }
 
-          throw new Error('Failed to refresh access token. Please reconnect Fathom in Settings.');
+          throw new Error(
+            "Failed to refresh access token. Please reconnect Fathom in Settings.",
+          );
         }
 
         const tokens = await tokenResponse.json();
-        const expiresAt = Date.now() + (tokens.expires_in * 1000);
+        const expiresAt = Date.now() + tokens.expires_in * 1000;
 
         // Store new tokens in import_sources if we have a source ID
         if (credSourceId) {
           await supabase
-            .from('import_sources')
+            .from("import_sources")
             .update({
               oauth_access_token: tokens.access_token,
               oauth_refresh_token: tokens.refresh_token,
               oauth_token_expires: expiresAt,
             })
-            .eq('id', credSourceId);
+            .eq("id", credSourceId);
         }
 
         // Also update user_settings for backward compat
         await supabase
-          .from('user_settings')
+          .from("user_settings")
           .update({
             oauth_access_token: tokens.access_token,
             oauth_refresh_token: tokens.refresh_token,
             oauth_token_expires: expiresAt,
           })
-          .eq('user_id', userId);
+          .eq("user_id", userId);
 
-        authHeaders['Authorization'] = `Bearer ${tokens.access_token}`;
-        console.log('OAuth token refreshed successfully for sync-meetings');
+        authHeaders["Authorization"] = `Bearer ${tokens.access_token}`;
+        console.log("OAuth token refreshed successfully for sync-meetings");
       } catch (refreshError) {
-        console.error('Error refreshing OAuth token:', refreshError);
+        console.error("Error refreshing OAuth token:", refreshError);
         if (creds.fathom_api_key) {
-          authHeaders['X-Api-Key'] = creds.fathom_api_key;
-          console.log('OAuth refresh failed, falling back to API key authentication');
+          authHeaders["X-Api-Key"] = creds.fathom_api_key;
+          console.log(
+            "OAuth refresh failed, falling back to API key authentication",
+          );
         } else {
-          throw new Error('OAuth token expired and refresh failed. Please reconnect Fathom in Settings.');
+          throw new Error(
+            "OAuth token expired and refresh failed. Please reconnect Fathom in Settings.",
+          );
         }
       }
     } else if (creds.fathom_api_key) {
-      authHeaders['X-Api-Key'] = creds.fathom_api_key;
-      console.log('Using API key authentication for sync-meetings');
+      authHeaders["X-Api-Key"] = creds.fathom_api_key;
+      console.log("Using API key authentication for sync-meetings");
     } else {
-      throw new Error('Fathom OAuth token has expired. Please reconnect your Fathom account in Settings.');
+      throw new Error(
+        "Fathom OAuth token has expired. Please reconnect your Fathom account in Settings.",
+      );
     }
-
 
     // Validate vault membership once at the top if workspace_id provided
     let validatedVaultId: string | null = null;
     if (workspace_id) {
       const { data: membership, error: membershipError } = await supabase
-        .from('workspace_memberships')
-        .select('id')
-        .eq('workspace_id', workspace_id)
-        .eq('user_id', userId)
+        .from("workspace_memberships")
+        .select("id")
+        .eq("workspace_id", workspace_id)
+        .eq("user_id", userId)
         .maybeSingle();
 
       if (membershipError) {
-        console.error('Error checking vault membership:', membershipError);
+        console.error("Error checking vault membership:", membershipError);
       } else if (!membership) {
-        console.warn(`User ${userId} is not a member of vault ${workspace_id}, ignoring workspace_id`);
+        console.warn(
+          `User ${userId} is not a member of vault ${workspace_id}, ignoring workspace_id`,
+        );
       } else {
         validatedVaultId = workspace_id;
-        console.log(`Vault ${workspace_id} membership validated for user ${userId}`);
+        console.log(
+          `Vault ${workspace_id} membership validated for user ${userId}`,
+        );
       }
     }
 
-    console.log(`Syncing ${recordingIds.length} meetings with date range:`, { createdAfter, createdBefore });
+    console.log(`Syncing ${recordingIds.length} meetings with date range:`, {
+      createdAfter,
+      createdBefore,
+    });
 
     // Create a sync job record
     const { data: syncJob, error: jobError } = await supabase
-      .from('sync_jobs')
+      .from("sync_jobs")
       .insert({
         user_id: userId,
         recording_ids: targetRecordingIds,
-        status: 'processing',
+        status: "processing",
         progress_current: 0,
         progress_total: targetRecordingIds.length,
-        type: 'fathom', // Explicitly set the source type
+        type: "fathom", // Explicitly set the source type
       })
       .select()
       .single();
@@ -472,27 +559,31 @@ Deno.serve(async (req) => {
     if (jobError) throw jobError;
     const jobId = syncJob.id;
 
-    console.log(`Created sync job ${jobId} for ${recordingIds.length} meetings`);
+    console.log(
+      `Created sync job ${jobId} for ${recordingIds.length} meetings`,
+    );
 
     // Helper function to fetch meeting metadata from paginated list
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fetchMeetingMetadata = async (targetRecordingId: number): Promise<any | null> => {
+    const fetchMeetingMetadata = async (
+      targetRecordingId: number,
+    ): Promise<any | null> => {
       let cursor: string | undefined = undefined;
       const maxPages = 100; // Increase max pages for old meetings
 
       for (let pageCount = 0; pageCount < maxPages; pageCount++) {
-        const url = new URL('https://api.fathom.ai/external/v1/meetings');
+        const url = new URL("https://api.fathom.ai/external/v1/meetings");
 
         // Add date filters if provided
         if (createdAfter) {
-          url.searchParams.append('created_after', createdAfter);
+          url.searchParams.append("created_after", createdAfter);
         }
         if (createdBefore) {
-          url.searchParams.append('created_before', createdBefore);
+          url.searchParams.append("created_before", createdBefore);
         }
 
         if (cursor) {
-          url.searchParams.append('cursor', cursor);
+          url.searchParams.append("cursor", cursor);
         }
 
         const response = await FathomClient.fetchWithRetry(url.toString(), {
@@ -506,7 +597,10 @@ Deno.serve(async (req) => {
         }
 
         const data = await response.json();
-        const found = data.items?.find((m: {recording_id: number}) => m.recording_id === Number(targetRecordingId));
+        const found = data.items?.find(
+          (m: { recording_id: number }) =>
+            m.recording_id === Number(targetRecordingId),
+        );
 
         if (found) {
           return found;
@@ -516,7 +610,7 @@ Deno.serve(async (req) => {
         if (!cursor) break;
 
         // Small delay between pages
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
       return null;
@@ -524,29 +618,39 @@ Deno.serve(async (req) => {
 
     // Helper function to fetch transcript and summary separately (like fetch-single-meeting)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fetchMeetingData = async (recordingId: number): Promise<any | null> => {
+    const fetchMeetingData = async (
+      recordingId: number,
+    ): Promise<any | null> => {
       try {
         // Fetch summary and transcript separately by recording_id
         const [summaryResponse, transcriptResponse] = await Promise.all([
           FathomClient.fetchWithRetry(
             `https://api.fathom.ai/external/v1/recordings/${recordingId}/summary`,
-            { headers: authHeaders, maxRetries: 3 }
+            { headers: authHeaders, maxRetries: 3 },
           ),
           FathomClient.fetchWithRetry(
             `https://api.fathom.ai/external/v1/recordings/${recordingId}/transcript`,
-            { headers: authHeaders, maxRetries: 3 }
-          )
+            { headers: authHeaders, maxRetries: 3 },
+          ),
         ]);
 
         if (!summaryResponse.ok && summaryResponse.status !== 404) {
-          console.error(`Failed to fetch summary for ${recordingId}: ${summaryResponse.status}`);
+          console.error(
+            `Failed to fetch summary for ${recordingId}: ${summaryResponse.status}`,
+          );
         }
         if (!transcriptResponse.ok && transcriptResponse.status !== 404) {
-          console.error(`Failed to fetch transcript for ${recordingId}: ${transcriptResponse.status}`);
+          console.error(
+            `Failed to fetch transcript for ${recordingId}: ${transcriptResponse.status}`,
+          );
         }
 
-        const summaryData = summaryResponse.ok ? await summaryResponse.json() : { summary: null };
-        const transcriptData = transcriptResponse.ok ? await transcriptResponse.json() : { transcript: [] };
+        const summaryData = summaryResponse.ok
+          ? await summaryResponse.json()
+          : { summary: null };
+        const transcriptData = transcriptResponse.ok
+          ? await transcriptResponse.json()
+          : { transcript: [] };
 
         // Get meeting metadata from paginated list
         const meetingMetadata = await fetchMeetingMetadata(recordingId);
@@ -576,7 +680,9 @@ Deno.serve(async (req) => {
       const rateLimiter = new RateLimiter();
 
       console.log(`Background processing started for sync job ${jobId}`);
-      console.log(`Using NEW direct recording_id approach for ${recordingIds.length} meetings`);
+      console.log(
+        `Using NEW direct recording_id approach for ${recordingIds.length} meetings`,
+      );
 
       try {
         // Process each meeting individually using direct recording_id endpoints
@@ -585,33 +691,46 @@ Deno.serve(async (req) => {
           try {
             await rateLimiter.throttle();
 
-            console.log(`Fetching meeting ${recordingId} via direct recording_id endpoints...`);
+            console.log(
+              `Fetching meeting ${recordingId} via direct recording_id endpoints...`,
+            );
             const meeting = await fetchMeetingData(recordingId);
 
             if (!meeting) {
-              console.error(`Meeting ${recordingId} not found or failed to fetch`);
+              console.error(
+                `Meeting ${recordingId} not found or failed to fetch`,
+              );
               failed.push(recordingId);
 
               // Update progress
               await supabase
-                .from('sync_jobs')
+                .from("sync_jobs")
                 .update({
-                  progress_current: synced.length + failed.length + skippedCount,
+                  progress_current:
+                    synced.length + failed.length + skippedCount,
                   synced_ids: synced,
                   failed_ids: failed,
                   skipped_count: skippedCount,
                 })
-                .eq('id', jobId);
+                .eq("id", jobId);
 
               continue;
             }
 
-            const outcome = await syncMeeting(supabase, userId, recordingId, meeting, validatedVaultId);
+            const outcome = await syncMeeting(
+              supabase,
+              userId,
+              recordingId,
+              meeting,
+              validatedVaultId,
+            );
 
-            if (outcome === 'synced') {
+            if (outcome === "synced") {
               synced.push(recordingId);
-              console.log(`✓ Synced ${recordingId} (${synced.length}/${recordingIds.length})${validatedVaultId ? ` → workspace ${validatedVaultId}` : ''}`);
-            } else if (outcome === 'skipped') {
+              console.log(
+                `✓ Synced ${recordingId} (${synced.length}/${recordingIds.length})${validatedVaultId ? ` → workspace ${validatedVaultId}` : ""}`,
+              );
+            } else if (outcome === "skipped") {
               skippedCount++;
               console.log(`→ Skipped ${recordingId} (duplicate)`);
             } else {
@@ -621,49 +740,54 @@ Deno.serve(async (req) => {
 
             // Update job progress (skipped items count toward progress)
             await supabase
-              .from('sync_jobs')
+              .from("sync_jobs")
               .update({
                 progress_current: synced.length + failed.length + skippedCount,
                 synced_ids: synced,
                 failed_ids: failed,
                 skipped_count: skippedCount,
               })
-              .eq('id', jobId);
+              .eq("id", jobId);
 
             // Small delay between meetings to be nice to the API
-            await new Promise(resolve => setTimeout(resolve, 500));
+            await new Promise((resolve) => setTimeout(resolve, 500));
           } catch (error) {
             console.error(`Error processing recording ${recordingId}:`, error);
             failed.push(recordingId);
 
             // Update progress even on error
             await supabase
-              .from('sync_jobs')
+              .from("sync_jobs")
               .update({
                 progress_current: synced.length + failed.length + skippedCount,
                 synced_ids: synced,
                 failed_ids: failed,
                 skipped_count: skippedCount,
               })
-              .eq('id', jobId);
+              .eq("id", jobId);
           }
         }
 
         // Mark job as completed with appropriate status
-        const finalStatus = failed.length === 0 ? 'completed' :
-                           synced.length === 0 ? 'failed' :
-                           'completed_with_errors';
+        const finalStatus =
+          failed.length === 0
+            ? "completed"
+            : synced.length === 0
+              ? "failed"
+              : "completed_with_errors";
 
         await supabase
-          .from('sync_jobs')
+          .from("sync_jobs")
           .update({
             status: finalStatus,
             completed_at: new Date().toISOString(),
             skipped_count: skippedCount,
           })
-          .eq('id', jobId);
+          .eq("id", jobId);
 
-        console.log(`Sync job ${jobId} complete: ${synced.length} succeeded, ${failed.length} failed, ${skippedCount} skipped`);
+        console.log(
+          `Sync job ${jobId} complete: ${synced.length} succeeded, ${failed.length} failed, ${skippedCount} skipped`,
+        );
 
         // [DISABLED] Embedding system disabled — pipeline broken
         // if (synced.length > 0) { ... }
@@ -671,55 +795,84 @@ Deno.serve(async (req) => {
         // Fire-and-forget: invoke generate-ai-titles for the synced recordings
         if (synced.length > 0) {
           // This generates descriptive AI titles - respects user preference
-          console.log(`Triggering AI title generation for ${synced.length} synced meetings...`);
-          supabase.functions.invoke('generate-ai-titles', {
-            body: {
-              recordingIds: synced,
-              respectPreference: true,
-            },
-            headers: {
-              Authorization: `Bearer ${jwt}`,
-            },
-          }).then(({ data, error }) => {
-            if (error) {
-              console.error(`AI title generation failed for sync job ${jobId}:`, error);
-            } else {
-              console.log(`AI title generation completed for ${synced.length} meetings:`, data);
-            }
-          }).catch((err) => {
-            console.error(`AI title invocation failed for sync job ${jobId}:`, err);
-          });
+          console.log(
+            `Triggering AI title generation for ${synced.length} synced meetings...`,
+          );
+          supabase.functions
+            .invoke("generate-ai-titles", {
+              body: {
+                recordingIds: synced,
+                respectPreference: true,
+              },
+              headers: {
+                Authorization: `Bearer ${jwt}`,
+              },
+            })
+            .then(({ data, error }) => {
+              if (error) {
+                console.error(
+                  `AI title generation failed for sync job ${jobId}:`,
+                  error,
+                );
+              } else {
+                console.log(
+                  `AI title generation completed for ${synced.length} meetings:`,
+                  data,
+                );
+              }
+            })
+            .catch((err) => {
+              console.error(
+                `AI title invocation failed for sync job ${jobId}:`,
+                err,
+              );
+            });
 
           // Fire-and-forget: invoke auto-tag-calls for the synced recordings
-          console.log(`Triggering auto-tagging for ${synced.length} synced meetings...`);
-          supabase.functions.invoke('auto-tag-calls', {
-            body: {
-              recordingIds: synced,
-              respectPreference: true,
-            },
-            headers: {
-              Authorization: `Bearer ${jwt}`,
-            },
-          }).then(({ data, error }) => {
-            if (error) {
-              console.error(`Auto-tagging failed for sync job ${jobId}:`, error);
-            } else {
-              console.log(`Auto-tagging completed for ${synced.length} meetings:`, data);
-            }
-          }).catch((err) => {
-            console.error(`Auto-tag invocation failed for sync job ${jobId}:`, err);
-          });
+          console.log(
+            `Triggering auto-tagging for ${synced.length} synced meetings...`,
+          );
+          supabase.functions
+            .invoke("auto-tag-calls", {
+              body: {
+                recordingIds: synced,
+                respectPreference: true,
+              },
+              headers: {
+                Authorization: `Bearer ${jwt}`,
+              },
+            })
+            .then(({ data, error }) => {
+              if (error) {
+                console.error(
+                  `Auto-tagging failed for sync job ${jobId}:`,
+                  error,
+                );
+              } else {
+                console.log(
+                  `Auto-tagging completed for ${synced.length} meetings:`,
+                  data,
+                );
+              }
+            })
+            .catch((err) => {
+              console.error(
+                `Auto-tag invocation failed for sync job ${jobId}:`,
+                err,
+              );
+            });
         }
       } catch (error) {
         console.error(`Sync job ${jobId} failed:`, error);
         await supabase
-          .from('sync_jobs')
+          .from("sync_jobs")
           .update({
-            status: 'failed',
-            error_message: error instanceof Error ? error.message : 'Unknown error',
+            status: "failed",
+            error_message:
+              error instanceof Error ? error.message : "Unknown error",
             completed_at: new Date().toISOString(),
           })
-          .eq('id', jobId);
+          .eq("id", jobId);
       }
     };
 
@@ -734,14 +887,15 @@ Deno.serve(async (req) => {
         jobId: jobId,
         message: `Sync job started for ${targetRecordingIds.length} meetings`,
       }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
   } catch (error) {
-    console.error('Error syncing meetings:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(
-      JSON.stringify({ error: errorMessage }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    console.error("Error syncing meetings:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return new Response(JSON.stringify({ error: errorMessage }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 });


### PR DESCRIPTION
Sweep PR for issue #294. Follow-up to PR #293 which fixed only `fetch-meetings`.

## What's fixed

Three more Fathom edge functions had the same encryption-at-rest bug class:

| Function | Bug |
|---|---|
| `fathom-reconcile` | Called non-existent `decrypt_oauth_tokens` RPC + raw-select fallback sent ciphertext |
| `fathom-refresh` | Same — non-existent RPC + raw-select fallback |
| `sync-meetings` | 2 raw-select sites (single sourceId + first-active fallback) |

Each was sending PGP-armored ciphertext as Bearer to Fathom → 401.

## Fix

All three routed through `getDecryptedOAuthTokens` helper which:
- Uses the correct RPC name (`get_decrypted_oauth_tokens`)
- Has plaintext fallback baked in (`decrypt_token` EXCEPTION clause)
- Keeps `fathom_api_key` as a separate small SELECT (unchanged column)

## Production state

- `tsc --noEmit` clean, `npm run build` 7.74s clean
- **All 3 functions deployed to prod** via `supabase functions deploy --use-api`
- Versions: sync-meetings 163, fathom-reconcile 29, fathom-refresh 28

## Still deferred (in #294)

- `fetch-single-meeting` — reads from `user_settings` (different table, separate encryption path)
- `create-fathom-webhook` — same (`user_settings` only)
- `fathom-oauth-refresh` — single `oauth_refresh_token` read, lower priority
- All `zoom-*` functions — no user reports yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Don