### PR TITLE
fix(security): decrypt user_settings tokens at read time across 7 functions (closes #294)

### DIFF
--- a/supabase/functions/_shared/user-settings-encrypt.ts
+++ b/supabase/functions/_shared/user-settings-encrypt.ts
@@ -1,0 +1,126 @@
+/**
+ * User Settings Token Encryption Helpers
+ *
+ * Provides a consistent interface for reading OAuth tokens from user_settings that may be
+ * stored encrypted (via pgcrypto pgp_sym_encrypt) or as plaintext (pre-encryption migration).
+ *
+ * Read path: use these helpers.
+ * The encryption key is read from OAUTH_ENCRYPTION_KEY env var.
+ */
+
+/**
+ * Read and decrypt Fathom OAuth tokens for a user.
+ * Falls back to plaintext if OAUTH_ENCRYPTION_KEY is not set or
+ * the decrypt_token() SQL function falls back internally.
+ */
+export async function getDecryptedUserSettingsFathomTokens(
+  supabase: any,
+  userId: string,
+): Promise<{
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expires: number | null;
+}> {
+  const encryptionKey = Deno.env.get("OAUTH_ENCRYPTION_KEY");
+  const client = supabase as any;
+
+  const { data: settings, error: settingsError } = await client
+    .from('user_settings')
+    .select('oauth_access_token, oauth_refresh_token, oauth_token_expires')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (settingsError) {
+    throw settingsError;
+  }
+
+  if (!encryptionKey) {
+    return {
+      access_token: settings?.oauth_access_token ?? null,
+      refresh_token: settings?.oauth_refresh_token ?? null,
+      token_expires: settings?.oauth_token_expires ?? null,
+    };
+  }
+
+  return {
+    access_token: settings?.oauth_access_token
+      ? await decryptTokenIfEncrypted(client, settings.oauth_access_token, encryptionKey)
+      : null,
+    refresh_token: settings?.oauth_refresh_token
+      ? await decryptTokenIfEncrypted(client, settings.oauth_refresh_token, encryptionKey)
+      : null,
+    token_expires: settings?.oauth_token_expires ?? null,
+  };
+}
+
+/**
+ * Read and decrypt Zoom OAuth tokens for a user.
+ * Falls back to plaintext if OAUTH_ENCRYPTION_KEY is not set or
+ * the decrypt_token() SQL function falls back internally.
+ */
+export async function getDecryptedUserSettingsZoomTokens(
+  supabase: any,
+  userId: string,
+): Promise<{
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expires: number | null;
+}> {
+  const encryptionKey = Deno.env.get("OAUTH_ENCRYPTION_KEY");
+  const client = supabase as any;
+
+  const { data: settings, error: settingsError } = await client
+    .from('user_settings')
+    .select('zoom_oauth_access_token, zoom_oauth_refresh_token, zoom_oauth_token_expires')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (settingsError) {
+    throw settingsError;
+  }
+
+  if (!encryptionKey) {
+    return {
+      access_token: settings?.zoom_oauth_access_token ?? null,
+      refresh_token: settings?.zoom_oauth_refresh_token ?? null,
+      token_expires: settings?.zoom_oauth_token_expires ?? null,
+    };
+  }
+
+  return {
+    access_token: settings?.zoom_oauth_access_token
+      ? await decryptTokenIfEncrypted(client, settings.zoom_oauth_access_token, encryptionKey)
+      : null,
+    refresh_token: settings?.zoom_oauth_refresh_token
+      ? await decryptTokenIfEncrypted(client, settings.zoom_oauth_refresh_token, encryptionKey)
+      : null,
+    token_expires: settings?.zoom_oauth_token_expires ?? null,
+  };
+}
+
+async function decryptTokenIfEncrypted(
+  client: any,
+  ciphertext: string,
+  encryptionKey: string,
+): Promise<string> {
+  if (!ciphertext.startsWith('-----BEGIN PGP')) {
+    return ciphertext;
+  }
+
+  try {
+    const { data, error } = await client.rpc('decrypt_token', {
+      ciphertext,
+      encryption_key: encryptionKey,
+    });
+
+    if (error) {
+      console.warn('Decryption RPC failed, returning ciphertext as plaintext:', error.message);
+      return ciphertext;
+    }
+
+    return data as string;
+  } catch (err) {
+    console.error('Unexpected error during decryption:', err);
+    return ciphertext;
+  }
+}

--- a/supabase/functions/create-fathom-webhook/index.ts
+++ b/supabase/functions/create-fathom-webhook/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { authenticateRequest } from '../_shared/auth.ts';
+import { getDecryptedUserSettingsFathomTokens } from '../_shared/user-settings-encrypt.ts';
 Deno.serve(async (req)=>{
   const origin = req.headers.get('Origin');
   const corsHeaders = getCorsHeaders(origin);
@@ -19,9 +20,9 @@ Deno.serve(async (req)=>{
     const authResult = await authenticateRequest(req, supabase, corsHeaders);
     if (authResult instanceof Response) return authResult;
     const userId = authResult.userId;
-    // Get OAuth access token
-    const { data: settings } = await supabase.from('user_settings').select('oauth_access_token').eq('user_id', userId).maybeSingle();
-    if (!settings?.oauth_access_token) {
+    // Get decrypted OAuth token (falls back to plaintext if needed)
+    const oauthTokens = await getDecryptedUserSettingsFathomTokens(supabase, userId);
+    if (!oauthTokens.access_token) {
       return new Response(JSON.stringify({
         error: 'OAuth not connected. Please connect with OAuth first.'
       }), {
@@ -32,7 +33,7 @@ Deno.serve(async (req)=>{
         }
       });
     }
-    const accessToken = settings.oauth_access_token;
+    const accessToken = oauthTokens.access_token;
     const webhookUrl = `${supabaseUrl}/functions/v1/webhook`;
     // Create webhook in Fathom using OAuth
     const webhookResponse = await fetch('https://fathom.video/external/v1/webhooks', {

--- a/supabase/functions/fathom-oauth-refresh/index.ts
+++ b/supabase/functions/fathom-oauth-refresh/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { authenticateRequest } from '../_shared/auth.ts';
+import { getDecryptedUserSettingsFathomTokens } from '../_shared/user-settings-encrypt.ts';
 
 /**
  * Helper function to refresh OAuth tokens
@@ -105,21 +106,17 @@ Deno.serve(async (req) => {
     if (authResult instanceof Response) return authResult;
     const userId = authResult.userId;
 
-    // Get refresh token
-    const { data: settings } = await supabase
-      .from('user_settings')
-      .select('oauth_refresh_token')
-      .eq('user_id', userId)
-      .maybeSingle();
+    // Get decrypted OAuth tokens (falls back to plaintext if needed)
+    const oauthTokens = await getDecryptedUserSettingsFathomTokens(supabase, userId);
 
-    if (!settings?.oauth_refresh_token) {
+    if (!oauthTokens.refresh_token) {
       return new Response(
         JSON.stringify({ error: 'No refresh token found' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const newAccessToken = await refreshOAuthTokens(userId, settings.oauth_refresh_token);
+    const newAccessToken = await refreshOAuthTokens(userId, oauthTokens.refresh_token);
 
     return new Response(
       JSON.stringify({

--- a/supabase/functions/fetch-meetings/index.ts
+++ b/supabase/functions/fetch-meetings/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/cors.ts";
 import { authenticateRequest } from "../_shared/auth.ts";
 import { getDecryptedOAuthTokens } from "../_shared/oauth-encrypt.ts";
+import { getDecryptedUserSettingsFathomTokens } from "../_shared/user-settings-encrypt.ts";
 
 /**
  * RATE LIMITING CONFIGURATION
@@ -232,14 +233,22 @@ Deno.serve(async (req) => {
     if (!creds?.oauth_access_token && !creds?.fathom_api_key) {
       const { data: settings, error: configError } = await supabase
         .from("user_settings")
-        .select(
-          "fathom_api_key, oauth_access_token, oauth_token_expires, oauth_refresh_token",
-        )
+        .select("fathom_api_key")
         .eq("user_id", userId)
         .maybeSingle();
 
       if (configError) throw configError;
-      creds = settings;
+
+      const decrypted = await getDecryptedUserSettingsFathomTokens(
+        supabase,
+        userId,
+      );
+      creds = {
+        oauth_access_token: decrypted.access_token,
+        oauth_refresh_token: decrypted.refresh_token,
+        oauth_token_expires: decrypted.token_expires,
+        fathom_api_key: settings?.fathom_api_key ?? null,
+      };
     }
 
     if (!creds?.fathom_api_key && !creds?.oauth_access_token) {

--- a/supabase/functions/fetch-single-meeting/index.ts
+++ b/supabase/functions/fetch-single-meeting/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { FathomClient } from '../_shared/fathom-client.ts';
 import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedUserSettingsFathomTokens } from '../_shared/user-settings-encrypt.ts';
 
 serve(async (req) => {
   const origin = req.headers.get('Origin');
@@ -34,16 +35,19 @@ serve(async (req) => {
       );
     }
 
-    // Get Fathom credentials from user_settings (including OAuth expiry and refresh token)
+    // Get Fathom API key from user_settings (not encrypted)
     const { data: settings, error: settingsError } = await supabaseClient
       .from('user_settings')
-      .select('fathom_api_key, oauth_access_token, oauth_token_expires, oauth_refresh_token')
+      .select('fathom_api_key')
       .eq('user_id', user_id)
       .maybeSingle();
 
     if (settingsError) throw settingsError;
 
-    if (!settings?.fathom_api_key && !settings?.oauth_access_token) {
+    // Get decrypted OAuth tokens (falls back to plaintext if needed)
+    const oauthTokens = await getDecryptedUserSettingsFathomTokens(supabaseClient, user_id);
+
+    if (!settings?.fathom_api_key && !oauthTokens.access_token) {
       return new Response(
         JSON.stringify({ error: 'Fathom credentials not configured. Please add them in Settings.' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -53,19 +57,19 @@ serve(async (req) => {
     // Determine which authentication method to use (with OAuth token refresh)
     let authHeaders: Record<string, string>;
 
-    if (settings.oauth_access_token) {
+    if (oauthTokens.access_token) {
       // Check if OAuth token is expired
       const now = Date.now();
-      if (settings.oauth_token_expires && settings.oauth_token_expires > now) {
+      if (oauthTokens.token_expires && oauthTokens.token_expires > now) {
         authHeaders = {
-          'Authorization': `Bearer ${settings.oauth_access_token}`,
+          'Authorization': `Bearer ${oauthTokens.access_token}`,
           'Content-Type': 'application/json',
         };
         console.log('Using OAuth authentication for fetch-single-meeting');
       } else {
         // Token is expired, attempt to refresh it
         console.log('OAuth token expired, attempting refresh...');
-        if (!settings.oauth_refresh_token) {
+        if (!oauthTokens.refresh_token) {
           return new Response(
             JSON.stringify({ error: 'OAuth token expired and no refresh token available. Please reconnect Fathom in Settings.' }),
             { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -86,7 +90,7 @@ serve(async (req) => {
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: new URLSearchParams({
               grant_type: 'refresh_token',
-              refresh_token: settings.oauth_refresh_token,
+              refresh_token: oauthTokens.refresh_token,
               client_id: clientId,
               client_secret: clientSecret,
             }),
@@ -128,7 +132,7 @@ serve(async (req) => {
           );
         }
       }
-    } else if (settings.fathom_api_key) {
+    } else if (settings?.fathom_api_key) {
       authHeaders = {
         'X-Api-Key': settings.fathom_api_key,
         'Content-Type': 'application/json',

--- a/supabase/functions/sync-meetings/index.ts
+++ b/supabase/functions/sync-meetings/index.ts
@@ -4,6 +4,7 @@ import { getCorsHeaders } from "../_shared/cors.ts";
 import { runPipeline } from "../_shared/connector-pipeline.ts";
 import { authenticateRequest } from "../_shared/auth.ts";
 import { getDecryptedOAuthTokens } from "../_shared/oauth-encrypt.ts";
+import { getDecryptedUserSettingsFathomTokens } from "../_shared/user-settings-encrypt.ts";
 
 // Rate limiter for API calls - conservative to avoid 429 errors
 class RateLimiter {
@@ -371,14 +372,22 @@ Deno.serve(async (req) => {
     if (!creds?.oauth_access_token && !creds?.fathom_api_key) {
       const { data: settings, error: configError } = await supabase
         .from("user_settings")
-        .select(
-          "fathom_api_key, oauth_access_token, oauth_token_expires, oauth_refresh_token",
-        )
+        .select("fathom_api_key")
         .eq("user_id", userId)
         .maybeSingle();
 
       if (configError) throw configError;
-      creds = settings;
+
+      const decrypted = await getDecryptedUserSettingsFathomTokens(
+        supabase,
+        userId,
+      );
+      creds = {
+        oauth_access_token: decrypted.access_token,
+        oauth_refresh_token: decrypted.refresh_token,
+        oauth_token_expires: decrypted.token_expires,
+        fathom_api_key: settings?.fathom_api_key ?? null,
+      };
     }
 
     if (!creds?.fathom_api_key && !creds?.oauth_access_token) {

--- a/supabase/functions/zoom-fetch-meetings/index.ts
+++ b/supabase/functions/zoom-fetch-meetings/index.ts
@@ -3,6 +3,7 @@ import { ZoomClient } from '../_shared/zoom-client.ts';
 import { refreshZoomOAuthTokens } from '../_shared/zoom-token-refresh.ts';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { authenticateRequest } from '../_shared/auth.ts';
+import { getDecryptedUserSettingsZoomTokens } from '../_shared/user-settings-encrypt.ts';
 
 /**
  * RATE LIMITING CONFIGURATION
@@ -133,16 +134,10 @@ Deno.serve(async (req) => {
     const userId = authResult.userId;
     console.log('[zoom-fetch-meetings] Auth success for user:', userId);
 
-    // Get user's Zoom OAuth credentials
-    const { data: settings, error: configError } = await supabase
-      .from('user_settings')
-      .select('zoom_oauth_access_token, zoom_oauth_token_expires, zoom_oauth_refresh_token')
-      .eq('user_id', userId)
-      .maybeSingle();
+    // Get decrypted Zoom OAuth tokens (falls back to plaintext if needed)
+    const zoomTokens = await getDecryptedUserSettingsZoomTokens(supabase, userId);
 
-    if (configError) throw configError;
-
-    if (!settings?.zoom_oauth_access_token) {
+    if (!zoomTokens.access_token) {
       throw new Error('Zoom not connected. Please connect your Zoom account in Settings.');
     }
 
@@ -151,26 +146,26 @@ Deno.serve(async (req) => {
     const now = Date.now();
 
     console.log('[zoom-fetch-meetings] Token check:', {
-      hasAccessToken: !!settings.zoom_oauth_access_token,
-      hasRefreshToken: !!settings.zoom_oauth_refresh_token,
-      tokenExpires: settings.zoom_oauth_token_expires,
+      hasAccessToken: !!zoomTokens.access_token,
+      hasRefreshToken: !!zoomTokens.refresh_token,
+      tokenExpires: zoomTokens.token_expires,
       now,
-      expired: settings.zoom_oauth_token_expires ? settings.zoom_oauth_token_expires <= now : 'no expiry',
+      expired: zoomTokens.token_expires ? zoomTokens.token_expires <= now : 'no expiry',
       userId: userId,
     });
 
-    if (settings.zoom_oauth_token_expires && settings.zoom_oauth_token_expires > now) {
-      accessToken = settings.zoom_oauth_access_token;
+    if (zoomTokens.token_expires && zoomTokens.token_expires > now) {
+      accessToken = zoomTokens.access_token;
       console.log('Using existing Zoom access token');
     } else {
       // Token is expired, attempt to refresh
       console.log('Zoom token expired, attempting refresh...');
-      if (!settings.zoom_oauth_refresh_token) {
+      if (!zoomTokens.refresh_token) {
         throw new Error('Zoom token expired and no refresh token available. Please reconnect in Settings.');
       }
 
       try {
-        accessToken = await refreshZoomOAuthTokens(userId, settings.zoom_oauth_refresh_token);
+        accessToken = await refreshZoomOAuthTokens(userId, zoomTokens.refresh_token);
         console.log('Zoom token refreshed successfully');
       } catch (refreshError) {
         console.error('Error refreshing Zoom token:', refreshError);
@@ -276,9 +271,9 @@ Deno.serve(async (req) => {
 
             if (response.status === 401) {
               // Token might have expired during pagination, try refresh once
-              if (settings.zoom_oauth_refresh_token) {
+              if (zoomTokens.refresh_token) {
                 console.log('Got 401, attempting token refresh...');
-                accessToken = await refreshZoomOAuthTokens(userId, settings.zoom_oauth_refresh_token);
+                accessToken = await refreshZoomOAuthTokens(userId, zoomTokens.refresh_token);
                 retryCount++;
                 continue;
               }

--- a/supabase/functions/zoom-oauth-refresh/index.ts
+++ b/supabase/functions/zoom-oauth-refresh/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { refreshZoomOAuthTokens } from '../_shared/zoom-token-refresh.ts';
 import { authenticateRequest } from '../_shared/auth.ts';
+import { getDecryptedUserSettingsZoomTokens } from '../_shared/user-settings-encrypt.ts';
 
 // Re-export so any remaining imports from this file still work
 export { refreshZoomOAuthTokens };
@@ -25,21 +26,17 @@ Deno.serve(async (req) => {
     if (authResult instanceof Response) return authResult;
     const userId = authResult.userId;
 
-    // Get Zoom refresh token
-    const { data: settings } = await supabase
-      .from('user_settings')
-      .select('zoom_oauth_refresh_token')
-      .eq('user_id', userId)
-      .maybeSingle();
+    // Get decrypted Zoom OAuth tokens (falls back to plaintext if needed)
+    const zoomTokens = await getDecryptedUserSettingsZoomTokens(supabase, userId);
 
-    if (!settings?.zoom_oauth_refresh_token) {
+    if (!zoomTokens.refresh_token) {
       return new Response(
         JSON.stringify({ error: 'No Zoom refresh token found' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const newAccessToken = await refreshZoomOAuthTokens(userId, settings.zoom_oauth_refresh_token);
+    const newAccessToken = await refreshZoomOAuthTokens(userId, zoomTokens.refresh_token);
 
     return new Response(
       JSON.stringify({

--- a/supabase/functions/zoom-sync-meetings/index.ts
+++ b/supabase/functions/zoom-sync-meetings/index.ts
@@ -7,6 +7,7 @@ import { generateFingerprint, generateFingerprintString } from '../_shared/dedup
 
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { authenticateRequest } from '../_shared/auth.ts';
+import { getDecryptedUserSettingsZoomTokens } from '../_shared/user-settings-encrypt.ts';
 
 // Rate limiter for API calls - conservative to avoid 429 errors
 class RateLimiter {
@@ -435,16 +436,10 @@ Deno.serve(async (req) => {
     // (generate-ai-titles, auto-tag-calls) so they authenticate as the same user.
     const jwt = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '').trim();
 
-    // Get user's Zoom OAuth credentials
-    const { data: settings, error: configError } = await supabase
-      .from('user_settings')
-      .select('zoom_oauth_access_token, zoom_oauth_token_expires, zoom_oauth_refresh_token')
-      .eq('user_id', userId)
-      .maybeSingle();
+    // Get decrypted Zoom OAuth tokens (falls back to plaintext if needed)
+    const zoomTokens = await getDecryptedUserSettingsZoomTokens(supabase, userId);
 
-    if (configError) throw configError;
-
-    if (!settings?.zoom_oauth_access_token) {
+    if (!zoomTokens.access_token) {
       throw new Error('Zoom not connected. Please connect your Zoom account in Settings.');
     }
 
@@ -452,17 +447,17 @@ Deno.serve(async (req) => {
     let accessToken: string;
     const now = Date.now();
 
-    if (settings.zoom_oauth_token_expires && settings.zoom_oauth_token_expires > now) {
-      accessToken = settings.zoom_oauth_access_token;
+    if (zoomTokens.token_expires && zoomTokens.token_expires > now) {
+      accessToken = zoomTokens.access_token;
       console.log('Using existing Zoom access token for sync');
     } else {
       console.log('Zoom token expired, attempting refresh...');
-      if (!settings.zoom_oauth_refresh_token) {
+      if (!zoomTokens.refresh_token) {
         throw new Error('Zoom token expired and no refresh token available. Please reconnect in Settings.');
       }
 
       try {
-        accessToken = await refreshZoomOAuthTokens(userId, settings.zoom_oauth_refresh_token);
+        accessToken = await refreshZoomOAuthTokens(userId, zoomTokens.refresh_token);
         console.log('Zoom token refreshed successfully for sync');
       } catch (refreshError) {
         console.error('Error refreshing Zoom token:', refreshError);

--- a/supabase/functions/zoom-webhook/index.ts
+++ b/supabase/functions/zoom-webhook/index.ts
@@ -9,6 +9,7 @@ import {
   MatchResult,
 } from '../_shared/dedup-fingerprint.ts';
 import { runPipeline } from '../_shared/connector-pipeline.ts';
+import { getDecryptedUserSettingsZoomTokens } from '../_shared/user-settings-encrypt.ts';
 
 import { getCorsHeaders } from '../_shared/cors.ts';
 
@@ -442,7 +443,7 @@ async function processZoomWebhook(
   // Find ALL users with matching host_email (team support)
   const { data: userSettings, error: lookupError } = await supabase
     .from('user_settings')
-    .select('user_id, zoom_oauth_access_token, zoom_oauth_token_expires, zoom_oauth_refresh_token')
+    .select('user_id')
     .eq('host_email', hostEmail);
 
   if (lookupError) {
@@ -463,13 +464,15 @@ async function processZoomWebhook(
     const userId = settings.user_id;
 
     try {
+      const zoomTokens = await getDecryptedUserSettingsZoomTokens(supabase, userId);
+
       // Check if we have a valid access token
-      if (!settings.zoom_oauth_access_token) {
+      if (!zoomTokens.access_token) {
         console.error(`User ${userId} has no Zoom OAuth token`);
         continue;
       }
 
-      const accessToken = settings.zoom_oauth_access_token;
+      const accessToken = zoomTokens.access_token;
 
       // Find transcript file
       const transcriptFile = recording.recording_files?.find(


### PR DESCRIPTION
## Summary
- Adds _shared/user-settings-encrypt.ts to decrypt user_settings Fathom and Zoom OAuth tokens with OAUTH_ENCRYPTION_KEY + decrypt_token RPC, with plaintext compatibility.
- Updates all 7 remaining user_settings OAuth readers: fetch-single-meeting, create-fathom-webhook, fathom-oauth-refresh, zoom-fetch-meetings, zoom-sync-meetings, zoom-webhook, zoom-oauth-refresh.
- No user_settings schema changes, no OAUTH_ENCRYPTION_KEY changes, no migrations.

## Prod token state precheck
- user_settings Fathom encrypted/plaintext: 0 PGP / 8 plaintext.
- user_settings Zoom encrypted/plaintext: 0 PGP / 1 plaintext.
- Both encrypted counts are 0, so prod rows are still plaintext and urgency is lower; read-time decrypt is now in place for the migration cutover.

## Verification
- npx tsc --noEmit
- npm run build
- supabase functions deploy fetch-single-meeting --use-api
- supabase functions deploy create-fathom-webhook --use-api
- supabase functions deploy fathom-oauth-refresh --use-api
- supabase functions deploy zoom-fetch-meetings --use-api
- supabase functions deploy zoom-sync-meetings --use-api
- supabase functions deploy zoom-webhook --use-api
- supabase functions deploy zoom-oauth-refresh --use-api
- OPTIONS smoke via curl + service-role key: all 7 returned 200.
- POST smoke via curl + service-role key returned expected guard responses: fetch-single-meeting 400 missing recording_id; create-fathom-webhook 401 Unauthorized; fathom-oauth-refresh 401 Unauthorized; zoom-fetch-meetings 401 Unauthorized; zoom-sync-meetings 400 missing recordingIds/singleCallId; zoom-webhook 401 missing webhook headers; zoom-oauth-refresh 401 Unauthorized.