### PR TITLE
feat(connectors): Phase 8b — Fathom adapter searchAvailable + importSelected (#295)

### DIFF
--- a/src/components/connectors/registry/adapters/__tests__/fathom.test.ts
+++ b/src/components/connectors/registry/adapters/__tests__/fathom.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+import { supabase } from "@/integrations/supabase/client";
+import { fathomAdapter } from "../fathom";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+describe("fathomAdapter.searchAvailable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests paged Fathom meetings and normalizes them for the import wizard", async () => {
+    invoke.mockResolvedValue({
+      data: {
+        meetings: [
+          {
+            recording_id: 123,
+            title: "Pipeline Review",
+            created_at: "2026-05-20T09:00:00Z",
+            recording_start_time: "2026-05-20T10:00:00Z",
+            recording_end_time: "2026-05-20T10:30:30Z",
+            synced: true,
+            calendar_invitees: [{ name: "Ava", email: "ava@example.com" }],
+            share_url: "https://fathom.video/share/123",
+          },
+          {
+            recording_id: 456,
+            title: "Fallback Start",
+            created_at: "2026-05-21T09:00:00Z",
+            recording_start_time: null,
+            recording_end_time: null,
+            synced: false,
+            url: "https://fathom.video/calls/456",
+          },
+        ],
+        next_cursor: "cursor-2",
+      },
+      error: null,
+    });
+
+    const result = await fathomAdapter.searchAvailable!({
+      sourceId: "source-1",
+      dateStart: new Date("2026-05-20T00:00:00Z"),
+      dateEnd: new Date("2026-05-22T00:00:00Z"),
+      cursor: "cursor-1",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("fetch-meetings", {
+      body: {
+        sourceId: "source-1",
+        createdAfter: "2026-05-20T00:00:00.000Z",
+        createdBefore: "2026-05-22T00:00:00.000Z",
+        cursor: "cursor-1",
+        pageMode: true,
+      },
+    });
+    expect(result).toEqual({
+      nextCursor: "cursor-2",
+      items: [
+        {
+          externalId: "123",
+          title: "Pipeline Review",
+          startTime: "2026-05-20T10:00:00Z",
+          durationSeconds: 1830,
+          participants: [{ name: "Ava", email: "ava@example.com" }],
+          alreadyImported: true,
+          externalUrl: "https://fathom.video/share/123",
+        },
+        {
+          externalId: "456",
+          title: "Fallback Start",
+          startTime: "2026-05-21T09:00:00Z",
+          durationSeconds: null,
+          participants: undefined,
+          alreadyImported: false,
+          externalUrl: "https://fathom.video/calls/456",
+        },
+      ],
+    });
+  });
+
+  it("throws Supabase invoke errors from searchAvailable", async () => {
+    invoke.mockResolvedValue({
+      data: null,
+      error: { message: "Function returned 401" },
+    });
+
+    await expect(
+      fathomAdapter.searchAvailable!({
+        sourceId: "source-1",
+        dateStart: new Date("2026-05-20T00:00:00Z"),
+        dateEnd: new Date("2026-05-21T00:00:00Z"),
+      }),
+    ).rejects.toThrow("Function returned 401");
+  });
+
+  it("throws provider payload errors from searchAvailable", async () => {
+    invoke.mockResolvedValue({
+      data: { error: "Fathom token expired" },
+      error: null,
+    });
+
+    await expect(
+      fathomAdapter.searchAvailable!({
+        sourceId: "source-1",
+        dateStart: new Date("2026-05-20T00:00:00Z"),
+        dateEnd: new Date("2026-05-21T00:00:00Z"),
+      }),
+    ).rejects.toThrow("Fathom token expired");
+  });
+
+  it("throws when fetch-meetings returns a malformed meetings payload", async () => {
+    invoke.mockResolvedValue({
+      data: { calls: [] },
+      error: null,
+    });
+
+    await expect(
+      fathomAdapter.searchAvailable!({
+        sourceId: "source-1",
+        dateStart: new Date("2026-05-20T00:00:00Z"),
+        dateEnd: new Date("2026-05-21T00:00:00Z"),
+      }),
+    ).rejects.toThrow("fetch-meetings returned an invalid meetings payload");
+  });
+});
+
+describe("fathomAdapter.importSelected", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts a Fathom sync job for the selected recording IDs", async () => {
+    invoke.mockResolvedValue({
+      data: { job_id: "job-123" },
+      error: null,
+    });
+
+    const result = await fathomAdapter.importSelected!({
+      sourceId: "source-1",
+      externalIds: ["123", "456"],
+      workspaceId: "workspace-1",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("sync-meetings", {
+      body: {
+        sourceId: "source-1",
+        workspaceId: "workspace-1",
+        workspace_id: "workspace-1",
+        recordingIds: [123, 456],
+      },
+    });
+    expect(result).toEqual({
+      jobId: "job-123",
+      total: 2,
+      message: "Importing 2 Fathom call(s)…",
+    });
+  });
+
+  it("throws provider payload errors from importSelected", async () => {
+    invoke.mockResolvedValue({
+      data: { error: "Fathom token expired" },
+      error: null,
+    });
+
+    await expect(
+      fathomAdapter.importSelected!({
+        sourceId: "source-1",
+        externalIds: ["123"],
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow("Fathom token expired");
+  });
+
+  it("throws when sync-meetings returns no job id", async () => {
+    invoke.mockResolvedValue({ data: {}, error: null });
+
+    await expect(
+      fathomAdapter.importSelected!({
+        sourceId: "source-1",
+        externalIds: ["123"],
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow("sync-meetings returned no jobId");
+  });
+
+  it("throws before invoking sync-meetings for invalid recording IDs", async () => {
+    await expect(
+      fathomAdapter.importSelected!({
+        sourceId: "source-1",
+        externalIds: ["not-a-number"],
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow("Invalid Fathom recording id: not-a-number");
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/connectors/registry/adapters/fathom.ts
+++ b/src/components/connectors/registry/adapters/fathom.ts
@@ -95,15 +95,22 @@ export const fathomAdapter: ConnectorAdapter = {
     }
 
     const response = data as {
-      meetings?: FathomAvailableMeeting[];
+      meetings?: unknown;
       next_cursor?: string | null;
     } | null;
 
+    if (!response || !Array.isArray(response.meetings)) {
+      throw new Error("fetch-meetings returned an invalid meetings payload");
+    }
+
     return {
-      items: (response?.meetings ?? []).map((meeting) => {
+      items: response.meetings.map((meeting) => {
+        const fathomMeeting = meeting as FathomAvailableMeeting;
         const startTime =
-          meeting.recording_start_time ?? meeting.created_at ?? null;
-        const endTime = meeting.recording_end_time;
+          fathomMeeting.recording_start_time ??
+          fathomMeeting.created_at ??
+          null;
+        const endTime = fathomMeeting.recording_end_time;
         const durationSeconds =
           startTime && endTime
             ? Math.max(
@@ -116,13 +123,13 @@ export const fathomAdapter: ConnectorAdapter = {
               )
             : null;
         return {
-          externalId: String(meeting.recording_id),
-          title: meeting.title,
+          externalId: String(fathomMeeting.recording_id),
+          title: fathomMeeting.title,
           startTime,
           durationSeconds,
-          participants: meeting.calendar_invitees,
-          alreadyImported: meeting.synced,
-          externalUrl: meeting.share_url ?? meeting.url ?? null,
+          participants: fathomMeeting.calendar_invitees,
+          alreadyImported: fathomMeeting.synced,
+          externalUrl: fathomMeeting.share_url ?? fathomMeeting.url ?? null,
         };
       }),
       nextCursor: response?.next_cursor ?? null,
@@ -131,6 +138,14 @@ export const fathomAdapter: ConnectorAdapter = {
 
   async importSelected({ sourceId, externalIds, workspaceId }) {
     const recordingIds = externalIds.map((id) => Number(id));
+    const invalidId = externalIds.find((_, index) => {
+      const recordingId = recordingIds[index];
+      return !Number.isSafeInteger(recordingId) || recordingId <= 0;
+    });
+
+    if (invalidId) {
+      throw new Error(`Invalid Fathom recording id: ${invalidId}`);
+    }
 
     const { data, error } = await supabase.functions.invoke("sync-meetings", {
       body: {

--- a/src/components/connectors/registry/adapters/fathom.ts
+++ b/src/components/connectors/registry/adapters/fathom.ts
@@ -10,6 +10,18 @@ import { RiMicLine } from "@remixicon/react";
 import { supabase } from "@/integrations/supabase/client";
 import type { ConnectorAdapter } from "../types";
 
+interface FathomAvailableMeeting {
+  recording_id: number;
+  title: string;
+  created_at?: string | null;
+  recording_start_time?: string | null;
+  recording_end_time?: string | null;
+  synced: boolean;
+  calendar_invitees?: Array<{ name: string | null; email: string | null }>;
+  share_url?: string | null;
+  url?: string | null;
+}
+
 export const fathomAdapter: ConnectorAdapter = {
   metadata: {
     sourceApp: "fathom",
@@ -62,5 +74,87 @@ export const fathomAdapter: ConnectorAdapter = {
       .eq("id", sourceId)
       .eq("source_app", "fathom");
     if (error) throw new Error(error.message);
+  },
+
+  async searchAvailable({ sourceId, dateStart, dateEnd, cursor }) {
+    const createdAfter = dateStart.toISOString();
+    const createdBefore = dateEnd.toISOString();
+
+    const { data, error } = await supabase.functions.invoke("fetch-meetings", {
+      body: {
+        sourceId,
+        createdAfter,
+        createdBefore,
+        cursor: cursor ?? undefined,
+        pageMode: true,
+      },
+    });
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+
+    const response = data as {
+      meetings?: FathomAvailableMeeting[];
+      next_cursor?: string | null;
+    } | null;
+
+    return {
+      items: (response?.meetings ?? []).map((meeting) => {
+        const startTime =
+          meeting.recording_start_time ?? meeting.created_at ?? null;
+        const endTime = meeting.recording_end_time;
+        const durationSeconds =
+          startTime && endTime
+            ? Math.max(
+                0,
+                Math.floor(
+                  (new Date(endTime).getTime() -
+                    new Date(startTime).getTime()) /
+                    1000,
+                ),
+              )
+            : null;
+        return {
+          externalId: String(meeting.recording_id),
+          title: meeting.title,
+          startTime,
+          durationSeconds,
+          participants: meeting.calendar_invitees,
+          alreadyImported: meeting.synced,
+          externalUrl: meeting.share_url ?? meeting.url ?? null,
+        };
+      }),
+      nextCursor: response?.next_cursor ?? null,
+    };
+  },
+
+  async importSelected({ sourceId, externalIds, workspaceId }) {
+    const recordingIds = externalIds.map((id) => Number(id));
+
+    const { data, error } = await supabase.functions.invoke("sync-meetings", {
+      body: {
+        sourceId,
+        workspaceId,
+        workspace_id: workspaceId,
+        recordingIds,
+      },
+    });
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+
+    const payload = data as { jobId?: string; job_id?: string } | null;
+    const jobId = payload?.jobId ?? payload?.job_id;
+    if (!jobId) {
+      throw new Error("sync-meetings returned no jobId");
+    }
+
+    return {
+      jobId,
+      total: externalIds.length,
+      message: `Importing ${externalIds.length} Fathom call(s)…`,
+    };
   },
 };


### PR DESCRIPTION
## Summary

Adds the Phase 8b Fathom adapter capabilities so `ConnectorImportWizard` can discover and import Fathom calls through the connector registry. Direct mirror of Phase 8d (Fireflies, #309).

## Changes

- Implements `fathomAdapter.searchAvailable()` using the existing `fetch-meetings` edge function and normalizes Fathom meeting rows into the registry's `AvailableCall` shape.
- Implements `fathomAdapter.importSelected()` using the existing `sync-meetings` edge function. Converts the string-typed `externalId` (registry contract) back to the numeric `recording_id` Fathom expects, returns an `ImportJob` for wizard polling.
- Computes `durationSeconds` from `recording_start_time` + `recording_end_time` when both are present; falls back to null when either is missing.
- Surfaces `share_url` / `url` as `externalUrl` so the wizard's "view original" affordance works.
- Local interface (`FathomAvailableMeeting`) uses nullable invitee names/emails — Fathom's API does return null for missing values.

## Contract compatibility

Both invocations reuse the **exact body keys** `FathomImportDetail.tsx` calls today, so this PR is additive (no breaking changes to the legacy detail pane):

| Call | Body |
|---|---|
| `fetch-meetings` | `{ sourceId, createdAfter, createdBefore, cursor?, pageMode: true }` |
| `sync-meetings` | `{ sourceId, workspaceId, workspace_id, recordingIds }` |

## Validation

- `npx tsc --noEmit` clean
- Registry already imports `fathomAdapter` (no wiring change needed)
- `ConnectorImportWizard` already reads `adapter.searchAvailable` / `adapter.importSelected` (Phase 8 scaffold, #306)

## Out of scope

- Migrating `FathomImportDetail.tsx` consumers to use the wizard — that's Phase 5 (Migrate Import Detail panes).
- Zoom adapter (Phase 8c) and Plaud adapter (Phase 8e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Don