### PR TITLE
feat(connectors): Phase 8d — Fireflies adapter searchAvailable + importSelected (#295)

### DIFF
--- a/src/components/connectors/registry/adapters/fireflies.ts
+++ b/src/components/connectors/registry/adapters/fireflies.ts
@@ -10,6 +10,17 @@ import { RiFireLine } from "@remixicon/react";
 import { supabase } from "@/integrations/supabase/client";
 import type { ConnectorAdapter } from "../types";
 
+interface FirefliesAvailableMeeting {
+  recording_id: string;
+  title: string;
+  recording_start_time: string | null;
+  duration: number | null;
+  calendar_invitees?: Array<{ name: string | null; email: string | null }>;
+  synced: boolean;
+  share_url?: string | null;
+  source_url?: string | null;
+}
+
 export const firefliesAdapter: ConnectorAdapter = {
   metadata: {
     sourceApp: "fireflies",
@@ -46,5 +57,73 @@ export const firefliesAdapter: ConnectorAdapter = {
       .eq("id", sourceId)
       .eq("source_app", "fireflies");
     if (error) throw new Error(error.message);
+  },
+
+  async searchAvailable({ sourceId, dateStart, dateEnd, limit, cursor }) {
+    const dateStartIso = dateStart.toISOString();
+    const dateEndIso = dateEnd.toISOString();
+    const { data, error } = await supabase.functions.invoke(
+      "fireflies-fetch-meetings",
+      {
+        body: {
+          sourceId,
+          dateStart: dateStartIso,
+          dateEnd: dateEndIso,
+          createdAfter: dateStartIso,
+          createdBefore: dateEndIso,
+          limit: limit ?? 50,
+          skip: cursor ? Number(cursor) : 0,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+
+    const response = data as {
+      meetings?: FirefliesAvailableMeeting[];
+      nextCursor?: string | null;
+      nextSkip?: number | null;
+    } | null;
+
+    return {
+      items: (response?.meetings ?? []).map((meeting) => ({
+        externalId: meeting.recording_id,
+        title: meeting.title,
+        startTime: meeting.recording_start_time,
+        durationSeconds: meeting.duration,
+        participants: meeting.calendar_invitees,
+        alreadyImported: meeting.synced,
+        externalUrl: meeting.share_url ?? meeting.source_url,
+      })),
+      nextCursor:
+        response?.nextCursor ?? response?.nextSkip?.toString() ?? null,
+    };
+  },
+
+  async importSelected({ sourceId, externalIds, workspaceId }) {
+    const { data, error } = await supabase.functions.invoke(
+      "fireflies-sync-meetings",
+      {
+        body: {
+          sourceId,
+          workspaceId,
+          workspace_id: workspaceId,
+          recordingIds: externalIds,
+          transcriptIds: externalIds,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+
+    return {
+      jobId: (data as { jobId: string }).jobId,
+      total: externalIds.length,
+      message: `Importing ${externalIds.length} Fireflies call(s)…`,
+    };
   },
 };


### PR DESCRIPTION
## Summary

Adds the Phase 8 Fireflies adapter capabilities so `ConnectorImportWizard` can discover and import selected Fireflies calls through the connector registry.

## Changes

- Implements `firefliesAdapter.searchAvailable()` using `fireflies-fetch-meetings` and normalizes Fireflies meeting rows into `AvailableCall`.
- Implements `firefliesAdapter.importSelected()` using `fireflies-sync-meetings` and returns an `ImportJob` for wizard polling.
- Keeps compatibility with the current Fireflies edge function request keys while also sending the Phase 8 unified payload names.

## Validation

- `npx tsc --noEmit`
- `git diff --check`