### PR TITLE
fix(fathom): replace import load more with infinite scroll

### DIFF
--- a/src/components/import/FathomImportDetail.tsx
+++ b/src/components/import/FathomImportDetail.tsx
@@ -149,7 +149,7 @@ export function FathomImportDetail({
   const [hasFetched, setHasFetched] = useState(false);
   // Cursor for the next Fathom page; null = no more pages.
   const [nextCursor, setNextCursor] = useState<string | null>(null);
-  // How many pages already pulled (used in the Load More button label).
+  // How many pages already pulled (cached with the loaded result set).
   const [pagesLoaded, setPagesLoaded] = useState(0);
 
   // Selection state — Fathom recording_id is numeric
@@ -163,6 +163,8 @@ export function FathomImportDetail({
   const [syncing, setSyncing] = useState(false);
   const [syncProgress, setSyncProgress] = useState({ current: 0, total: 0 });
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Sentinel observed for infinite scroll pagination.
+  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
 
   // ── Connection Settings state ─────────────────────────────────────────────
   const [connectionOpen, setConnectionOpen] = useState(false);
@@ -395,8 +397,8 @@ export function FathomImportDetail({
     }
 
     try {
-      // Fetch only the FIRST page so the user can start clicking right away.
-      // The Load More button pulls additional pages on demand.
+      // Fetch only the FIRST page so results render quickly.
+      // Infinite scroll pulls additional pages on demand.
       const { meetings: firstPage, nextCursor: cursor } = await fetchPage(null);
       setMeetings(firstPage);
       setNextCursor(cursor);
@@ -418,7 +420,7 @@ export function FathomImportDetail({
   }, [dateRange, activeSourceId, fetchPage]);
 
   const handleLoadMore = useCallback(async () => {
-    if (!nextCursor || loadingMore || !dateRange.from) return;
+    if (!nextCursor || loadingMore || syncing || !dateRange.from) return;
     setLoadingMore(true);
     try {
       const { meetings: nextPage, nextCursor: newCursor } = await fetchPage(nextCursor);
@@ -443,7 +445,22 @@ export function FathomImportDetail({
     } finally {
       setLoadingMore(false);
     }
-  }, [nextCursor, loadingMore, dateRange, activeSourceId, fetchPage, meetings, pagesLoaded]);
+  }, [nextCursor, loadingMore, syncing, dateRange, activeSourceId, fetchPage, meetings, pagesLoaded]);
+
+  useEffect(() => {
+    const sentinel = loadMoreSentinelRef.current;
+    if (!sentinel || !nextCursor || loadingMore || syncing || !dateRange.from) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) void handleLoadMore();
+      },
+      { rootMargin: '200px 0px', threshold: 0 }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [nextCursor, loadingMore, syncing, dateRange.from, handleLoadMore]);
 
   // ── Selection helpers ─────────────────────────────────────────────────────
 
@@ -1012,20 +1029,19 @@ export function FathomImportDetail({
                   );
                 })}
 
-                {/* Load more — only when Fathom has additional pages. */}
+                {/* Infinite scroll sentinel — loads the next Fathom page when visible. */}
                 {nextCursor && (
-                  <div className="pt-3 flex justify-center">
-                    <Button
-                      variant="hollow"
-                      size="sm"
-                      onClick={handleLoadMore}
-                      disabled={loadingMore || syncing}
-                      className="gap-2"
-                    >
-                      {loadingMore
-                        ? 'Loading…'
-                        : `Load more (${pagesLoaded * 10} loaded)`}
-                    </Button>
+                  <div
+                    ref={loadMoreSentinelRef}
+                    className="pt-3 min-h-8 flex justify-center"
+                    aria-live="polite"
+                  >
+                    {loadingMore && (
+                      <div className="inline-flex items-center gap-2 text-[11px] text-muted-foreground">
+                        <RiLoader4Line className="h-3.5 w-3.5 animate-spin" />
+                        Loading more…
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/import/FathomImportDetail.tsx
+++ b/src/components/import/FathomImportDetail.tsx
@@ -26,6 +26,7 @@ import {
   RiUserLine,
   RiRefreshLine,
   RiLoader4Line,
+  RiErrorWarningLine,
 } from '@remixicon/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -146,6 +147,7 @@ export function FathomImportDetail({
   const [meetings, setMeetings] = useState<FathomMeeting[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
   const [hasFetched, setHasFetched] = useState(false);
   // Cursor for the next Fathom page; null = no more pages.
   const [nextCursor, setNextCursor] = useState<string | null>(null);
@@ -165,6 +167,7 @@ export function FathomImportDetail({
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Sentinel observed for infinite scroll pagination.
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
+  const loadingMoreRef = useRef(false);
 
   // ── Connection Settings state ─────────────────────────────────────────────
   const [connectionOpen, setConnectionOpen] = useState(false);
@@ -291,8 +294,10 @@ export function FathomImportDetail({
   useEffect(() => {
     setMeetings([]);
     setHasFetched(false);
+    setLoadMoreError(null);
     setSelected(new Set());
     setSyncing(false);
+    loadingMoreRef.current = false;
     if (pollRef.current) {
       clearInterval(pollRef.current);
       pollRef.current = null;
@@ -375,7 +380,9 @@ export function FathomImportDetail({
     setMeetings([]);
     setSelected(new Set());
     setNextCursor(null);
+    setLoadMoreError(null);
     setPagesLoaded(0);
+    loadingMoreRef.current = false;
 
     const createdAfter = toUTCStart(dateRange.from);
     const createdBefore = dateRange.to ? toUTCEnd(dateRange.to) : toUTCEnd(dateRange.from);
@@ -419,9 +426,17 @@ export function FathomImportDetail({
     }
   }, [dateRange, activeSourceId, fetchPage]);
 
-  const handleLoadMore = useCallback(async () => {
-    if (!nextCursor || loadingMore || syncing || !dateRange.from) return;
+  const handleLoadMore = useCallback(async (options?: { force?: boolean }) => {
+    if (
+      !nextCursor ||
+      loadingMoreRef.current ||
+      syncing ||
+      (!options?.force && loadMoreError) ||
+      !dateRange.from
+    ) return;
+    loadingMoreRef.current = true;
     setLoadingMore(true);
+    setLoadMoreError(null);
     try {
       const { meetings: nextPage, nextCursor: newCursor } = await fetchPage(nextCursor);
       const merged = [...meetings, ...nextPage];
@@ -440,16 +455,23 @@ export function FathomImportDetail({
         fetchedAt: Date.now(),
       });
     } catch (err) {
+      logger.error('Failed to load additional Fathom meetings', {
+        error: err,
+        sourceId: activeSourceId,
+        cursor: nextCursor,
+      });
       const msg = err instanceof Error ? err.message : 'Failed to load more';
+      setLoadMoreError(msg);
       toast.error(msg);
     } finally {
+      loadingMoreRef.current = false;
       setLoadingMore(false);
     }
-  }, [nextCursor, loadingMore, syncing, dateRange, activeSourceId, fetchPage, meetings, pagesLoaded]);
+  }, [nextCursor, syncing, loadMoreError, dateRange, activeSourceId, fetchPage, meetings, pagesLoaded]);
 
   useEffect(() => {
     const sentinel = loadMoreSentinelRef.current;
-    if (!sentinel || !nextCursor || loadingMore || syncing || !dateRange.from) return;
+    if (!sentinel || !nextCursor || loadingMore || syncing || loadMoreError || !dateRange.from) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -460,7 +482,7 @@ export function FathomImportDetail({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [nextCursor, loadingMore, syncing, dateRange.from, handleLoadMore]);
+  }, [nextCursor, loadingMore, syncing, loadMoreError, dateRange.from, handleLoadMore]);
 
   // ── Selection helpers ─────────────────────────────────────────────────────
 
@@ -1029,19 +1051,33 @@ export function FathomImportDetail({
                   );
                 })}
 
-                {/* Infinite scroll sentinel — loads the next Fathom page when visible. */}
+                {/* Infinite scroll sentinel — prefetches the next Fathom page near the viewport. */}
                 {nextCursor && (
                   <div
                     ref={loadMoreSentinelRef}
                     className="pt-3 min-h-8 flex justify-center"
                     aria-live="polite"
                   >
-                    {loadingMore && (
+                    {loadMoreError ? (
+                      <div className="inline-flex items-center gap-2 text-[11px] text-muted-foreground">
+                        <RiErrorWarningLine className="h-3.5 w-3.5 text-destructive" />
+                        <span>Couldn't load more calls.</span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          onClick={() => void handleLoadMore({ force: true })}
+                        >
+                          Retry
+                        </Button>
+                      </div>
+                    ) : loadingMore ? (
                       <div className="inline-flex items-center gap-2 text-[11px] text-muted-foreground">
                         <RiLoader4Line className="h-3.5 w-3.5 animate-spin" />
                         Loading more…
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 )}
               </div>

--- a/src/components/import/__tests__/FathomImportDetail.infinite-scroll.test.tsx
+++ b/src/components/import/__tests__/FathomImportDetail.infinite-scroll.test.tsx
@@ -1,0 +1,210 @@
+import * as React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ImportSource } from '@/services/import-sources.service';
+
+const mockInvoke = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockFrom = vi.fn(() => ({
+  select: vi.fn(() => ({
+    eq: vi.fn(() => ({
+      maybeSingle: mockMaybeSingle,
+    })),
+  })),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    functions: {
+      invoke: (...args: unknown[]) => mockInvoke(...args),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth-utils', () => ({
+  getSafeUser: vi.fn(async () => ({ user: { id: 'user-1' }, error: null })),
+}));
+
+vi.mock('@/hooks/useUserRole', () => ({
+  useUserRole: () => ({ isPro: false, isTeam: false, isAdmin: false }),
+}));
+
+vi.mock('@/hooks/useFathomRefresh', () => ({
+  useFathomRefresh: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock('@/components/ui/date-range-picker', () => ({
+  DateRangePicker: ({ onDateRangeChange, disabled }: {
+    onDateRangeChange: (range: { from: Date; to: Date }) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onDateRangeChange({
+        from: new Date('2026-05-01T00:00:00Z'),
+        to: new Date('2026-05-02T00:00:00Z'),
+      })}
+    >
+      Set date range
+    </button>
+  ),
+}));
+
+vi.mock('@/components/workspace/WorkspaceSelector', () => ({
+  WorkspaceSelector: () => <div data-testid="workspace-selector" />,
+}));
+vi.mock('@/components/dialogs/CreateWorkspaceDialog', () => ({
+  CreateWorkspaceDialog: () => null,
+}));
+
+vi.mock('@/components/dialogs/RefreshFromFathomDialog', () => ({
+  RefreshFromFathomDialog: () => null,
+}));
+
+type ObserverCallback = IntersectionObserverCallback;
+let intersectionCallback: ObserverCallback | null = null;
+const observeMock = vi.fn();
+const disconnectMock = vi.fn();
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+
+  constructor(callback: ObserverCallback) {
+    intersectionCallback = callback;
+  }
+
+  observe = observeMock;
+  unobserve = vi.fn();
+  disconnect = disconnectMock;
+  takeRecords = vi.fn(() => []);
+}
+
+const source: ImportSource = {
+  id: 'source-1',
+  user_id: 'user-1',
+  source_app: 'fathom',
+  is_active: true,
+  account_email: 'fathom@example.com',
+  last_sync_at: null,
+  error_message: null,
+  connection_metadata: null,
+  webhook_path_token: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+};
+
+function renderComponent() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FathomImportDetail
+        fathomSources={[source]}
+        onConnect={vi.fn()}
+        onDisconnect={vi.fn()}
+      />
+    </QueryClientProvider>
+  );
+}
+
+import { FathomImportDetail } from '../FathomImportDetail';
+
+describe('FathomImportDetail infinite scroll pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    intersectionCallback = null;
+    mockMaybeSingle.mockResolvedValue({ data: { oauth_token_expires: '2026-06-01T00:00:00Z' }, error: null });
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads the next Fathom page when the bottom sentinel enters view', async () => {
+    mockInvoke
+      .mockResolvedValueOnce({
+        data: {
+          meetings: [
+            {
+              recording_id: 1,
+              title: 'First page call',
+              created_at: '2026-05-01T12:00:00Z',
+              recording_start_time: '2026-05-01T12:00:00Z',
+              recording_end_time: '2026-05-01T12:30:00Z',
+              synced: false,
+              calendar_invitees: [],
+            },
+          ],
+          next_cursor: 'cursor-2',
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          meetings: [
+            {
+              recording_id: 2,
+              title: 'Second page call',
+              created_at: '2026-05-02T12:00:00Z',
+              recording_start_time: '2026-05-02T12:00:00Z',
+              recording_end_time: '2026-05-02T12:45:00Z',
+              synced: false,
+              calendar_invitees: [],
+            },
+          ],
+          next_cursor: null,
+        },
+        error: null,
+      });
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /set date range/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /search fathom/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /search fathom/i }));
+
+    expect(await screen.findByText('First page call')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(observeMock).toHaveBeenCalled();
+      expect(intersectionCallback).not.toBeNull();
+    });
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(
+      2,
+      'fetch-meetings',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          sourceId: 'source-1',
+          cursor: 'cursor-2',
+          pageMode: true,
+        }),
+      })
+    );
+    expect(await screen.findByText('Second page call')).toBeInTheDocument();
+  });
+});

--- a/src/components/import/__tests__/FathomImportDetail.infinite-scroll.test.tsx
+++ b/src/components/import/__tests__/FathomImportDetail.infinite-scroll.test.tsx
@@ -35,6 +35,12 @@ vi.mock('@/hooks/useFathomRefresh', () => ({
   useFathomRefresh: () => ({ isPending: false, mutate: vi.fn() }),
 }));
 
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
 vi.mock('@/components/ui/date-range-picker', () => ({
   DateRangePicker: ({ onDateRangeChange, disabled }: {
     onDateRangeChange: (range: { from: Date; to: Date }) => void;
@@ -54,7 +60,18 @@ vi.mock('@/components/ui/date-range-picker', () => ({
 }));
 
 vi.mock('@/components/workspace/WorkspaceSelector', () => ({
-  WorkspaceSelector: () => <div data-testid="workspace-selector" />,
+  WorkspaceSelector: ({ onWorkspaceChange, disabled }: {
+    onWorkspaceChange: (workspaceId: string) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onWorkspaceChange('workspace-1')}
+    >
+      Select workspace
+    </button>
+  ),
 }));
 vi.mock('@/components/dialogs/CreateWorkspaceDialog', () => ({
   CreateWorkspaceDialog: () => null,
@@ -80,7 +97,10 @@ class MockIntersectionObserver implements IntersectionObserver {
 
   observe = observeMock;
   unobserve = vi.fn();
-  disconnect = disconnectMock;
+  disconnect = () => {
+    disconnectMock();
+    intersectionCallback = null;
+  };
   takeRecords = vi.fn(() => []);
 }
 
@@ -98,7 +118,19 @@ const source: ImportSource = {
   updated_at: '2026-05-01T00:00:00Z',
 };
 
-function renderComponent() {
+function meeting(recordingId: number, title: string) {
+  return {
+    recording_id: recordingId,
+    title,
+    created_at: '2026-05-01T12:00:00Z',
+    recording_start_time: '2026-05-01T12:00:00Z',
+    recording_end_time: '2026-05-01T12:30:00Z',
+    synced: false,
+    calendar_invitees: [],
+  };
+}
+
+function renderComponent(sourceId = source.id) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -106,7 +138,7 @@ function renderComponent() {
   return render(
     <QueryClientProvider client={queryClient}>
       <FathomImportDetail
-        fathomSources={[source]}
+        fathomSources={[{ ...source, id: sourceId }]}
         onConnect={vi.fn()}
         onDisconnect={vi.fn()}
       />
@@ -132,34 +164,14 @@ describe('FathomImportDetail infinite scroll pagination', () => {
     mockInvoke
       .mockResolvedValueOnce({
         data: {
-          meetings: [
-            {
-              recording_id: 1,
-              title: 'First page call',
-              created_at: '2026-05-01T12:00:00Z',
-              recording_start_time: '2026-05-01T12:00:00Z',
-              recording_end_time: '2026-05-01T12:30:00Z',
-              synced: false,
-              calendar_invitees: [],
-            },
-          ],
+          meetings: [meeting(1, 'First page call')],
           next_cursor: 'cursor-2',
         },
         error: null,
       })
       .mockResolvedValueOnce({
         data: {
-          meetings: [
-            {
-              recording_id: 2,
-              title: 'Second page call',
-              created_at: '2026-05-02T12:00:00Z',
-              recording_start_time: '2026-05-02T12:00:00Z',
-              recording_end_time: '2026-05-02T12:45:00Z',
-              synced: false,
-              calendar_invitees: [],
-            },
-          ],
+          meetings: [meeting(2, 'Second page call')],
           next_cursor: null,
         },
         error: null,
@@ -206,5 +218,113 @@ describe('FathomImportDetail infinite scroll pagination', () => {
       })
     );
     expect(await screen.findByText('Second page call')).toBeInTheDocument();
+  });
+
+  it('does not request the same next cursor twice while loading more is pending', async () => {
+    let resolveSecondPage!: (value: {
+      data: { meetings: ReturnType<typeof meeting>[]; next_cursor: null };
+      error: null;
+    }) => void;
+    const secondPage = new Promise<{
+      data: { meetings: ReturnType<typeof meeting>[]; next_cursor: null };
+      error: null;
+    }>((resolve) => {
+      resolveSecondPage = resolve;
+    });
+
+    mockInvoke
+      .mockResolvedValueOnce({
+        data: {
+          meetings: [meeting(10, 'Deferred first page call')],
+          next_cursor: 'cursor-2',
+        },
+        error: null,
+      })
+      .mockReturnValueOnce(secondPage);
+
+    renderComponent('source-duplicate-guard');
+
+    fireEvent.click(screen.getByRole('button', { name: /set date range/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /search fathom/i }));
+
+    expect(await screen.findByText('Deferred first page call')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(observeMock).toHaveBeenCalled();
+      expect(intersectionCallback).not.toBeNull();
+    });
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      );
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      );
+    });
+
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+    expect(mockInvoke).toHaveBeenNthCalledWith(
+      2,
+      'fetch-meetings',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          sourceId: 'source-duplicate-guard',
+          cursor: 'cursor-2',
+          pageMode: true,
+        }),
+      })
+    );
+
+    await act(async () => {
+      resolveSecondPage({
+        data: {
+          meetings: [meeting(11, 'Deferred second page call')],
+          next_cursor: null,
+        },
+        error: null,
+      });
+      await secondPage;
+    });
+
+    expect(await screen.findByText('Deferred second page call')).toBeInTheDocument();
+  });
+
+  it('does not keep observing for more pages while an import is syncing', async () => {
+    mockInvoke
+      .mockResolvedValueOnce({
+        data: {
+          meetings: [meeting(20, 'Unsynced call')],
+          next_cursor: 'cursor-2',
+        },
+        error: null,
+      })
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    renderComponent('source-sync-guard');
+
+    fireEvent.click(screen.getByRole('button', { name: /select workspace/i }));
+    fireEvent.click(screen.getByRole('button', { name: /set date range/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /search fathom/i }));
+    fireEvent.click(await screen.findByLabelText('Select Unsynced call'));
+    fireEvent.click(screen.getByRole('button', { name: /import 1 call/i }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+      expect(disconnectMock).toHaveBeenCalled();
+      expect(intersectionCallback).toBeNull();
+    });
+
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      'fetch-meetings',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          sourceId: 'source-sync-guard',
+          cursor: 'cursor-2',
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION
Closes #300.

## Summary
- Replace the Fathom Import manual Load more button with an IntersectionObserver sentinel.
- Keep cursor pagination, search cache extension, and the first-page fast render behavior.
- Add regression coverage for sentinel-triggered next-page loading.

## Verification
- npm run test -- src/components/import/__tests__/FathomImportDetail.infinite-scroll.test.tsx
- npm run type-check
- npx eslint src/components/import/FathomImportDetail.tsx src/components/import/__tests__/FathomImportDetail.infinite-scroll.test.tsx