### PR TITLE
Read.ai Import Connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,22 @@ FATHOM_OAUTH_WEBHOOK_SECRET=your-fathom-webhook-secret
 
 
 # ============================================
+# READ.AI — Meeting Sync (OAuth open beta)
+# ============================================
+
+# [required for Read.ai integration] Dynamic OAuth client credentials.
+# Register operationally with Read.ai, then store the returned values here.
+READAI_OAUTH_CLIENT_ID=your-readai-client-id
+READAI_OAUTH_CLIENT_SECRET=your-readai-client-secret
+
+# [optional] OAuth endpoint overrides. Defaults reflect Read.ai's current docs.
+READAI_OAUTH_REDIRECT_URI=https://app.callvaultai.com/oauth/callback/read-ai
+READAI_OAUTH_AUTHORIZE_URL=https://api.read.ai/oauth/ui
+READAI_OAUTH_TOKEN_URL=https://authn.read.ai/oauth2/token
+READAI_API_BASE=https://api.read.ai
+
+
+# ============================================
 # ZOOM — Meeting Sync (OAuth)
 # ============================================
 

--- a/e2e/import-page.spec.ts
+++ b/e2e/import-page.spec.ts
@@ -36,6 +36,7 @@ test.describe('Import Page', () => {
     const sources = page.getByText(/zoom|youtube|upload|fathom/i);
     const hasSource = await sources.first().isVisible({ timeout: 10_000 }).catch(() => false);
     expect(hasSource).toBeTruthy();
+    await expect(page.getByText('Read.ai').first()).toBeVisible({ timeout: 10_000 });
   });
 
   test('should show connected sources status', async ({ page }) => {

--- a/e2e/settings-pane-navigation.spec.ts
+++ b/e2e/settings-pane-navigation.spec.ts
@@ -184,6 +184,7 @@ test.describe('Settings Pane Navigation', () => {
       await expect(detailPane).toBeVisible({ timeout: 5000 });
       await expect(detailPane.getByRole('heading', { name: 'Integrations' }).first()).toBeVisible();
       await expect(detailPane.getByText('Connected services')).toBeVisible();
+      await expect(detailPane.getByText('Read.ai')).toBeVisible({ timeout: 5000 });
     });
 
     test('should show correct header in detail pane for AI Integrations', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,14 @@ function App() {
                       </ProtectedRoute>
                     }
                   />
+                  <Route
+                    path="/oauth/callback/read-ai"
+                    element={
+                      <ProtectedRoute>
+                        <OAuthCallback />
+                      </ProtectedRoute>
+                    }
+                  />
 
                   {/* OAuth consent page - public route, handles its own auth check internally */}
                   <Route path="/oauth/consent" element={<OAuthConsentPage />} />

--- a/src/components/connectors/ConnectorImportWizard.tsx
+++ b/src/components/connectors/ConnectorImportWizard.tsx
@@ -49,6 +49,8 @@ import { RiLoader4Line, RiSearchLine } from "@remixicon/react";
 import { toast } from "sonner";
 import { ConnectorPanel } from "./ConnectorPanel";
 import { useConnector } from "./hooks/useConnector";
+import { useOrgContext } from "@/hooks/useOrgContext";
+import { useWorkspaces } from "@/hooks/useWorkspaces";
 import { getConnectorAdapter } from "./registry/connectorRegistry";
 import type { AvailableCall, ConnectorSourceApp } from "./registry/types";
 
@@ -69,6 +71,9 @@ export function ConnectorImportWizard({
 }: ConnectorImportWizardProps) {
   const adapter = getConnectorAdapter(sourceApp);
   const { status } = useConnector(sourceApp);
+  const { activeOrgId } = useOrgContext();
+  const { workspaces = [], isLoading: workspacesLoading } =
+    useWorkspaces(activeOrgId);
 
   // Wizard state
   const [dateRange, setDateRange] = React.useState<{
@@ -82,6 +87,14 @@ export function ConnectorImportWizard({
   );
   const [searching, setSearching] = React.useState(false);
   const [importing, setImporting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (workspaceId || workspaces.length === 0) return;
+    const defaultWorkspace =
+      workspaces.find((workspace) => workspace.is_default || workspace.is_home) ??
+      workspaces[0];
+    setWorkspaceId(defaultWorkspace.id);
+  }, [workspaceId, workspaces]);
 
   // Capability flags from adapter
   const canSearch = Boolean(adapter.searchAvailable);
@@ -284,10 +297,16 @@ export function ConnectorImportWizard({
               value={workspaceId ?? ""}
               onChange={(e) => setWorkspaceId(e.target.value || undefined)}
               className="rounded-md border border-border bg-card px-3 py-2 text-sm"
+              disabled={workspacesLoading}
             >
-              <option value="">Select workspace…</option>
-              {/* TODO Phase 8a-ii: wire to useWorkspaces() so the dropdown
-                  shows real workspaces. Scaffold leaves it empty for now. */}
+              <option value="">
+                {workspacesLoading ? "Loading workspaces..." : "Select workspace..."}
+              </option>
+              {workspaces.map((workspace) => (
+                <option key={workspace.id} value={workspace.id}>
+                  {workspace.name}
+                </option>
+              ))}
             </select>
           </div>
           <Button

--- a/src/components/connectors/__tests__/deriveConnectorStatus.test.ts
+++ b/src/components/connectors/__tests__/deriveConnectorStatus.test.ts
@@ -140,6 +140,44 @@ describe("deriveConnectorStatus — Zoom legacy path", () => {
   });
 });
 
+describe("deriveConnectorStatus — Read.ai", () => {
+  it("active Read.ai row with future OAuth expiry is connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "read-ai",
+      rows: [
+        row({
+          source_app: "read-ai",
+          account_email: "read@example.com",
+          oauth_token_expires: NOW + 10 * 60 * 1000,
+        }),
+      ],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.accountEmail).toBe("read@example.com");
+    expect(status.tokenExpired).toBe(false);
+  });
+
+  it("expired Read.ai token row is not connected", () => {
+    const status = deriveConnectorStatus({
+      sourceApp: "read-ai",
+      rows: [
+        row({
+          source_app: "read-ai",
+          oauth_token_expires: NOW - 1,
+        }),
+      ],
+      userSettings: null,
+      now: NOW,
+    });
+
+    expect(status.connected).toBe(false);
+    expect(status.tokenExpired).toBe(true);
+  });
+});
+
 describe("deriveConnectorStatus — always-available sources", () => {
   it("youtube has no auth → always connected", () => {
     const status = deriveConnectorStatus({

--- a/src/components/connectors/registry/adapters/__tests__/read-ai.test.ts
+++ b/src/components/connectors/registry/adapters/__tests__/read-ai.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(async () => ({ error: null })),
+        })),
+      })),
+    })),
+  },
+}));
+
+import { supabase } from "@/integrations/supabase/client";
+import { readAiAdapter } from "../read-ai";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+describe("readAiAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests a Read.ai OAuth URL", async () => {
+    invoke.mockResolvedValue({
+      data: { authUrl: "https://api.read.ai/oauth/ui", sourceId: "source-1" },
+      error: null,
+    });
+
+    const result = await readAiAdapter.getOAuthAuthUrl!();
+
+    expect(invoke).toHaveBeenCalledWith("read-ai-oauth-url");
+    expect(result).toEqual({
+      authUrl: "https://api.read.ai/oauth/ui",
+      sourceId: "source-1",
+    });
+  });
+
+  it("saves pasted bearer tokens through the token fallback function", async () => {
+    invoke.mockResolvedValue({
+      data: { success: true, sourceId: "source-2" },
+      error: null,
+    });
+
+    const result = await readAiAdapter.saveApiKeyCredentials!({
+      apiKey: "  bearer-token  ",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("read-ai-connect-token", {
+      body: { accessToken: "bearer-token" },
+    });
+    expect(result).toEqual({ sourceId: "source-2" });
+  });
+
+  it("maps Read.ai search results for the import wizard", async () => {
+    invoke.mockResolvedValue({
+      data: {
+        meetings: [
+          {
+            recording_id: "01READ",
+            title: "Read.ai Review",
+            recording_start_time: "2026-05-20T10:00:00Z",
+            duration: 1800,
+            synced: false,
+            importable: true,
+            calendar_invitees: [{ name: "Ava", email: "ava@example.com" }],
+            share_url: "https://app.read.ai/analytics/meetings/01READ",
+          },
+        ],
+        nextCursor: "01NEXT",
+      },
+      error: null,
+    });
+
+    const result = await readAiAdapter.searchAvailable!({
+      sourceId: "source-1",
+      dateStart: new Date("2026-05-20T00:00:00Z"),
+      dateEnd: new Date("2026-05-21T00:00:00Z"),
+      limit: 25,
+      cursor: "01CURSOR",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("read-ai-fetch-meetings", {
+      body: {
+        sourceId: "source-1",
+        createdAfter: "2026-05-20T00:00:00.000Z",
+        createdBefore: "2026-05-21T00:00:00.000Z",
+        cursor: "01CURSOR",
+        limit: 25,
+      },
+    });
+    expect(result).toEqual({
+      nextCursor: "01NEXT",
+      items: [
+        {
+          externalId: "01READ",
+          title: "Read.ai Review",
+          startTime: "2026-05-20T10:00:00Z",
+          durationSeconds: 1800,
+          participants: [{ name: "Ava", email: "ava@example.com" }],
+          alreadyImported: false,
+          externalUrl: "https://app.read.ai/analytics/meetings/01READ",
+          metadata: { importable: true },
+        },
+      ],
+    });
+  });
+
+  it("starts a Read.ai sync job for selected meetings", async () => {
+    invoke.mockResolvedValue({
+      data: { jobId: "job-1" },
+      error: null,
+    });
+
+    const result = await readAiAdapter.importSelected!({
+      sourceId: "source-1",
+      externalIds: ["01READ"],
+      workspaceId: "workspace-1",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("read-ai-sync-meetings", {
+      body: {
+        sourceId: "source-1",
+        workspaceId: "workspace-1",
+        workspace_id: "workspace-1",
+        meetingIds: ["01READ"],
+      },
+    });
+    expect(result).toEqual({
+      jobId: "job-1",
+      total: 1,
+      message: "Importing 1 Read.ai call(s)...",
+    });
+  });
+});

--- a/src/components/connectors/registry/adapters/read-ai.ts
+++ b/src/components/connectors/registry/adapters/read-ai.ts
@@ -1,0 +1,133 @@
+import { RiCloudLine } from "@remixicon/react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ConnectorAdapter } from "../types";
+
+interface ReadAiAvailableMeeting {
+  recording_id: string;
+  title: string;
+  recording_start_time: string | null;
+  duration: number | null;
+  calendar_invitees?: Array<{ name: string | null; email: string | null }>;
+  synced: boolean;
+  importable?: boolean;
+  share_url?: string | null;
+  source_url?: string | null;
+}
+
+export const readAiAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "read-ai",
+    label: "Read.ai",
+    description: "Meeting reports and transcripts",
+    icon: RiCloudLine,
+    brandColor: "#5B7CFA",
+    authMethods: ["oauth", "api_key"],
+    order: 45,
+  },
+
+  async getOAuthAuthUrl() {
+    const { data, error } = await supabase.functions.invoke("read-ai-oauth-url");
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+    if (!data?.authUrl) {
+      throw new Error("read-ai-oauth-url returned no authUrl");
+    }
+    return {
+      authUrl: data.authUrl as string,
+      sourceId: data.sourceId as string | undefined,
+    };
+  },
+
+  async saveApiKeyCredentials({ apiKey }) {
+    const { data, error } = await supabase.functions.invoke(
+      "read-ai-connect-token",
+      {
+        body: { accessToken: apiKey.trim() },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+    if (!data?.sourceId) {
+      throw new Error("read-ai-connect-token returned no sourceId");
+    }
+    return { sourceId: data.sourceId as string };
+  },
+
+  async disconnect(sourceId) {
+    const { error } = await supabase
+      .from("import_sources")
+      .update({ is_active: false })
+      .eq("id", sourceId)
+      .eq("source_app", "read-ai");
+    if (error) throw new Error(error.message);
+  },
+
+  async searchAvailable({ sourceId, dateStart, dateEnd, limit, cursor }) {
+    const { data, error } = await supabase.functions.invoke(
+      "read-ai-fetch-meetings",
+      {
+        body: {
+          sourceId,
+          createdAfter: dateStart.toISOString(),
+          createdBefore: dateEnd.toISOString(),
+          cursor: cursor ?? null,
+          limit: limit ?? 10,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+
+    const response = data as {
+      meetings?: ReadAiAvailableMeeting[];
+      nextCursor?: string | null;
+    } | null;
+
+    return {
+      items: (response?.meetings ?? []).map((meeting) => ({
+        externalId: meeting.recording_id,
+        title: meeting.title,
+        startTime: meeting.recording_start_time,
+        durationSeconds: meeting.duration,
+        participants: meeting.calendar_invitees,
+        alreadyImported: meeting.synced || meeting.importable === false,
+        externalUrl: meeting.share_url ?? meeting.source_url,
+        metadata: { importable: meeting.importable ?? true },
+      })),
+      nextCursor: response?.nextCursor ?? null,
+    };
+  },
+
+  async importSelected({ sourceId, externalIds, workspaceId }) {
+    const { data, error } = await supabase.functions.invoke(
+      "read-ai-sync-meetings",
+      {
+        body: {
+          sourceId,
+          workspaceId,
+          workspace_id: workspaceId,
+          meetingIds: externalIds,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+    if (!(data as { jobId?: string } | null)?.jobId) {
+      throw new Error("read-ai-sync-meetings returned no jobId");
+    }
+
+    return {
+      jobId: (data as { jobId: string }).jobId,
+      total: externalIds.length,
+      message: `Importing ${externalIds.length} Read.ai call(s)...`,
+    };
+  },
+};

--- a/src/components/connectors/registry/connectorRegistry.ts
+++ b/src/components/connectors/registry/connectorRegistry.ts
@@ -17,6 +17,7 @@
 import { fathomAdapter } from "./adapters/fathom";
 import { zoomAdapter } from "./adapters/zoom";
 import { firefliesAdapter } from "./adapters/fireflies";
+import { readAiAdapter } from "./adapters/read-ai";
 import { plaudAdapter } from "./adapters/plaud";
 import { youtubeAdapter } from "./adapters/youtube";
 import { fileUploadAdapter } from "./adapters/file-upload";
@@ -30,6 +31,7 @@ const ALL_ADAPTERS: readonly ConnectorAdapter[] = [
   fathomAdapter,
   zoomAdapter,
   firefliesAdapter,
+  readAiAdapter,
   plaudAdapter,
   youtubeAdapter,
   fileUploadAdapter,

--- a/src/components/connectors/registry/types.ts
+++ b/src/components/connectors/registry/types.ts
@@ -13,6 +13,7 @@ export type ConnectorSourceApp =
   | "fathom"
   | "zoom"
   | "fireflies"
+  | "read-ai"
   | "plaud"
   | "youtube"
   | "file-upload";

--- a/src/components/panes/ImportSourcePane.tsx
+++ b/src/components/panes/ImportSourcePane.tsx
@@ -28,6 +28,7 @@ export type ImportSourceId =
   | 'fathom'
   | 'zoom'
   | 'fireflies'
+  | 'read-ai'
   | 'plaud'
   | 'youtube'
   | 'file-upload'
@@ -56,6 +57,7 @@ const PRIMARY_SOURCES: SourceDef[] = [
   { id: 'fathom', label: 'Fathom', subtitle: 'AI meeting recorder', icon: RiCloudLine },
   { id: 'zoom', label: 'Zoom', subtitle: 'Cloud recordings', icon: RiVideoLine },
   { id: 'fireflies', label: 'Fireflies', subtitle: 'Transcript API import', icon: RiCloudLine },
+  { id: 'read-ai', label: 'Read.ai', subtitle: 'Meeting reports', icon: RiCloudLine },
   { id: 'plaud', label: 'Plaud', subtitle: 'AI voice recorder', icon: RiCloudLine },
   { id: 'youtube', label: 'YouTube', subtitle: 'Video imports', icon: RiYoutubeLine },
   { id: 'file-upload', label: 'File Upload', subtitle: 'Direct upload', icon: RiUploadCloud2Line },

--- a/src/config/source-registry.ts
+++ b/src/config/source-registry.ts
@@ -37,6 +37,7 @@ export type SourceId =
   | "fathom"
   | "zoom"
   | "fireflies"
+  | "read-ai"
   | "plaud"
   | "youtube"
   | "file-upload"
@@ -108,6 +109,16 @@ export const SOURCE_REGISTRY: readonly SourceConfig[] = [
     authMode: "api-key",
     hasWebhook: true,
     status: "stable",
+  },
+  {
+    id: "read-ai",
+    label: "Read.ai",
+    subtitle: "Import Read.ai meeting reports and transcripts",
+    icon: RiCloudLine,
+    adapter: "native",
+    authMode: "oauth2",
+    hasWebhook: false,
+    status: "beta",
   },
   {
     id: "plaud",

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -147,6 +147,24 @@ export async function completePlaudOAuth(code: string, state: string) {
   return callEdgeFunction('plaud-oauth-callback', { code, state }, { retry: false });
 }
 
+// =============================================
+// READ.AI OAUTH & SYNC FUNCTIONS
+// =============================================
+
+/**
+ * Get Read.ai OAuth authorization URL.
+ */
+export async function getReadAiOAuthUrl() {
+  return callEdgeFunction('read-ai-oauth-url', undefined, { retry: false });
+}
+
+/**
+ * Complete Read.ai OAuth flow.
+ */
+export async function completeReadAiOAuth(code: string, state: string) {
+  return callEdgeFunction('read-ai-oauth-callback', { code, state }, { retry: false });
+}
+
 /**
  * Refresh Zoom OAuth token
  */

--- a/src/lib/source-labels.ts
+++ b/src/lib/source-labels.ts
@@ -9,6 +9,7 @@ export const SOURCE_LABELS: Record<string, string> = {
   youtube: 'YouTube',
   'file-upload': 'Upload',
   fireflies: 'Fireflies',
+  'read-ai': 'Read.ai',
   plaud: 'Plaud',
   grain: 'Grain',
   otter: 'Otter',

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -21,6 +21,7 @@ import { FathomImportDetail } from "@/components/import/FathomImportDetail";
 import { ZoomImportDetail } from "@/components/import/ZoomImportDetail";
 import { FirefliesImportDetail } from "@/components/import/FirefliesImportDetail";
 import { PasteTranscriptModal } from "@/components/import/PasteTranscriptModal";
+import { ConnectorImportWizard } from "@/components/connectors/ConnectorImportWizard";
 import {
   AddImportSourceDialog,
   type AddImportSourceChoice,
@@ -59,6 +60,17 @@ async function connectZoom() {
   const { data, error } = await supabase.functions.invoke("zoom-oauth-url");
   if (error || !data?.authUrl) {
     toast.error("Failed to start Zoom connection");
+    return;
+  }
+  window.open(data.authUrl as string, "_blank", "noopener,noreferrer");
+}
+
+async function connectReadAi(sourceId?: string) {
+  const { data, error } = await supabase.functions.invoke("read-ai-oauth-url", {
+    body: sourceId ? { sourceId } : undefined,
+  });
+  if (error || !data?.authUrl) {
+    toast.error("Failed to start Read.ai connection");
     return;
   }
   window.open(data.authUrl as string, "_blank", "noopener,noreferrer");
@@ -143,6 +155,7 @@ export default function ImportPage() {
         const syncFnMap: Record<string, string> = {
           fathom: "sync-meetings",
           zoom: "zoom-sync-meetings",
+          "read-ai": "read-ai-sync-meetings",
           plaud: "plaud-sync-recordings",
         };
         const fnName = syncFnMap[connectedSource];
@@ -157,7 +170,9 @@ export default function ImportPage() {
               ? "Fathom"
               : connectedSource === "zoom"
                 ? "Zoom"
-                : "Plaud";
+                : connectedSource === "read-ai"
+                  ? "Read.ai"
+                  : "Plaud";
           if (synced > 0) {
             toast.success(
               `${sourceName} sync complete — ${synced} new calls imported`,
@@ -493,6 +508,36 @@ export default function ImportPage() {
       );
     }
 
+    if (selectedSource === "read-ai") {
+      const readAiRow =
+        sources.find((s) => s.source_app === "read-ai") ?? null;
+      return (
+        <div className="flex flex-col h-full overflow-y-auto">
+          <PageHeader
+            title="Read.ai"
+            subtitle="Connect Read.ai, search completed meeting reports, and import selected transcripts"
+            icon={RiDownloadCloud2Line}
+          />
+          <div className="px-6 py-4 max-w-4xl space-y-4">
+            {!readAiRow?.is_active && (
+              <Button variant="default" onClick={() => void connectReadAi()}>
+                Connect Read.ai
+              </Button>
+            )}
+            <ConnectorImportWizard sourceApp="read-ai" />
+            {readAiRow && (
+              <Button
+                variant="hollow"
+                onClick={() => setDisconnectTarget(readAiRow)}
+              >
+                Disconnect
+              </Button>
+            )}
+          </div>
+        </div>
+      );
+    }
+
     if (selectedSource === "youtube") {
       return (
         <div className="flex flex-col h-full overflow-y-auto">
@@ -596,6 +641,8 @@ export default function ImportPage() {
       void connectZoom();
     } else if (choice === "fireflies") {
       setSelectedSource("fireflies");
+    } else if (choice === "read-ai") {
+      void connectReadAi();
     } else if (choice === "plaud") {
       void connectPlaud();
     } else if (choice === "youtube") {
@@ -688,6 +735,7 @@ export default function ImportPage() {
 
 function getSourceName(sourceApp: string): string {
   if (sourceApp === "fireflies") return "Fireflies";
+  if (sourceApp === "read-ai") return "Read.ai";
   if (sourceApp === "plaud") return "Plaud";
   if (sourceApp === "youtube") return "YouTube";
   if (sourceApp === "file-upload") return "File Upload";

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { RiLoader4Line, RiCheckLine, RiCloseLine } from "@remixicon/react";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
-import { completeFathomOAuth, completePlaudOAuth, completeZoomOAuth } from "@/lib/api-client";
+import { completeFathomOAuth, completePlaudOAuth, completeReadAiOAuth, completeZoomOAuth } from "@/lib/api-client";
 import { supabase } from "@/integrations/supabase/client";
 import { getSafeUser } from "@/lib/auth-utils";
 
@@ -16,6 +16,7 @@ type CallbackState = "loading" | "success" | "error";
  *   /oauth/callback/ - Fathom OAuth callback
  *   /oauth/callback/zoom - Zoom OAuth callback
  *   /oauth/callback/plaud - Plaud OAuth callback
+ *   /oauth/callback/read-ai - Read.ai OAuth callback
  * Process:
  * 1. Extract code and state from URL params
  * 2. Determine provider from path
@@ -56,7 +57,14 @@ export default function OAuthCallback() {
         // Determine provider from path
         const isZoomCallback = location.pathname.includes("/zoom");
         const isPlaudCallback = location.pathname.includes("/plaud");
-        const provider = isZoomCallback ? "Zoom" : isPlaudCallback ? "Plaud" : "Fathom";
+        const isReadAiCallback = location.pathname.includes("/read-ai");
+        const provider = isZoomCallback
+          ? "Zoom"
+          : isPlaudCallback
+            ? "Plaud"
+            : isReadAiCallback
+              ? "Read.ai"
+              : "Fathom";
 
         setMessage(`Completing ${provider} connection...`);
         logger.info(`Processing ${provider} OAuth callback`);
@@ -67,6 +75,8 @@ export default function OAuthCallback() {
           response = await completeZoomOAuth(code, stateParam);
         } else if (isPlaudCallback) {
           response = await completePlaudOAuth(code, stateParam);
+        } else if (isReadAiCallback) {
+          response = await completeReadAiOAuth(code, stateParam);
         } else {
           response = await completeFathomOAuth(code, stateParam);
         }
@@ -85,7 +95,13 @@ export default function OAuthCallback() {
         const connectedEmail = response.data?.accountEmail;
 
         // Check if onboarding is incomplete — if so, route to setup wizard
-        const sourceParam = isZoomCallback ? "zoom" : isPlaudCallback ? "plaud" : "fathom";
+        const sourceParam = isZoomCallback
+          ? "zoom"
+          : isPlaudCallback
+            ? "plaud"
+            : isReadAiCallback
+              ? "read-ai"
+              : "fathom";
         const extraParams = [
           connectedSourceId ? `sourceId=${connectedSourceId}` : "",
           connectedEmail ? `email=${encodeURIComponent(connectedEmail)}` : "",

--- a/src/services/import-sources.service.ts
+++ b/src/services/import-sources.service.ts
@@ -330,6 +330,7 @@ export async function disconnectImportSource(sourceId: string): Promise<void> {
  * - zoom      → zoom-sync-meetings        with { singleCallId }
  * - youtube   → youtube-import            with { singleCallId }
  * - fireflies → fireflies-sync-meetings   with { singleCallId }
+ * - read-ai   → read-ai-sync-meetings     with { singleCallId }
  * - plaud     → plaud-sync-recordings     with { singleCallId }
  * - file-upload → error (user must re-upload)
  */
@@ -342,6 +343,7 @@ export async function retryFailedImport(
     zoom: "zoom-sync-meetings",
     youtube: "youtube-import",
     fireflies: "fireflies-sync-meetings",
+    "read-ai": "read-ai-sync-meetings",
     plaud: "plaud-sync-recordings",
   };
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -45,6 +45,24 @@ verify_jwt = false
 [functions.fireflies-sync-meetings]
 verify_jwt = false
 
+[functions.read-ai-oauth-url]
+verify_jwt = false
+
+[functions.read-ai-oauth-callback]
+verify_jwt = false
+
+[functions.read-ai-oauth-refresh]
+verify_jwt = false
+
+[functions.read-ai-connect-token]
+verify_jwt = false
+
+[functions.read-ai-fetch-meetings]
+verify_jwt = false
+
+[functions.read-ai-sync-meetings]
+verify_jwt = false
+
 
 [functions.youtube-import]
 verify_jwt = false

--- a/supabase/functions/_shared/__tests__/read-ai-connector.test.ts
+++ b/supabase/functions/_shared/__tests__/read-ai-connector.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clampReadAiLimit,
+  listMeetings,
+} from "../read-ai-client";
+import {
+  readAiMeetingToCanonical,
+  type ReadAiMeeting,
+} from "../read-ai-connector";
+
+describe("read-ai connector", () => {
+  const meeting: ReadAiMeeting = {
+    id: "01HFYH0A6JM4R7MZ2E6X5T9BNP",
+    title: "Weekly status sync",
+    start_time_ms: 1_733_800_000_000,
+    end_time_ms: 1_733_803_600_000,
+    report_url: "https://app.read.ai/analytics/meetings/01HFYH0A6JM4R7MZ2E6X5T9BNP",
+    platform: "zoom",
+    platform_id: "987654321",
+    owner: { name: "Alice Example", email: "alice@example.com" },
+    participants: [
+      { name: "Alice Example", email: "alice@example.com", invited: true, attended: true },
+      { name: "Bob Example", email: "bob@example.com", invited: true, attended: true },
+    ],
+    summary: "We reviewed project timelines.",
+    topics: ["Roadmap"],
+    action_items: [{ text: "Send launch notes", assignee: { name: "Bob Example" } }],
+    metrics: { read_score: 0.9 },
+    transcript: {
+      turns: [
+        {
+          speaker: { name: "Alice Example", email: "alice@example.com" },
+          text: "Let's start with project updates.",
+          start_time_ms: 1_733_800_000_000,
+          end_time_ms: 1_733_800_005_000,
+        },
+        {
+          speaker: { name: "Bob Example", email: "bob@example.com" },
+          text: "The import connector is ready.",
+          start_time_ms: 1_733_800_012_000,
+          end_time_ms: 1_733_800_018_000,
+        },
+      ],
+    },
+  };
+
+  it("normalizes Read.ai API meetings into canonical recordings", () => {
+    const canonical = readAiMeetingToCanonical(meeting);
+
+    expect(canonical).toMatchObject({
+      externalId: "01HFYH0A6JM4R7MZ2E6X5T9BNP",
+      sourceApp: "read-ai",
+      title: "Weekly status sync",
+      recordingStartTime: "2024-12-10T03:06:40.000Z",
+      recordingEndTime: "2024-12-10T04:06:40.000Z",
+      durationSeconds: 3600,
+      sourceUrl: "https://app.read.ai/analytics/meetings/01HFYH0A6JM4R7MZ2E6X5T9BNP",
+      recordedByEmail: "alice@example.com",
+      participantEmails: ["alice@example.com", "bob@example.com"],
+    });
+    expect(canonical.fullTranscript).toBe(
+      "[0:00] Alice Example: Let's start with project updates.\n\n[0:12] Bob Example: The import connector is ready.",
+    );
+    expect(canonical.summary).toContain("We reviewed project timelines.");
+    expect(canonical.summary).toContain("- Send launch notes");
+    expect(canonical.sourceMetadata).toMatchObject({
+      read_ai_meeting_id: "01HFYH0A6JM4R7MZ2E6X5T9BNP",
+      read_ai_platform: "zoom",
+      read_ai_action_items: ["Send launch notes (assignee: Bob Example)"],
+      read_ai_topics: ["Roadmap"],
+      read_ai_metrics: { read_score: 0.9 },
+    });
+  });
+
+  it("normalizes webhook-style speaker_blocks", () => {
+    const canonical = readAiMeetingToCanonical({
+      id: "01WEBHOOK",
+      title: "Webhook payload",
+      start_time_ms: 1_733_800_000_000,
+      transcript: {
+        speaker_blocks: [
+          {
+            speaker_name: "Speaker One",
+            words: [{ text: "Hello" }, { text: "there." }],
+            start_time_ms: 1_733_800_003_000,
+          },
+        ],
+      },
+    });
+
+    expect(canonical.fullTranscript).toBe("[0:03] Speaker One: Hello there.");
+  });
+
+  it("throws for meetings without transcript text", () => {
+    expect(() =>
+      readAiMeetingToCanonical({
+        id: "01EMPTY",
+        title: "Empty",
+        start_time_ms: 1_733_800_000_000,
+        transcript: { turns: [] },
+      }),
+    ).toThrow(/no transcript text/);
+  });
+});
+
+describe("read-ai client", () => {
+  it("uses bearer auth, date filters, clamped limit, and cursor pagination", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ object: "list", has_more: true, data: [] }), {
+          status: 200,
+        }),
+    ) as unknown as typeof fetch;
+
+    await listMeetings({
+      token: "secret-token",
+      limit: 50,
+      cursor: "01LAST",
+      startTimeMsGte: 1_733_800_000_000,
+      startTimeMsLte: 1_733_900_000_000,
+      expand: ["transcript", "summary"],
+      fetchImpl,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).toContain("https://api.read.ai/v1/meetings");
+    expect(String(url)).toContain("limit=10");
+    expect(String(url)).toContain("cursor=01LAST");
+    expect(String(url)).toContain("start_time_ms.gte=1733800000000");
+    expect(String(url)).toContain("start_time_ms.lte=1733900000000");
+    expect(String(url)).toContain("expand%5B%5D=transcript");
+    expect(String(url)).toContain("expand%5B%5D=summary");
+    expect(init).toMatchObject({
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer secret-token",
+      },
+    });
+  });
+
+  it("clamps list limits to Read.ai's documented maximum", () => {
+    expect(clampReadAiLimit(0)).toBe(1);
+    expect(clampReadAiLimit(8)).toBe(8);
+    expect(clampReadAiLimit(100)).toBe(10);
+  });
+});

--- a/supabase/functions/_shared/__tests__/read-ai-source.test.ts
+++ b/supabase/functions/_shared/__tests__/read-ai-source.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveReadAiSource } from "../read-ai-source";
+
+function createSourceQuery(result: unknown) {
+  const query = {
+    from: vi.fn(() => query),
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    maybeSingle: vi.fn(async () => result),
+  };
+  return query;
+}
+
+describe("resolveReadAiSource", () => {
+  it("scopes caller-provided source ids to the user's Read.ai sources", async () => {
+    const query = createSourceQuery({ data: { id: "source-1" }, error: null });
+
+    await expect(resolveReadAiSource(query, "user-1", "source-1")).resolves.toEqual({ id: "source-1" });
+
+    expect(query.from).toHaveBeenCalledWith("import_sources");
+    expect(query.select).toHaveBeenCalledWith("id");
+    expect(query.eq).toHaveBeenCalledWith("user_id", "user-1");
+    expect(query.eq).toHaveBeenCalledWith("source_app", "read-ai");
+    expect(query.eq).toHaveBeenCalledWith("id", "source-1");
+  });
+
+  it("selects the latest active Read.ai source when no source id is provided", async () => {
+    const query = createSourceQuery({ data: { id: "source-2" }, error: null });
+
+    await expect(resolveReadAiSource(query, "user-1", null)).resolves.toEqual({ id: "source-2" });
+
+    expect(query.eq).toHaveBeenCalledWith("is_active", true);
+    expect(query.order).toHaveBeenCalledWith("updated_at", { ascending: false });
+    expect(query.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("surfaces lookup errors instead of treating them as disconnected", async () => {
+    const query = createSourceQuery({ data: null, error: new Error("database unavailable") });
+
+    await expect(resolveReadAiSource(query, "user-1", "source-1")).rejects.toThrow("database unavailable");
+  });
+});

--- a/supabase/functions/_shared/read-ai-client.ts
+++ b/supabase/functions/_shared/read-ai-client.ts
@@ -1,0 +1,231 @@
+export const READ_AI_API_BASE = "https://api.read.ai";
+export const READ_AI_TOKEN_URL = "https://authn.read.ai/oauth2/token";
+export const READ_AI_AUTHORIZE_URL = "https://api.read.ai/oauth/ui";
+
+export interface ReadAiTokenResponse {
+  access_token: string;
+  refresh_token?: string | null;
+  expires_in?: number | null;
+  id_token?: string | null;
+  scope?: string | null;
+  token_type?: string | null;
+}
+
+export interface ReadAiListMeetingsParams {
+  token: string;
+  limit?: number;
+  cursor?: string | null;
+  startTimeMsGte?: number | null;
+  startTimeMsLte?: number | null;
+  expand?: string[];
+  fetchImpl?: typeof fetch;
+}
+
+export interface ReadAiListResponse<T> {
+  object?: string;
+  url?: string;
+  has_more?: boolean;
+  data?: T[];
+}
+
+export interface ReadAiClientOptions {
+  accessToken?: string;
+  apiBase?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class ReadAiClient {
+  private readonly accessToken: string;
+  private readonly apiBase: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ReadAiClientOptions = {}) {
+    this.accessToken = options.accessToken ?? "";
+    this.apiBase = normalizeBaseUrl(options.apiBase ?? Deno.env.get("READAI_API_BASE") ?? READ_AI_API_BASE);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  static authorizationUrl(): string {
+    return Deno.env.get("READAI_OAUTH_AUTHORIZE_URL") ?? READ_AI_AUTHORIZE_URL;
+  }
+
+  static tokenUrl(): string {
+    return Deno.env.get("READAI_OAUTH_TOKEN_URL") ?? READ_AI_TOKEN_URL;
+  }
+
+  static buildAuthorizationUrl(params: {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    scope?: string;
+  }): string {
+    const url = new URL(ReadAiClient.authorizationUrl());
+    url.searchParams.set("client_id", params.clientId);
+    url.searchParams.set("redirect_uri", params.redirectUri);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("state", params.state);
+    url.searchParams.set("scope", params.scope ?? "openid email offline_access profile meeting:read");
+    return url.toString();
+  }
+
+  static async exchangeCodeForTokens(params: {
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    redirectUri: string;
+    codeVerifier?: string | null;
+    fetchImpl?: typeof fetch;
+  }): Promise<ReadAiTokenResponse> {
+    const fetchImpl = params.fetchImpl ?? fetch;
+    const body = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: params.code,
+      redirect_uri: params.redirectUri,
+    });
+    if (params.codeVerifier) body.set("code_verifier", params.codeVerifier);
+
+    const response = await fetchImpl(ReadAiClient.tokenUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        Authorization: `Basic ${btoa(`${params.clientId}:${params.clientSecret}`)}`,
+      },
+      body,
+    });
+
+    return await parseJsonResponse<ReadAiTokenResponse>(response, "Read.ai token exchange failed");
+  }
+
+  static async refreshTokens(params: {
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    fetchImpl?: typeof fetch;
+  }): Promise<ReadAiTokenResponse> {
+    const fetchImpl = params.fetchImpl ?? fetch;
+    const response = await fetchImpl(ReadAiClient.tokenUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        Authorization: `Basic ${btoa(`${params.clientId}:${params.clientSecret}`)}`,
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: params.refreshToken,
+      }),
+    });
+
+    return await parseJsonResponse<ReadAiTokenResponse>(response, "Read.ai token refresh failed");
+  }
+
+  async listMeetings(params: Omit<ReadAiListMeetingsParams, "token" | "fetchImpl"> = {}) {
+    return await listMeetings({
+      ...params,
+      token: this.accessToken,
+      fetchImpl: this.fetchImpl,
+    });
+  }
+
+  async getMeeting<T = unknown>(id: string, expand: string[] = []) {
+    return await getMeeting<T>(this.accessToken, id, expand, this.fetchImpl, this.apiBase);
+  }
+
+  async testToken() {
+    const response = await this.fetchImpl(`${this.apiBase}/oauth/test-token-with-scopes`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+    return await parseJsonResponse<unknown>(response, "Read.ai token test failed");
+  }
+}
+
+export async function listMeetings<T = unknown>(params: ReadAiListMeetingsParams): Promise<ReadAiListResponse<T>> {
+  const token = params.token.trim().replace(/^Bearer\s+/i, "");
+  if (!token) throw new Error("Read.ai access token is required");
+
+  const url = new URL(`${READ_AI_API_BASE}/v1/meetings`);
+  url.searchParams.set("limit", String(clampReadAiLimit(params.limit)));
+  if (params.cursor) url.searchParams.set("cursor", params.cursor);
+  if (params.startTimeMsGte != null) url.searchParams.set("start_time_ms.gte", String(params.startTimeMsGte));
+  if (params.startTimeMsLte != null) url.searchParams.set("start_time_ms.lte", String(params.startTimeMsLte));
+  for (const item of params.expand ?? []) {
+    url.searchParams.append("expand[]", item);
+  }
+
+  const response = await (params.fetchImpl ?? fetch)(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await parseJsonResponse<ReadAiListResponse<T>>(response, "Read.ai list meetings failed");
+}
+
+export async function getMeeting<T = unknown>(
+  token: string,
+  id: string,
+  expand: string[] = [],
+  fetchImpl: typeof fetch = fetch,
+  apiBase = READ_AI_API_BASE,
+): Promise<T> {
+  const cleanToken = token.trim().replace(/^Bearer\s+/i, "");
+  if (!cleanToken) throw new Error("Read.ai access token is required");
+  if (!id.trim()) throw new Error("Read.ai meeting id is required");
+
+  const url = new URL(`${normalizeBaseUrl(apiBase)}/v1/meetings/${encodeURIComponent(id)}`);
+  for (const item of expand) {
+    url.searchParams.append("expand[]", item);
+  }
+
+  const response = await fetchImpl(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${cleanToken}`,
+    },
+  });
+  return await parseJsonResponse<T>(response, "Read.ai retrieve meeting failed");
+}
+
+export async function parseJsonResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const text = await response.text();
+  let payload: unknown = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  if (!response.ok) {
+    const message = extractErrorMessage(payload) ?? `${fallbackMessage} with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+export function clampReadAiLimit(limit: number | null | undefined): number {
+  if (limit == null || !Number.isFinite(limit)) return 10;
+  return Math.min(Math.max(Math.floor(limit), 1), 10);
+}
+
+function extractErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.error === "string") return record.error;
+  if (typeof record.message === "string") return record.message;
+  if (record.error && typeof record.error === "object") {
+    const nested = record.error as Record<string, unknown>;
+    if (typeof nested.message === "string") return nested.message;
+  }
+  return null;
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}

--- a/supabase/functions/_shared/read-ai-connector.ts
+++ b/supabase/functions/_shared/read-ai-connector.ts
@@ -1,0 +1,243 @@
+import {
+  formatCanonicalTranscript,
+  normalizeEmailList,
+  type CanonicalRecording,
+  type CanonicalTranscriptTurn,
+} from "./canonical-recording.ts";
+
+export interface ReadAiParticipant {
+  name?: string | null;
+  email?: string | null;
+  invited?: boolean | null;
+  attended?: boolean | null;
+}
+
+export interface ReadAiPerson {
+  name?: string | null;
+  email?: string | null;
+}
+
+export interface ReadAiTranscriptTurn {
+  speaker?: ReadAiPerson | string | null;
+  text?: string | null;
+  start_time_ms?: number | null;
+  end_time_ms?: number | null;
+}
+
+export interface ReadAiSpeakerBlock {
+  speaker?: ReadAiPerson | string | null;
+  speaker_name?: string | null;
+  text?: string | null;
+  words?: Array<{ text?: string | null }> | null;
+  start_time_ms?: number | null;
+  end_time_ms?: number | null;
+}
+
+export interface ReadAiTranscript {
+  turns?: ReadAiTranscriptTurn[] | null;
+  speaker_blocks?: ReadAiSpeakerBlock[] | null;
+  text?: string | null;
+}
+
+export interface ReadAiActionItem {
+  text?: string | null;
+  description?: string | null;
+  assignee?: ReadAiPerson | string | null;
+  due_date?: string | null;
+}
+
+export interface ReadAiMeeting {
+  id: string;
+  start_time_ms?: number | null;
+  end_time_ms?: number | null;
+  scheduled_start_time_ms?: number | null;
+  scheduled_end_time_ms?: number | null;
+  participants?: ReadAiParticipant[] | null;
+  owner?: ReadAiPerson | null;
+  title?: string | null;
+  report_url?: string | null;
+  platform?: string | null;
+  platform_id?: string | null;
+  folders?: string[] | null;
+  live_enabled?: boolean | null;
+  summary?: string | Record<string, unknown> | null;
+  chapter_summaries?: unknown;
+  action_items?: Array<ReadAiActionItem | string> | string | null;
+  key_questions?: unknown;
+  topics?: string[] | string | null;
+  metrics?: Record<string, unknown> | null;
+  transcript?: ReadAiTranscript | null;
+  recording_download?: unknown;
+}
+
+export function readAiMeetingToCanonical(meeting: ReadAiMeeting): CanonicalRecording {
+  const turns = readAiTranscriptToTurns(meeting);
+  const fullTranscript = formatCanonicalTranscript(turns);
+  if (!fullTranscript.trim()) {
+    throw new Error(`Read.ai meeting ${meeting.id} has no transcript text`);
+  }
+
+  const recordingStartTime = coerceReadAiStartTime(meeting);
+  const recordingEndTime = coerceReadAiEndTime(meeting);
+  const durationSeconds = readAiDurationSeconds(meeting);
+  const participantEmails = normalizeEmailList([
+    meeting.owner?.email ?? "",
+    ...(meeting.participants ?? []).map((participant) => participant.email ?? ""),
+  ]);
+
+  return {
+    externalId: meeting.id,
+    sourceApp: "read-ai",
+    title: meeting.title?.trim() || `Read.ai meeting ${meeting.id}`,
+    fullTranscript,
+    summary: readAiSummaryMarkdown(meeting),
+    recordingStartTime,
+    recordingEndTime,
+    durationSeconds,
+    sourceUrl: meeting.report_url ?? null,
+    shareUrl: meeting.report_url ?? null,
+    recordedByName: meeting.owner?.name ?? null,
+    recordedByEmail: meeting.owner?.email ?? null,
+    participantEmails,
+    calendarInvitees: meeting.participants ?? [],
+    sourceMetadata: {
+      read_ai_meeting_id: meeting.id,
+      read_ai_report_url: meeting.report_url ?? null,
+      read_ai_platform: meeting.platform ?? null,
+      read_ai_platform_id: meeting.platform_id ?? null,
+      read_ai_folders: meeting.folders ?? [],
+      read_ai_live_enabled: Boolean(meeting.live_enabled),
+      read_ai_action_items: normalizeActionItems(meeting.action_items),
+      read_ai_topics: normalizeStringList(meeting.topics),
+      read_ai_metrics: meeting.metrics ?? null,
+    },
+    rawPayload: meeting,
+  };
+}
+
+export function readAiTranscriptToTurns(meeting: ReadAiMeeting): CanonicalTranscriptTurn[] {
+  const startMs = meeting.start_time_ms ?? meeting.scheduled_start_time_ms ?? 0;
+  const apiTurns = meeting.transcript?.turns ?? [];
+  if (apiTurns.length > 0) {
+    return apiTurns.map((turn) => ({
+      speakerName: speakerName(turn.speaker),
+      speakerEmail: speakerEmail(turn.speaker),
+      text: turn.text ?? "",
+      startSeconds: millisOffset(turn.start_time_ms, startMs),
+      endSeconds: millisOffset(turn.end_time_ms, startMs),
+    })).filter((turn) => turn.text.trim().length > 0);
+  }
+
+  const speakerBlocks = meeting.transcript?.speaker_blocks ?? [];
+  if (speakerBlocks.length > 0) {
+    return speakerBlocks.map((block) => ({
+      speakerName: block.speaker_name ?? speakerName(block.speaker),
+      speakerEmail: speakerEmail(block.speaker),
+      text: block.text ?? wordsText(block.words),
+      startSeconds: millisOffset(block.start_time_ms, startMs),
+      endSeconds: millisOffset(block.end_time_ms, startMs),
+    })).filter((turn) => turn.text.trim().length > 0);
+  }
+
+  const text = meeting.transcript?.text?.trim();
+  if (text) {
+    return [{ speakerName: "Read.ai", text, startSeconds: 0, endSeconds: null }];
+  }
+
+  return [];
+}
+
+export function coerceReadAiStartTime(meeting: ReadAiMeeting): string {
+  const value = meeting.start_time_ms ?? meeting.scheduled_start_time_ms;
+  if (value != null && Number.isFinite(value) && value > 0) {
+    return new Date(value).toISOString();
+  }
+  throw new Error(`Read.ai meeting ${meeting.id} is missing a valid start_time_ms`);
+}
+
+export function coerceReadAiEndTime(meeting: ReadAiMeeting): string | null {
+  if (meeting.end_time_ms != null && Number.isFinite(meeting.end_time_ms) && meeting.end_time_ms > 0) {
+    return new Date(meeting.end_time_ms).toISOString();
+  }
+  return null;
+}
+
+export function readAiDurationSeconds(meeting: ReadAiMeeting): number | null {
+  if (
+    meeting.start_time_ms != null &&
+    meeting.end_time_ms != null &&
+    Number.isFinite(meeting.start_time_ms) &&
+    Number.isFinite(meeting.end_time_ms) &&
+    meeting.end_time_ms >= meeting.start_time_ms
+  ) {
+    return Math.round((meeting.end_time_ms - meeting.start_time_ms) / 1000);
+  }
+  return null;
+}
+
+export function readAiSummaryMarkdown(meeting: ReadAiMeeting): string | null {
+  const sections = [
+    stringifyUnknown(meeting.summary),
+    stringifyList("Topics", normalizeStringList(meeting.topics)),
+    stringifyList("Action items", normalizeActionItems(meeting.action_items)),
+  ].filter((section): section is string => Boolean(section?.trim()));
+
+  return sections.length > 0 ? sections.join("\n\n") : null;
+}
+
+function normalizeActionItems(value: ReadAiMeeting["action_items"]): string[] {
+  if (!value) return [];
+  if (typeof value === "string") return value.trim() ? [value.trim()] : [];
+  return value.map((item) => {
+    if (typeof item === "string") return item.trim();
+    const text = item.text ?? item.description ?? "";
+    const assignee = speakerName(item.assignee);
+    const suffix = [
+      assignee ? `assignee: ${assignee}` : null,
+      item.due_date ? `due: ${item.due_date}` : null,
+    ].filter(Boolean).join(", ");
+    return suffix ? `${text} (${suffix})`.trim() : text.trim();
+  }).filter(Boolean);
+}
+
+function normalizeStringList(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value.map((item) => item.trim()).filter(Boolean);
+  if (typeof value === "string" && value.trim()) return [value.trim()];
+  return [];
+}
+
+function stringifyUnknown(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "object") {
+    const direct = ["text", "summary", "overview"]
+      .map((key) => (value as Record<string, unknown>)[key])
+      .find((candidate) => typeof candidate === "string" && candidate.trim());
+    if (typeof direct === "string") return direct.trim();
+  }
+  return null;
+}
+
+function stringifyList(label: string, items: string[]): string | null {
+  return items.length > 0 ? `${label}:\n${items.map((item) => `- ${item}`).join("\n")}` : null;
+}
+
+function speakerName(value: ReadAiPerson | string | null | undefined): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  return value?.name?.trim() || value?.email?.trim() || null;
+}
+
+function speakerEmail(value: ReadAiPerson | string | null | undefined): string | null {
+  if (!value || typeof value === "string") return null;
+  return value.email?.trim() || null;
+}
+
+function millisOffset(value: number | null | undefined, meetingStartMs: number): number | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  if (!Number.isFinite(meetingStartMs) || meetingStartMs <= 0) return value / 1000;
+  return Math.max(0, (value - meetingStartMs) / 1000);
+}
+
+function wordsText(words: Array<{ text?: string | null }> | null | undefined): string {
+  return (words ?? []).map((word) => word.text?.trim()).filter(Boolean).join(" ");
+}

--- a/supabase/functions/_shared/read-ai-source.ts
+++ b/supabase/functions/_shared/read-ai-source.ts
@@ -1,0 +1,26 @@
+export interface ReadAiSourceRecord {
+  id: string;
+  account_email?: string | null;
+  oauth_token_expires?: number | null;
+}
+
+export async function resolveReadAiSource<T extends ReadAiSourceRecord = ReadAiSourceRecord>(
+  supabase: any,
+  userId: string,
+  sourceId: string | null,
+  columns = "id",
+): Promise<T | null> {
+  let query = supabase
+    .from("import_sources")
+    .select(columns)
+    .eq("user_id", userId)
+    .eq("source_app", "read-ai");
+
+  query = sourceId
+    ? query.eq("id", sourceId)
+    : query.eq("is_active", true).order("updated_at", { ascending: false }).limit(1);
+
+  const { data, error } = await query.maybeSingle();
+  if (error) throw error;
+  return data as T | null;
+}

--- a/supabase/functions/read-ai-connect-token/__tests__/read-ai-connect-token.test.ts
+++ b/supabase/functions/read-ai-connect-token/__tests__/read-ai-connect-token.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("read-ai-connect-token wiring", () => {
+  it("validates pasted tokens against a user-owned Read.ai source before storing credentials", () => {
+    expect(source).toMatch(/resolveReadAiSource\(supabase,\s*userId,\s*sourceId\)/);
+    expect(source.indexOf("resolveSourceId")).toBeLessThan(source.indexOf("storeAccessToken"));
+  });
+
+  it("returns not found for caller-provided non-Read.ai source ids", () => {
+    expect(source).toMatch(/sourceId && !existing/);
+    expect(source).toMatch(/Read\.ai source not found\./);
+  });
+});

--- a/supabase/functions/read-ai-connect-token/index.ts
+++ b/supabase/functions/read-ai-connect-token/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { authenticateRequest } from '../_shared/auth.ts';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { ReadAiClient } from '../_shared/read-ai-client.ts';
+import { resolveReadAiSource } from '../_shared/read-ai-source.ts';
 
 interface ReadAiConnectTokenRequest {
   sourceId?: string | null;
@@ -23,7 +24,8 @@ Deno.serve(async (req) => {
     const accessToken = body.accessToken?.trim().replace(/^Bearer\s+/i, '') ?? '';
     if (!accessToken) return json({ error: 'Read.ai bearer token is required.' }, 400, corsHeaders);
 
-    const sourceId = await resolveSourceId(supabase, userId, body.sourceId ?? null);
+    const sourceId = await resolveSourceId(supabase, userId, body.sourceId ?? null, corsHeaders);
+    if (sourceId instanceof Response) return sourceId;
     await new ReadAiClient({ accessToken }).testToken();
 
     await storeAccessToken(supabase, sourceId, userId, accessToken);
@@ -50,9 +52,14 @@ Deno.serve(async (req) => {
   }
 });
 
-async function resolveSourceId(supabase: any, userId: string, sourceId: string | null): Promise<string> {
-  if (sourceId) return sourceId;
-  const { data: existing } = await supabase.from('import_sources').select('id').eq('user_id', userId).eq('source_app', 'read-ai').limit(1).maybeSingle();
+async function resolveSourceId(
+  supabase: any,
+  userId: string,
+  sourceId: string | null,
+  corsHeaders: Record<string, string>,
+): Promise<string | Response> {
+  const existing = await resolveReadAiSource(supabase, userId, sourceId);
+  if (sourceId && !existing) return json({ success: false, error: 'Read.ai source not found.' }, 404, corsHeaders);
   if (existing?.id) return existing.id;
   const { data, error } = await supabase.from('import_sources').insert({ user_id: userId, source_app: 'read-ai', is_active: false }).select('id').single();
   if (error || !data?.id) throw new Error(error?.message ?? 'Failed to create Read.ai import source');

--- a/supabase/functions/read-ai-connect-token/index.ts
+++ b/supabase/functions/read-ai-connect-token/index.ts
@@ -1,0 +1,91 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { ReadAiClient } from '../_shared/read-ai-client.ts';
+
+interface ReadAiConnectTokenRequest {
+  sourceId?: string | null;
+  accessToken?: string;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as ReadAiConnectTokenRequest;
+    const accessToken = body.accessToken?.trim().replace(/^Bearer\s+/i, '') ?? '';
+    if (!accessToken) return json({ error: 'Read.ai bearer token is required.' }, 400, corsHeaders);
+
+    const sourceId = await resolveSourceId(supabase, userId, body.sourceId ?? null);
+    await new ReadAiClient({ accessToken }).testToken();
+
+    await storeAccessToken(supabase, sourceId, userId, accessToken);
+    const { error } = await supabase
+      .from('import_sources')
+      .update({
+        account_email: null,
+        connection_metadata: {
+          auth_type: 'token_paste',
+          note: 'Manual Read.ai bearer tokens are short-lived unless paired with a refresh token.',
+        },
+        error_message: null,
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sourceId)
+      .eq('user_id', userId);
+    if (error) throw error;
+
+    return json({ success: true, sourceId, warning: 'Read.ai pasted access tokens expire quickly. OAuth is recommended.' }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Read.ai connect-token error:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function resolveSourceId(supabase: any, userId: string, sourceId: string | null): Promise<string> {
+  if (sourceId) return sourceId;
+  const { data: existing } = await supabase.from('import_sources').select('id').eq('user_id', userId).eq('source_app', 'read-ai').limit(1).maybeSingle();
+  if (existing?.id) return existing.id;
+  const { data, error } = await supabase.from('import_sources').insert({ user_id: userId, source_app: 'read-ai', is_active: false }).select('id').single();
+  if (error || !data?.id) throw new Error(error?.message ?? 'Failed to create Read.ai import source');
+  return data.id;
+}
+
+async function storeAccessToken(supabase: any, sourceId: string, userId: string, accessToken: string) {
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  const expiresAt = Date.now() + 10 * 60 * 1000;
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: accessToken,
+      p_refresh_token: null,
+      p_token_expires: expiresAt,
+      p_encryption_key: encryptionKey,
+      p_is_active: true,
+    });
+    if (error) throw error;
+    return;
+  }
+
+  const { error } = await supabase.from('import_sources').update({
+    oauth_access_token: accessToken,
+    oauth_refresh_token: null,
+    oauth_token_expires: expiresAt,
+    is_active: true,
+    updated_at: new Date().toISOString(),
+  }).eq('id', sourceId).eq('user_id', userId);
+  if (error) throw error;
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/read-ai-fetch-meetings/index.ts
+++ b/supabase/functions/read-ai-fetch-meetings/index.ts
@@ -4,6 +4,7 @@ import { getCorsHeaders } from '../_shared/cors.ts';
 import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
 import { clampReadAiLimit, listMeetings, ReadAiClient } from '../_shared/read-ai-client.ts';
 import { coerceReadAiStartTime, readAiDurationSeconds, type ReadAiMeeting } from '../_shared/read-ai-connector.ts';
+import { resolveReadAiSource } from '../_shared/read-ai-source.ts';
 
 interface ReadAiFetchMeetingsRequest {
   sourceId?: string | null;
@@ -64,10 +65,7 @@ interface SourceRecord {
 }
 
 async function resolveSource(supabase: any, userId: string, sourceId: string | null): Promise<SourceRecord | null> {
-  let query = supabase.from('import_sources').select('id, account_email, oauth_token_expires').eq('user_id', userId).eq('source_app', 'read-ai');
-  query = sourceId ? query.eq('id', sourceId) : query.eq('is_active', true).order('updated_at', { ascending: false }).limit(1);
-  const { data } = await query.maybeSingle();
-  return data;
+  return await resolveReadAiSource<SourceRecord>(supabase, userId, sourceId, 'id, account_email, oauth_token_expires');
 }
 
 async function resolveAccessToken(supabase: any, source: SourceRecord, userId: string): Promise<string> {

--- a/supabase/functions/read-ai-fetch-meetings/index.ts
+++ b/supabase/functions/read-ai-fetch-meetings/index.ts
@@ -1,0 +1,139 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
+import { clampReadAiLimit, listMeetings, ReadAiClient } from '../_shared/read-ai-client.ts';
+import { coerceReadAiStartTime, readAiDurationSeconds, type ReadAiMeeting } from '../_shared/read-ai-connector.ts';
+
+interface ReadAiFetchMeetingsRequest {
+  sourceId?: string | null;
+  createdAfter?: string | null;
+  createdBefore?: string | null;
+  dateStart?: string | null;
+  dateEnd?: string | null;
+  cursor?: string | null;
+  limit?: number;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as ReadAiFetchMeetingsRequest;
+    const source = await resolveSource(supabase, userId, body.sourceId ?? null);
+    if (!source) return json({ error: 'Read.ai is not connected. Connect Read.ai first.' }, 400, corsHeaders);
+
+    const accessToken = await resolveAccessToken(supabase, source, userId);
+    const start = body.createdAfter ?? body.dateStart ?? null;
+    const end = body.createdBefore ?? body.dateEnd ?? null;
+    const response = await listMeetings<ReadAiMeeting>({
+      token: accessToken,
+      limit: clampReadAiLimit(body.limit),
+      cursor: body.cursor ?? null,
+      startTimeMsGte: start ? Date.parse(start) : null,
+      startTimeMsLte: end ? Date.parse(end) : null,
+      fetchImpl: fetch,
+    });
+    const meetings = response.data ?? [];
+    const ids = meetings.map((meeting) => meeting.id).filter(Boolean);
+    const syncedIds = await fetchSyncedIds(supabase, userId, ids);
+
+    return json({
+      meetings: meetings.map((meeting) => mapMeeting(meeting, syncedIds)),
+      nextCursor: response.has_more && meetings.length > 0 ? meetings[meetings.length - 1].id : null,
+      sourceId: source.id,
+      accountEmail: source.account_email ?? null,
+    }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Error fetching Read.ai meetings:', error);
+    return json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+interface SourceRecord {
+  id: string;
+  account_email: string | null;
+  oauth_token_expires: number | null;
+}
+
+async function resolveSource(supabase: any, userId: string, sourceId: string | null): Promise<SourceRecord | null> {
+  let query = supabase.from('import_sources').select('id, account_email, oauth_token_expires').eq('user_id', userId).eq('source_app', 'read-ai');
+  query = sourceId ? query.eq('id', sourceId) : query.eq('is_active', true).order('updated_at', { ascending: false }).limit(1);
+  const { data } = await query.maybeSingle();
+  return data;
+}
+
+async function resolveAccessToken(supabase: any, source: SourceRecord, userId: string): Promise<string> {
+  const tokens = await getDecryptedOAuthTokens(supabase, source.id, userId);
+  if (!tokens.access_token) throw new Error('Read.ai access token is missing. Reconnect Read.ai.');
+  if (tokens.token_expires && tokens.token_expires < Date.now() + 30_000) {
+    if (!tokens.refresh_token) throw new Error('Read.ai token expired. Reconnect Read.ai with OAuth.');
+    return await refreshReadAiTokens(supabase, source.id, userId, tokens.refresh_token);
+  }
+  return tokens.access_token;
+}
+
+async function refreshReadAiTokens(supabase: any, sourceId: string, userId: string, refreshToken: string): Promise<string> {
+  const clientId = Deno.env.get('READAI_OAUTH_CLIENT_ID');
+  const clientSecret = Deno.env.get('READAI_OAUTH_CLIENT_SECRET');
+  if (!clientId || !clientSecret) throw new Error('Read.ai OAuth is not configured.');
+  const refreshed = await ReadAiClient.refreshTokens({ clientId, clientSecret, refreshToken });
+  const expiresAt = refreshed.expires_in ? Date.now() + refreshed.expires_in * 1000 : null;
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: refreshed.access_token,
+      p_refresh_token: refreshed.refresh_token ?? refreshToken,
+      p_token_expires: expiresAt,
+      p_encryption_key: encryptionKey,
+      p_is_active: true,
+    });
+    if (error) throw error;
+  } else {
+    const { error } = await supabase.from('import_sources').update({ oauth_access_token: refreshed.access_token, oauth_refresh_token: refreshed.refresh_token ?? refreshToken, oauth_token_expires: expiresAt, updated_at: new Date().toISOString() }).eq('id', sourceId).eq('user_id', userId);
+    if (error) throw error;
+  }
+  return refreshed.access_token;
+}
+
+async function fetchSyncedIds(supabase: any, userId: string, ids: string[]): Promise<Set<string>> {
+  if (ids.length === 0) return new Set();
+  const { data, error } = await supabase.from('recordings').select('source_call_id').eq('owner_user_id', userId).eq('source_app', 'read-ai').in('source_call_id', ids);
+  if (error) throw error;
+  return new Set((data ?? []).map((row: { source_call_id?: string | null }) => row.source_call_id).filter(Boolean));
+}
+
+function mapMeeting(meeting: ReadAiMeeting, syncedIds: Set<string>) {
+  let start: string | null = null;
+  try {
+    start = coerceReadAiStartTime(meeting);
+  } catch {
+    start = null;
+  }
+  return {
+    recording_id: meeting.id,
+    title: meeting.title?.trim() || `Read.ai meeting ${meeting.id}`,
+    created_at: start,
+    recording_start_time: start,
+    recording_end_time: meeting.end_time_ms ? new Date(meeting.end_time_ms).toISOString() : null,
+    duration: readAiDurationSeconds(meeting),
+    synced: syncedIds.has(meeting.id),
+    importable: Boolean(meeting.end_time_ms),
+    calendar_invitees: (meeting.participants ?? []).map((participant) => ({ name: participant.name ?? null, email: participant.email ?? null })),
+    source_url: meeting.report_url ?? null,
+    share_url: meeting.report_url ?? null,
+  };
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/read-ai-oauth-callback/__tests__/read-ai-oauth-callback.test.ts
+++ b/supabase/functions/read-ai-oauth-callback/__tests__/read-ai-oauth-callback.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("read-ai-oauth-callback wiring", () => {
+  it("validates the pending source is owned by the user and is a Read.ai source before storing tokens", () => {
+    expect(source).toMatch(/resolveReadAiSource\(supabase,\s*userId,\s*sourceId\)/);
+    expect(source.indexOf("resolveReadAiSource")).toBeLessThan(source.indexOf("storeTokens"));
+  });
+
+  it("checks state clearing and source activation failures", () => {
+    expect(source).toMatch(/settingsClearError/);
+    expect(source).toMatch(/sourceUpdateError/);
+    expect(source).toMatch(/Read\.ai connected, but activating the source failed/);
+  });
+
+  it("starts initial Read.ai sync after successful connection", () => {
+    expect(source).toMatch(/supabase\.functions\.invoke\('read-ai-sync-meetings'/);
+    expect(source).toMatch(/body:\s*\{\s*sourceId\s*\}/);
+  });
+});

--- a/supabase/functions/read-ai-oauth-callback/index.ts
+++ b/supabase/functions/read-ai-oauth-callback/index.ts
@@ -1,0 +1,153 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { ReadAiClient } from '../_shared/read-ai-client.ts';
+
+interface ReadAiOAuthCallbackRequest {
+  code?: string;
+  state?: string;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const { code, state } = await req.json() as ReadAiOAuthCallbackRequest;
+    if (!code || !state) return json({ error: 'Missing code or state' }, 400, corsHeaders);
+
+    const { data: settings } = await supabase
+      .from('user_settings')
+      .select('oauth_state, pending_import_source_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (!settings?.oauth_state || settings.oauth_state !== `read-ai:${state}`) {
+      return json({ error: 'Invalid state parameter' }, 400, corsHeaders);
+    }
+    const sourceId = settings.pending_import_source_id;
+    if (!sourceId) return json({ error: 'No pending import source found. Please connect Read.ai again.' }, 400, corsHeaders);
+
+    const clientId = Deno.env.get('READAI_OAUTH_CLIENT_ID');
+    const clientSecret = Deno.env.get('READAI_OAUTH_CLIENT_SECRET');
+    const redirectUri = Deno.env.get('READAI_OAUTH_REDIRECT_URI')
+      || `${Deno.env.get('SITE_URL') || 'https://app.callvaultai.com'}/oauth/callback/read-ai`;
+    if (!clientId || !clientSecret) {
+      return json({ error: 'Read.ai OAuth is not configured. Set READAI_OAUTH_CLIENT_ID and READAI_OAUTH_CLIENT_SECRET.' }, 500, corsHeaders);
+    }
+
+    const tokens = await ReadAiClient.exchangeCodeForTokens({ clientId, clientSecret, code, redirectUri });
+    const expiresAt = tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null;
+    await storeTokens(supabase, sourceId, userId, tokens.access_token, tokens.refresh_token ?? null, expiresAt, true);
+
+    await supabase
+      .from('user_settings')
+      .update({ oauth_state: null, pending_import_source_id: null })
+      .eq('user_id', userId);
+
+    let accountEmail: string | null = extractEmailFromJwt(tokens.id_token);
+    try {
+      await new ReadAiClient({ accessToken: tokens.access_token }).testToken();
+    } catch (error) {
+      console.warn('Read.ai token test failed after OAuth callback:', error);
+    }
+
+    await supabase
+      .from('import_sources')
+      .update({
+        account_email: accountEmail,
+        connection_metadata: { auth_type: 'oauth', scope: tokens.scope ?? null },
+        error_message: null,
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sourceId)
+      .eq('user_id', userId);
+
+    const authHeaderForward = req.headers.get('Authorization') || '';
+    const syncTask = supabase.functions.invoke('read-ai-sync-meetings', {
+      body: { sourceId },
+      headers: { Authorization: authHeaderForward, 'Content-Type': 'application/json' },
+    }).then((result: { error?: unknown }) => {
+      if (result.error) console.error('[read-ai-oauth-callback] initial sync invoke error:', result.error);
+    }).catch((error: unknown) => console.error('[read-ai-oauth-callback] initial sync invoke threw:', error));
+
+    // @ts-expect-error EdgeRuntime is available in Supabase Edge Functions.
+    EdgeRuntime.waitUntil(syncTask);
+
+    return json({
+      success: true,
+      message: 'Successfully connected to Read.ai. Your meetings are syncing in the background.',
+      sourceId,
+      accountEmail,
+      backfillTriggered: true,
+    }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Read.ai OAuth callback error:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function storeTokens(
+  supabase: any,
+  sourceId: string,
+  userId: string,
+  accessToken: string,
+  refreshToken: string | null,
+  tokenExpires: number | null,
+  isActive: boolean,
+) {
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: accessToken,
+      p_refresh_token: refreshToken,
+      p_token_expires: tokenExpires,
+      p_encryption_key: encryptionKey,
+      p_is_active: isActive,
+    });
+    if (error) throw error;
+    return;
+  }
+
+  const { error } = await supabase
+    .from('import_sources')
+    .update({
+      oauth_access_token: accessToken,
+      oauth_refresh_token: refreshToken,
+      oauth_token_expires: tokenExpires,
+      is_active: isActive,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', sourceId)
+    .eq('user_id', userId);
+  if (error) throw error;
+}
+
+function extractEmailFromJwt(jwt: string | null | undefined): string | null {
+  if (!jwt) return null;
+  try {
+    const payload = JSON.parse(atob(jwt.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'))) as Record<string, unknown>;
+    return typeof payload.email === 'string' && payload.email.includes('@') ? payload.email : null;
+  } catch {
+    return null;
+  }
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/read-ai-oauth-callback/index.ts
+++ b/supabase/functions/read-ai-oauth-callback/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { authenticateRequest } from '../_shared/auth.ts';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { ReadAiClient } from '../_shared/read-ai-client.ts';
+import { resolveReadAiSource } from '../_shared/read-ai-source.ts';
 
 interface ReadAiOAuthCallbackRequest {
   code?: string;
@@ -25,17 +26,20 @@ Deno.serve(async (req) => {
     const { code, state } = await req.json() as ReadAiOAuthCallbackRequest;
     if (!code || !state) return json({ error: 'Missing code or state' }, 400, corsHeaders);
 
-    const { data: settings } = await supabase
+    const { data: settings, error: settingsError } = await supabase
       .from('user_settings')
       .select('oauth_state, pending_import_source_id')
       .eq('user_id', userId)
       .maybeSingle();
+    if (settingsError) throw settingsError;
 
     if (!settings?.oauth_state || settings.oauth_state !== `read-ai:${state}`) {
       return json({ error: 'Invalid state parameter' }, 400, corsHeaders);
     }
     const sourceId = settings.pending_import_source_id;
     if (!sourceId) return json({ error: 'No pending import source found. Please connect Read.ai again.' }, 400, corsHeaders);
+    const source = await resolveReadAiSource(supabase, userId, sourceId);
+    if (!source) return json({ error: 'Pending Read.ai source was not found. Please connect Read.ai again.' }, 400, corsHeaders);
 
     const clientId = Deno.env.get('READAI_OAUTH_CLIENT_ID');
     const clientSecret = Deno.env.get('READAI_OAUTH_CLIENT_SECRET');
@@ -49,10 +53,11 @@ Deno.serve(async (req) => {
     const expiresAt = tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null;
     await storeTokens(supabase, sourceId, userId, tokens.access_token, tokens.refresh_token ?? null, expiresAt, true);
 
-    await supabase
+    const { error: settingsClearError } = await supabase
       .from('user_settings')
       .update({ oauth_state: null, pending_import_source_id: null })
       .eq('user_id', userId);
+    if (settingsClearError) throw settingsClearError;
 
     let accountEmail: string | null = extractEmailFromJwt(tokens.id_token);
     try {
@@ -61,7 +66,7 @@ Deno.serve(async (req) => {
       console.warn('Read.ai token test failed after OAuth callback:', error);
     }
 
-    await supabase
+    const { error: sourceUpdateError } = await supabase
       .from('import_sources')
       .update({
         account_email: accountEmail,
@@ -72,6 +77,10 @@ Deno.serve(async (req) => {
       })
       .eq('id', sourceId)
       .eq('user_id', userId);
+    if (sourceUpdateError) {
+      console.error('Failed to activate Read.ai source after OAuth:', { userId, sourceId, error: sourceUpdateError });
+      throw new Error('Read.ai connected, but activating the source failed. Try reconnecting.');
+    }
 
     const authHeaderForward = req.headers.get('Authorization') || '';
     const syncTask = supabase.functions.invoke('read-ai-sync-meetings', {

--- a/supabase/functions/read-ai-oauth-refresh/index.ts
+++ b/supabase/functions/read-ai-oauth-refresh/index.ts
@@ -1,0 +1,87 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
+import { ReadAiClient } from '../_shared/read-ai-client.ts';
+
+interface ReadAiRefreshRequest {
+  sourceId?: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+    const body = await req.json().catch(() => ({})) as ReadAiRefreshRequest;
+
+    const source = await resolveSource(supabase, userId, body.sourceId ?? null);
+    if (!source) return json({ error: 'Read.ai is not connected.' }, 400, corsHeaders);
+
+    const tokens = await getDecryptedOAuthTokens(supabase as any, source.id, userId);
+    if (!tokens.refresh_token) {
+      await markSourceError(supabase, source.id, userId, 'Read.ai refresh token is missing. Reconnect Read.ai.');
+      return json({ error: 'Read.ai refresh token is missing. Reconnect Read.ai.' }, 400, corsHeaders);
+    }
+
+    const clientId = Deno.env.get('READAI_OAUTH_CLIENT_ID');
+    const clientSecret = Deno.env.get('READAI_OAUTH_CLIENT_SECRET');
+    if (!clientId || !clientSecret) {
+      return json({ error: 'Read.ai OAuth is not configured.' }, 500, corsHeaders);
+    }
+
+    const refreshed = await ReadAiClient.refreshTokens({ clientId, clientSecret, refreshToken: tokens.refresh_token });
+    const expiresAt = refreshed.expires_in ? Date.now() + refreshed.expires_in * 1000 : null;
+    await storeTokens(supabase, source.id, userId, refreshed.access_token, refreshed.refresh_token ?? tokens.refresh_token, expiresAt);
+    await markSourceError(supabase, source.id, userId, null);
+
+    return json({ success: true, sourceId: source.id, accessTokenExpires: expiresAt }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Read.ai token refresh error:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function resolveSource(supabase: any, userId: string, sourceId: string | null) {
+  let query = supabase.from('import_sources').select('id').eq('user_id', userId).eq('source_app', 'read-ai');
+  query = sourceId ? query.eq('id', sourceId) : query.eq('is_active', true).order('updated_at', { ascending: false }).limit(1);
+  const { data } = await query.maybeSingle();
+  return data as { id: string } | null;
+}
+
+async function storeTokens(supabase: any, sourceId: string, userId: string, accessToken: string, refreshToken: string, tokenExpires: number | null) {
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: accessToken,
+      p_refresh_token: refreshToken,
+      p_token_expires: tokenExpires,
+      p_encryption_key: encryptionKey,
+      p_is_active: true,
+    });
+    if (error) throw error;
+  } else {
+    const { error } = await supabase
+      .from('import_sources')
+      .update({ oauth_access_token: accessToken, oauth_refresh_token: refreshToken, oauth_token_expires: tokenExpires, is_active: true, updated_at: new Date().toISOString() })
+      .eq('id', sourceId)
+      .eq('user_id', userId);
+    if (error) throw error;
+  }
+}
+
+async function markSourceError(supabase: any, sourceId: string, userId: string, errorMessage: string | null) {
+  await supabase.from('import_sources').update({ error_message: errorMessage, updated_at: new Date().toISOString() }).eq('id', sourceId).eq('user_id', userId);
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/read-ai-oauth-url/__tests__/read-ai-oauth-url.test.ts
+++ b/supabase/functions/read-ai-oauth-url/__tests__/read-ai-oauth-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("read-ai-oauth-url wiring", () => {
+  it("validates caller-provided source ids before persisting OAuth state", () => {
+    expect(source).toMatch(/resolveReadAiSource\(supabase,\s*userId,\s*requestedSourceId\)/);
+    expect(source.indexOf("resolveReadAiSource")).toBeLessThan(source.indexOf("pending_import_source_id"));
+  });
+
+  it("returns a startup error when OAuth state persistence fails", () => {
+    expect(source).toMatch(/settingsError/);
+    expect(source).toMatch(/Failed to start Read\.ai OAuth\. Try again\./);
+  });
+});

--- a/supabase/functions/read-ai-oauth-url/index.ts
+++ b/supabase/functions/read-ai-oauth-url/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { authenticateRequest } from '../_shared/auth.ts';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { ReadAiClient } from '../_shared/read-ai-client.ts';
+import { resolveReadAiSource } from '../_shared/read-ai-source.ts';
 
 interface ReadAiOAuthUrlRequest {
   sourceId?: string | null;
@@ -30,8 +31,12 @@ Deno.serve(async (req) => {
       return json({ success: false, error: 'Read.ai OAuth is not configured. Set READAI_OAUTH_CLIENT_ID.' }, 500, corsHeaders);
     }
 
-    let sourceId = body.sourceId ?? null;
-    if (!sourceId) {
+    const requestedSourceId = body.sourceId ?? null;
+    let sourceId = requestedSourceId;
+    if (requestedSourceId) {
+      const source = await resolveReadAiSource(supabase, userId, requestedSourceId);
+      if (!source) return json({ success: false, error: 'Read.ai source not found.' }, 404, corsHeaders);
+    } else {
       const { data, error } = await supabase
         .from('import_sources')
         .insert({
@@ -47,13 +52,17 @@ Deno.serve(async (req) => {
     }
 
     const state = crypto.randomUUID();
-    await supabase
+    const { error: settingsError } = await supabase
       .from('user_settings')
       .upsert({
         user_id: userId,
         oauth_state: `read-ai:${state}`,
         pending_import_source_id: sourceId,
       }, { onConflict: 'user_id' });
+    if (settingsError) {
+      console.error('Failed to persist Read.ai OAuth state:', { userId, sourceId, error: settingsError });
+      return json({ success: false, error: 'Failed to start Read.ai OAuth. Try again.' }, 500, corsHeaders);
+    }
 
     const authUrl = ReadAiClient.buildAuthorizationUrl({ clientId, redirectUri, state });
     return json({ success: true, authUrl, sourceId }, 200, corsHeaders);

--- a/supabase/functions/read-ai-oauth-url/index.ts
+++ b/supabase/functions/read-ai-oauth-url/index.ts
@@ -1,0 +1,71 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { ReadAiClient } from '../_shared/read-ai-client.ts';
+
+interface ReadAiOAuthUrlRequest {
+  sourceId?: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as ReadAiOAuthUrlRequest;
+    const clientId = Deno.env.get('READAI_OAUTH_CLIENT_ID');
+    const redirectUri = Deno.env.get('READAI_OAUTH_REDIRECT_URI')
+      || `${Deno.env.get('SITE_URL') || 'https://app.callvaultai.com'}/oauth/callback/read-ai`;
+
+    if (!clientId) {
+      return json({ success: false, error: 'Read.ai OAuth is not configured. Set READAI_OAUTH_CLIENT_ID.' }, 500, corsHeaders);
+    }
+
+    let sourceId = body.sourceId ?? null;
+    if (!sourceId) {
+      const { data, error } = await supabase
+        .from('import_sources')
+        .insert({
+          user_id: userId,
+          source_app: 'read-ai',
+          is_active: false,
+          connection_metadata: { auth_type: 'oauth' },
+        })
+        .select('id')
+        .single();
+      if (error || !data?.id) throw new Error(error?.message ?? 'Failed to initialize Read.ai source');
+      sourceId = data.id;
+    }
+
+    const state = crypto.randomUUID();
+    await supabase
+      .from('user_settings')
+      .upsert({
+        user_id: userId,
+        oauth_state: `read-ai:${state}`,
+        pending_import_source_id: sourceId,
+      }, { onConflict: 'user_id' });
+
+    const authUrl = ReadAiClient.buildAuthorizationUrl({ clientId, redirectUri, state });
+    return json({ success: true, authUrl, sourceId }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Error generating Read.ai OAuth URL:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/read-ai-sync-meetings/__tests__/read-ai-sync-meetings.test.ts
+++ b/supabase/functions/read-ai-sync-meetings/__tests__/read-ai-sync-meetings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("read-ai-sync-meetings wiring", () => {
+  it("resolves sources through the shared Read.ai ownership/type guard", () => {
+    expect(source).toMatch(/resolveReadAiSource\(supabase,\s*userId,\s*sourceId\)/);
+  });
+
+  it("validates workspace membership before creating the sync job", () => {
+    expect(source.indexOf("validateWorkspace")).toBeLessThan(source.indexOf(".from('sync_jobs')"));
+    expect(source).toMatch(/workspace_memberships/);
+  });
+
+  it("runs selected meetings through the canonical connector pipeline and returns completion details", () => {
+    expect(source).toMatch(/getMeeting<ReadAiMeeting>/);
+    expect(source).toMatch(/runCanonicalConnectorPipeline/);
+    expect(source).toMatch(/waitForCompletion/);
+    expect(source).toMatch(/finalStatus/);
+  });
+});

--- a/supabase/functions/read-ai-sync-meetings/index.ts
+++ b/supabase/functions/read-ai-sync-meetings/index.ts
@@ -1,0 +1,217 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
+import { getMeeting, listMeetings, ReadAiClient } from '../_shared/read-ai-client.ts';
+import { readAiMeetingToCanonical, type ReadAiMeeting } from '../_shared/read-ai-connector.ts';
+import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+
+interface ReadAiSyncRequest {
+  sourceId?: string | null;
+  meetingIds?: string[];
+  recordingIds?: string[];
+  singleCallId?: string;
+  createdAfter?: string | null;
+  createdBefore?: string | null;
+  workspace_id?: string | null;
+  workspaceId?: string | null;
+  waitForCompletion?: boolean;
+}
+
+const MAX_BATCH_SIZE = 50;
+const READ_AI_DETAIL_EXPAND = ['summary', 'action_items', 'topics', 'transcript', 'metrics'];
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as ReadAiSyncRequest;
+    const source = await resolveSource(supabase, userId, body.sourceId ?? null);
+    if (!source) return json({ error: 'Read.ai is not connected. Connect Read.ai first.' }, 400, corsHeaders);
+
+    const accessToken = await resolveAccessToken(supabase, source.id, userId);
+    const explicitIds = body.singleCallId
+      ? [body.singleCallId]
+      : (body.meetingIds ?? body.recordingIds ?? []).map(String).filter(Boolean);
+    const meetingIds = explicitIds.length > 0
+      ? explicitIds
+      : await fetchRecentMeetingIds(accessToken, body);
+
+    if (meetingIds.length === 0) {
+      return json({ error: 'meetingIds must be provided or a date-window must return meetings.' }, 400, corsHeaders);
+    }
+    if (meetingIds.length > MAX_BATCH_SIZE) {
+      return json({ error: `Too many Read.ai meetings: max ${MAX_BATCH_SIZE} per request.` }, 400, corsHeaders);
+    }
+
+    const workspaceId = body.workspace_id ?? body.workspaceId ?? null;
+    const validatedWorkspaceId = workspaceId ? await validateWorkspace(supabase, userId, workspaceId, corsHeaders) : null;
+    if (validatedWorkspaceId instanceof Response) return validatedWorkspaceId;
+
+    const { data: syncJob, error: jobError } = await supabase
+      .from('sync_jobs')
+      .insert({
+        user_id: userId,
+        recording_ids: meetingIds,
+        status: 'processing',
+        progress_current: 0,
+        progress_total: meetingIds.length,
+        type: 'read-ai',
+      })
+      .select()
+      .single();
+    if (jobError) throw jobError;
+    const jobId = syncJob.id;
+
+    const processSyncJob = async () => {
+      const synced: string[] = [];
+      const failed: string[] = [];
+      let skippedCount = 0;
+
+      try {
+        for (const meetingId of meetingIds) {
+          try {
+            const meeting = await getMeeting<ReadAiMeeting>(accessToken, meetingId, READ_AI_DETAIL_EXPAND);
+            if (!meeting.end_time_ms) {
+              skippedCount++;
+            } else {
+              const canonical = readAiMeetingToCanonical(meeting);
+              const result = await runCanonicalConnectorPipeline(supabase, userId, canonical, {
+                importSource: 'read-ai-sync-meetings',
+                workspaceId: validatedWorkspaceId,
+                includeRawPayload: true,
+              });
+
+              if (result.success) {
+                synced.push(meetingId);
+              } else if (result.skipped) {
+                skippedCount++;
+              } else {
+                failed.push(meetingId);
+                console.error(`Read.ai sync failed for ${meetingId}:`, result.error);
+              }
+            }
+          } catch (error) {
+            failed.push(meetingId);
+            console.error(`Read.ai sync failed for ${meetingId}:`, error);
+          }
+
+          await supabase.from('sync_jobs').update({
+            progress_current: synced.length + failed.length + skippedCount,
+            synced_ids: synced,
+            failed_ids: failed,
+            skipped_count: skippedCount,
+          }).eq('id', jobId);
+        }
+
+        const finalStatus = failed.length === 0 ? 'completed' : synced.length === 0 && skippedCount === 0 ? 'failed' : 'completed_with_errors';
+        await supabase.from('sync_jobs').update({
+          status: finalStatus,
+          completed_at: new Date().toISOString(),
+          skipped_count: skippedCount,
+        }).eq('id', jobId);
+        await supabase.from('import_sources').update({
+          last_sync_at: new Date().toISOString(),
+          error_message: failed.length ? `${failed.length} Read.ai meeting${failed.length === 1 ? '' : 's'} failed to sync` : null,
+          updated_at: new Date().toISOString(),
+        }).eq('id', source.id).eq('user_id', userId);
+
+        return { finalStatus, synced, failed, skippedCount };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Read.ai sync job crashed';
+        await supabase.from('sync_jobs').update({
+          status: 'failed',
+          error: message,
+          completed_at: new Date().toISOString(),
+          synced_ids: synced,
+          failed_ids: failed,
+          skipped_count: skippedCount,
+        }).eq('id', jobId);
+        await supabase.from('import_sources').update({
+          error_message: message,
+          updated_at: new Date().toISOString(),
+        }).eq('id', source.id).eq('user_id', userId);
+        return { finalStatus: 'failed', synced, failed, skippedCount, error: message };
+      }
+    };
+
+    if (body.waitForCompletion) {
+      const result = await processSyncJob();
+      return json({ success: true, jobId, result }, 200, corsHeaders);
+    }
+
+    // @ts-expect-error EdgeRuntime is available in Supabase Edge Functions.
+    EdgeRuntime.waitUntil(processSyncJob());
+
+    return json({ success: true, jobId, message: `Read.ai sync job started for ${meetingIds.length} meetings` }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Error syncing Read.ai meetings:', error);
+    return json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function resolveSource(supabase: any, userId: string, sourceId: string | null): Promise<{ id: string } | null> {
+  let query = supabase.from('import_sources').select('id').eq('user_id', userId).eq('source_app', 'read-ai');
+  query = sourceId ? query.eq('id', sourceId) : query.eq('is_active', true).order('updated_at', { ascending: false }).limit(1);
+  const { data } = await query.maybeSingle();
+  return data;
+}
+
+async function resolveAccessToken(supabase: any, sourceId: string, userId: string): Promise<string> {
+  const tokens = await getDecryptedOAuthTokens(supabase, sourceId, userId);
+  if (!tokens.access_token) throw new Error('Read.ai access token is missing. Reconnect Read.ai.');
+  if (tokens.token_expires && tokens.token_expires < Date.now() + 30_000) {
+    if (!tokens.refresh_token) throw new Error('Read.ai token expired. Reconnect Read.ai with OAuth.');
+    const clientId = Deno.env.get('READAI_OAUTH_CLIENT_ID');
+    const clientSecret = Deno.env.get('READAI_OAUTH_CLIENT_SECRET');
+    if (!clientId || !clientSecret) throw new Error('Read.ai OAuth is not configured.');
+    const refreshed = await ReadAiClient.refreshTokens({ clientId, clientSecret, refreshToken: tokens.refresh_token });
+    const expiresAt = refreshed.expires_in ? Date.now() + refreshed.expires_in * 1000 : null;
+    const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+    if (encryptionKey) {
+      const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+        p_source_id: sourceId,
+        p_user_id: userId,
+        p_access_token: refreshed.access_token,
+        p_refresh_token: refreshed.refresh_token ?? tokens.refresh_token,
+        p_token_expires: expiresAt,
+        p_encryption_key: encryptionKey,
+        p_is_active: true,
+      });
+      if (error) throw error;
+    } else {
+      const { error } = await supabase.from('import_sources').update({ oauth_access_token: refreshed.access_token, oauth_refresh_token: refreshed.refresh_token ?? tokens.refresh_token, oauth_token_expires: expiresAt, updated_at: new Date().toISOString() }).eq('id', sourceId).eq('user_id', userId);
+      if (error) throw error;
+    }
+    return refreshed.access_token;
+  }
+  return tokens.access_token;
+}
+
+async function fetchRecentMeetingIds(accessToken: string, body: ReadAiSyncRequest): Promise<string[]> {
+  const response = await listMeetings<ReadAiMeeting>({
+    token: accessToken,
+    limit: 10,
+    startTimeMsGte: body.createdAfter ? Date.parse(body.createdAfter) : null,
+    startTimeMsLte: body.createdBefore ? Date.parse(body.createdBefore) : null,
+  });
+  return (response.data ?? []).filter((meeting) => Boolean(meeting.end_time_ms)).map((meeting) => meeting.id);
+}
+
+async function validateWorkspace(supabase: any, userId: string, workspaceId: string, corsHeaders: Record<string, string>): Promise<string | Response> {
+  const { data, error } = await supabase.from('workspace_memberships').select('id').eq('workspace_id', workspaceId).eq('user_id', userId).maybeSingle();
+  if (error) return json({ error: 'Failed to verify workspace membership. Try again.' }, 500, corsHeaders);
+  if (!data) return json({ error: 'You are not a member of the requested workspace.' }, 403, corsHeaders);
+  return workspaceId;
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/read-ai-sync-meetings/index.ts
+++ b/supabase/functions/read-ai-sync-meetings/index.ts
@@ -5,6 +5,7 @@ import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
 import { getMeeting, listMeetings, ReadAiClient } from '../_shared/read-ai-client.ts';
 import { readAiMeetingToCanonical, type ReadAiMeeting } from '../_shared/read-ai-connector.ts';
 import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+import { resolveReadAiSource } from '../_shared/read-ai-source.ts';
 
 interface ReadAiSyncRequest {
   sourceId?: string | null;
@@ -158,10 +159,7 @@ Deno.serve(async (req) => {
 });
 
 async function resolveSource(supabase: any, userId: string, sourceId: string | null): Promise<{ id: string } | null> {
-  let query = supabase.from('import_sources').select('id').eq('user_id', userId).eq('source_app', 'read-ai');
-  query = sourceId ? query.eq('id', sourceId) : query.eq('is_active', true).order('updated_at', { ascending: false }).limit(1);
-  const { data } = await query.maybeSingle();
-  return data;
+  return await resolveReadAiSource(supabase, userId, sourceId);
 }
 
 async function resolveAccessToken(supabase: any, sourceId: string, userId: string): Promise<string> {


### PR DESCRIPTION
## Summary

Add Read.ai as a first-class import source for CallVault, with OAuth-first credential handling, token-paste fallback support, meeting search/fetch, and canonical recording imports through `runCanonicalConnectorPipeline()`.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `supabase/functions/_shared/read-ai-client.ts` | CREATE | Read.ai REST and OAuth client with bearer auth, token exchange/refresh, cursor pagination, and `limit<=10` clamping. |
| `supabase/functions/_shared/read-ai-connector.ts` | CREATE | Normalizes Read.ai meetings, transcripts, participants, summaries, action items, and report metadata into `CanonicalRecording`. |
| `supabase/functions/_shared/__tests__/read-ai-connector.test.ts` | CREATE | Covers normalization, transcript handling, bearer requests, list pagination, and limit clamping. |
| `supabase/functions/read-ai-oauth-url/index.ts` | CREATE | Creates OAuth authorization URLs and source rows for Read.ai. |
| `supabase/functions/read-ai-oauth-callback/index.ts` | CREATE | Exchanges authorization codes, stores encrypted tokens, and triggers initial sync. |
| `supabase/functions/read-ai-oauth-refresh/index.ts` | CREATE | Refreshes Read.ai OAuth access tokens and persists rotated refresh tokens. |
| `supabase/functions/read-ai-connect-token/index.ts` | CREATE | Stores pasted bearer tokens as encrypted fallback credentials. |
| `supabase/functions/read-ai-fetch-meetings/index.ts` | CREATE | Fetches Read.ai meetings with date filters, cursor pagination, sync status, and importability metadata. |
| `supabase/functions/read-ai-sync-meetings/index.ts` | CREATE | Imports selected Read.ai meetings through the canonical connector pipeline and updates sync job/source status. |
| `src/components/connectors/registry/adapters/read-ai.ts` | CREATE | Adds the frontend Read.ai connector adapter for OAuth, token fallback, search, import, and disconnect. |
| `src/components/connectors/registry/adapters/__tests__/read-ai.test.ts` | CREATE | Covers OAuth URL generation, token save, search mapping, and selected imports. |
| `.env.example` | UPDATE | Documents Read.ai OAuth and API configuration variables. |
| `supabase/config.toml` | UPDATE | Registers Read.ai edge functions. |
| `src/components/connectors/registry/types.ts` | UPDATE | Adds `read-ai` to connector source typing. |
| `src/components/connectors/registry/connectorRegistry.ts` | UPDATE | Registers the Read.ai connector adapter. |
| `src/config/source-registry.ts` | UPDATE | Adds Read.ai to source registry metadata. |
| `src/lib/source-labels.ts` | UPDATE | Adds Read.ai display labeling. |
| `src/lib/api-client.ts` | UPDATE | Adds Read.ai API client helpers. |
| `src/pages/OAuthCallback.tsx` | UPDATE | Routes Read.ai OAuth callbacks. |
| `src/App.tsx` | UPDATE | Adds Read.ai OAuth callback route support. |
| `src/components/panes/ImportSourcePane.tsx` | UPDATE | Exposes Read.ai in the import source pane. |
| `src/pages/ImportPage.tsx` | UPDATE | Wires Read.ai into import page routing and connector wizard flow. |
| `src/services/import-sources.service.ts` | UPDATE | Adds Read.ai retry/sync dispatch support. |
| `src/components/connectors/ConnectorImportWizard.tsx` | UPDATE | Loads real workspaces for the generic connector import flow. |
| `src/components/connectors/__tests__/deriveConnectorStatus.test.ts` | UPDATE | Adds Read.ai connected and expired-token status coverage. |
| `e2e/import-page.spec.ts` | UPDATE | Verifies Read.ai appears in the import page source list. |
| `e2e/settings-pane-navigation.spec.ts` | UPDATE | Verifies Read.ai appears in settings integrations. |

## Tests

- `supabase/functions/_shared/__tests__/read-ai-connector.test.ts` - API meeting normalization, speaker blocks, missing transcript handling, bearer/list request behavior, and limit clamping.
- `src/components/connectors/registry/adapters/__tests__/read-ai.test.ts` - OAuth URL, token save, search mapping, and selected import behavior.
- `src/components/connectors/__tests__/deriveConnectorStatus.test.ts` - Read.ai connected status and expired token status.
- `e2e/import-page.spec.ts` - Read.ai import source visibility.
- `e2e/settings-pane-navigation.spec.ts` - Read.ai settings integration visibility.

## Validation

- [x] Type check passes
- [x] Lint passes with 0 errors and 214 warnings
- [ ] Format check not available because `package.json` has no `format` or `format:check` script
- [x] Targeted tests pass, 24 passed
- [x] Full tests pass, 1,042 passed and 93 skipped
- [x] Build succeeds
- [ ] Targeted Playwright smoke specs blocked by missing `CALLVAULTAI_LOGIN` / `CALLVAULTAI_LOGIN_PASSWORD`
- [ ] Supabase function serve blocked by local Supabase/Docker image startup failure

## Implementation Notes

### Deviations from Plan

- Rendered `ConnectorImportWizard` for Read.ai and updated the wizard to load real workspaces via `useWorkspaces()`. This completed the intended generic connector flow without adding Read.ai-specific import UI.
- Playwright smoke specs were run but blocked in auth setup because `CALLVAULTAI_LOGIN` and `CALLVAULTAI_LOGIN_PASSWORD` are unavailable locally.

### Issues Resolved

- Installed dependencies from the existing lockfile after initial Vitest runs failed due to missing `node_modules`.
- Documented local environment blockers for Playwright and Supabase function serving in the validation artifact.

---

**Plan**: `/Users/admin/.archon/workspaces/Vibe-Marketer/brain/artifacts/runs/a2d97f3f1ccc304954a0c3d8f751786c/plan-context.md`
**Workflow ID**: `a2d97f3f1ccc304954a0c3d8f751786c`
