### PR TITLE
fix(payment): email-guard + idempotency for polar-create-customer

### DIFF
--- a/supabase/functions/polar-create-customer/__tests__/polar-create-customer.regression.test.ts
+++ b/supabase/functions/polar-create-customer/__tests__/polar-create-customer.regression.test.ts
@@ -35,21 +35,59 @@ describe("polar-create-customer regression", () => {
     const DISPLAY_NAME_RE =
       /const\s+displayName\s*=\s*[\s\S]*?profile\?\.display_name\s*\|\|\s*user\.user_metadata\?\.display_name\s*;/;
     expect(source).toMatch(DISPLAY_NAME_RE);
-    // Pin the basic email-from-user shape without locking in the unsafe `!`
-    // form. Allows future safety improvements (`user.email?`, `user.email ?? fallback`)
-    // to preserve the contract without breaking this test.
+    // Pin the basic email-from-user shape (issue #301 removed the unsafe `!`).
     expect(source).toMatch(/email:\s*user\.email[!?]?(\s*\?\?|,)/);
 
     const authIdx = source.indexOf("const { userId, user } = authResult;");
     const nameMatch = source.match(DISPLAY_NAME_RE);
     const nameIdx = nameMatch ? source.indexOf(nameMatch[0]) : -1;
-    const createIdx = source.indexOf(
-      "const customer = await polar.customers.create({",
-    );
+    const createIdx = source.indexOf("await polar.customers.create({");
 
     expect(authIdx).toBeGreaterThan(0);
     expect(nameIdx).toBeGreaterThan(authIdx);
     expect(createIdx).toBeGreaterThan(nameIdx);
+  });
+
+  it("guards against missing user.email with a 400 before calling Polar (issue #301)", () => {
+    const source = readSource(FUNCTION_SOURCE_PATH);
+
+    // The guard must use a truthy check on user.email and return 400.
+    expect(source).toMatch(/if\s*\(\s*!user\.email\s*\)/);
+    expect(source).toContain("Email required for Polar customer creation");
+
+    const guardMatch = source.match(/if\s*\(\s*!user\.email\s*\)/);
+    const guardIdx = guardMatch ? source.indexOf(guardMatch[0]) : -1;
+    const createIdx = source.indexOf("await polar.customers.create({");
+
+    expect(guardIdx).toBeGreaterThan(0);
+    expect(createIdx).toBeGreaterThan(guardIdx);
+
+    // The unsafe non-null assertion form must not return.
+    expect(source).not.toContain("email: user.email!");
+  });
+
+  it("looks up an existing Polar customer by externalId before creating (issue #302)", () => {
+    const source = readSource(FUNCTION_SOURCE_PATH);
+
+    // The lookup must call getStateExternal with externalId: userId, inside
+    // a try block so a miss falls through to create() without bubbling.
+    const lookupIdx = source.indexOf(
+      "await polar.customers.getStateExternal({",
+    );
+    const createIdx = source.indexOf("await polar.customers.create({");
+
+    expect(lookupIdx).toBeGreaterThan(0);
+    expect(createIdx).toBeGreaterThan(lookupIdx);
+    expect(source).toMatch(/externalId:\s*userId/);
+
+    // The create call must be gated behind a check that no existing customer
+    // was found, otherwise the idempotency lookup achieves nothing.
+    expect(source).toMatch(/if\s*\(\s*!polarCustomerId\s*\)/);
+
+    // The response customerId must come from the resolved polarCustomerId
+    // (works for both the reuse and create branches), not a stale
+    // `customer.id` only set on the create branch.
+    expect(source).toMatch(/customerId:\s*polarCustomerId/);
   });
 
   it("does not pass organizationId when using the production Polar org token", () => {

--- a/supabase/functions/polar-create-customer/index.ts
+++ b/supabase/functions/polar-create-customer/index.ts
@@ -42,6 +42,22 @@ Deno.serve(async (req) => {
     if (authResult instanceof Response) return authResult;
     const { userId, user } = authResult;
 
+    // Email guard (issue #301): Supabase Auth permits users without an email
+    // (phone-only signups, OAuth without email scope). Polar requires email
+    // on customer creation, so refuse here with a clear 400 instead of
+    // letting `user.email!` send `undefined` to Polar and throw.
+    if (!user.email) {
+      return new Response(
+        JSON.stringify({
+          error: "Email required for Polar customer creation",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
     // Check if user already has a Polar customer ID
     const { data: profile, error: profileError } = await supabase
       .from("user_profiles")
@@ -83,22 +99,48 @@ Deno.serve(async (req) => {
       profile?.display_name || user.user_metadata?.display_name;
     const customerName = displayName || user.email?.split("@")[0] || "User";
 
-    // Create Polar customer
-    // Organization tokens are already scoped to one organization, so passing
-    // organizationId here triggers Polar's validation error.
-    const customer = await polar.customers.create({
-      email: user.email!,
-      name: customerName,
-      externalId: userId, // Links back to our user
-    });
+    // Idempotency check (issue #302): a concurrent retry (double-click or
+    // client-side retry over a slow first request) can race past the
+    // `polar_customer_id IS NULL` check above and create a duplicate Polar
+    // customer for the same externalId. Look up the existing customer by
+    // externalId before creating; reuse if found.
+    let polarCustomerId: string | null = null;
+    let created = false;
+    try {
+      const existingState = await polar.customers.getStateExternal({
+        externalId: userId,
+      });
+      polarCustomerId = existingState.id;
+      console.log(
+        `Idempotency: reusing existing Polar customer ${polarCustomerId} for user ${userId}`,
+      );
+    } catch (_lookupError) {
+      // Not found is the common case for a true first-time customer.
+      // `getStateExternal` throws for both "not found" and transport errors;
+      // proceed to create either way and let create() surface real failures.
+    }
 
-    console.log(`Created Polar customer ${customer.id} for user ${userId}`);
+    if (!polarCustomerId) {
+      // Create Polar customer
+      // Organization tokens are already scoped to one organization, so passing
+      // organizationId here triggers Polar's validation error.
+      const customer = await polar.customers.create({
+        email: user.email,
+        name: customerName,
+        externalId: userId, // Links back to our user
+      });
+      polarCustomerId = customer.id;
+      created = true;
+      console.log(
+        `Created Polar customer ${polarCustomerId} for user ${userId}`,
+      );
+    }
 
     // Store customer IDs in profile
     const { error: updateError } = await supabase
       .from("user_profiles")
       .update({
-        polar_customer_id: customer.id,
+        polar_customer_id: polarCustomerId,
         polar_external_id: userId,
       })
       .eq("user_id", userId);
@@ -106,11 +148,11 @@ Deno.serve(async (req) => {
     if (updateError) {
       // Structured log for ops visibility — this branch returns success but
       // the local profile row was not updated. The polar-webhook
-      // customer.created handler will reconcile; until it does, a client
-      // retry inside the webhook latency window can create a duplicate
-      // Polar customer with the same externalId. Watch this severity tag.
+      // customer.created handler will reconcile. The externalId-lookup above
+      // (issue #302) prevents a concurrent retry from creating a duplicate
+      // Polar customer during the reconcile window.
       console.error("Error storing customer ID:", updateError, {
-        polarCustomerId: customer.id,
+        polarCustomerId,
         userId,
         severity: "reconcile_required",
       });
@@ -121,8 +163,8 @@ Deno.serve(async (req) => {
     return new Response(
       JSON.stringify({
         success: true,
-        customerId: customer.id,
-        created: true,
+        customerId: polarCustomerId,
+        created,
       }),
       { headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );


### PR DESCRIPTION
## Summary

Two production hardening fixes for `supabase/functions/polar-create-customer/index.ts`, both deferred from PR #288's review and now backlogged as issues:

**Closes #301 — Email guard**
Replaces `user.email!` with an explicit `if (!user.email)` guard that returns 400 with `{ error: "Email required for Polar customer creation" }`. Supabase Auth permits users without an email (phone-only signups, OAuth without email scope); the old non-null assertion would send `undefined` to Polar and throw.

**Closes #302 — Idempotency lookup**
Adds a `polar.customers.getStateExternal({ externalId: userId })` lookup before `polar.customers.create`. Concurrent requests for the same user (double-click, client-side retry over a slow first request) could previously race past the local `polar_customer_id IS NULL` check and create two Polar customers for the same `externalId` — one of which would become orphaned (only one DB row). The lookup is wrapped in try/catch so a miss (the common first-time case) falls through to `create()` as before. On hit, the existing customer is reused and the response reports `created: false`.

Same SDK method (`customers.getStateExternal`) is already used in `polar-customer-state/index.ts`, so the lookup pattern is consistent with existing code.

## Changes

| File | Change |
|------|--------|
| `supabase/functions/polar-create-customer/index.ts` | M1 guard + M2 lookup; `customer.id`/`true` references rewritten to use the resolved `polarCustomerId` + `created` vars (works for both reuse and create branches). Observability log on `updateError` updated to note the race is now closed by the lookup. |
| `supabase/functions/polar-create-customer/__tests__/polar-create-customer.regression.test.ts` | Two new contract tests: one asserting the email guard precedes any `polar.customers.create` call and that `user.email!` is not present; one asserting `getStateExternal` is called before `create`, the create is gated on `!polarCustomerId`, and the response uses `polarCustomerId` (not a stale `customer.id`). |

## Validation

- ✅ Type-check (`tsc --noEmit`) — clean
- ✅ Regression suite — 7/7 (was 5; added 2 new contract tests)
- ✅ Full vitest unit suite — 938/938 (excluded the 3 DB-integration tests that fail on `main` for unrelated reasons: `setDefaultWorkspace.integration.test.ts`, `auto-tag-calls.integration.test.ts`, `rpc-type-smoke.test.ts` — separate concern, not in this PR's scope)

## Risk

- M1: zero functional change for existing callers (all current signup paths collect email). Forward-looking hardening.
- M2: adds one Polar API call per first-time customer creation. Industry-standard idempotency pattern.