### PR TITLE
[codex] add Grain import connector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,14 @@ function App() {
                       </ProtectedRoute>
                     }
                   />
+                  <Route
+                    path="/oauth/callback/grain"
+                    element={
+                      <ProtectedRoute>
+                        <OAuthCallback />
+                      </ProtectedRoute>
+                    }
+                  />
 
                   {/* OAuth consent page - public route, handles its own auth check internally */}
                   <Route path="/oauth/consent" element={<OAuthConsentPage />} />

--- a/src/components/connectors/registry/adapters/__tests__/grain.test.ts
+++ b/src/components/connectors/registry/adapters/__tests__/grain.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(async () => ({ error: null })),
+        })),
+      })),
+    })),
+  },
+}));
+
+import { supabase } from "@/integrations/supabase/client";
+import { grainAdapter } from "../grain";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+describe("grainAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests a Grain OAuth URL", async () => {
+    invoke.mockResolvedValue({
+      data: { authUrl: "https://grain.com/_/public-api/oauth2/authorize", sourceId: "source-1" },
+      error: null,
+    });
+
+    const result = await grainAdapter.getOAuthAuthUrl!();
+
+    expect(invoke).toHaveBeenCalledWith("grain-oauth-url");
+    expect(result).toEqual({
+      authUrl: "https://grain.com/_/public-api/oauth2/authorize",
+      sourceId: "source-1",
+    });
+  });
+
+  it("saves pasted bearer tokens through the token fallback function", async () => {
+    invoke.mockResolvedValue({
+      data: { success: true, sourceId: "source-2" },
+      error: null,
+    });
+
+    const result = await grainAdapter.saveApiKeyCredentials!({
+      apiKey: "  bearer-token  ",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("grain-connect-token", {
+      body: { accessToken: "bearer-token" },
+    });
+    expect(result).toEqual({ sourceId: "source-2" });
+  });
+
+  it("maps Grain search results for the import wizard", async () => {
+    invoke.mockResolvedValue({
+      data: {
+        meetings: [
+          {
+            recording_id: "grain-1",
+            title: "Grain Review",
+            recording_start_time: "2026-05-20T10:00:00Z",
+            duration: 1800,
+            synced: false,
+            importable: true,
+            calendar_invitees: [{ name: "Ava", email: "ava@example.com" }],
+            share_url: "https://grain.com/share/recording/grain-1",
+          },
+        ],
+        nextCursor: "01NEXT",
+      },
+      error: null,
+    });
+
+    const result = await grainAdapter.searchAvailable!({
+      sourceId: "source-1",
+      dateStart: new Date("2026-05-20T00:00:00Z"),
+      dateEnd: new Date("2026-05-21T00:00:00Z"),
+      limit: 25,
+      cursor: "01CURSOR",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("grain-fetch-recordings", {
+      body: {
+        sourceId: "source-1",
+        createdAfter: "2026-05-20T00:00:00.000Z",
+        createdBefore: "2026-05-21T00:00:00.000Z",
+        cursor: "01CURSOR",
+        limit: 25,
+      },
+    });
+    expect(result).toEqual({
+      nextCursor: "01NEXT",
+      items: [
+        {
+          externalId: "grain-1",
+          title: "Grain Review",
+          startTime: "2026-05-20T10:00:00Z",
+          durationSeconds: 1800,
+          participants: [{ name: "Ava", email: "ava@example.com" }],
+          alreadyImported: false,
+          externalUrl: "https://grain.com/share/recording/grain-1",
+          metadata: { importable: true },
+        },
+      ],
+    });
+  });
+
+  it("starts a Grain sync job for selected recordings", async () => {
+    invoke.mockResolvedValue({
+      data: { jobId: "job-1" },
+      error: null,
+    });
+
+    const result = await grainAdapter.importSelected!({
+      sourceId: "source-1",
+      externalIds: ["grain-1"],
+      workspaceId: "workspace-1",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("grain-sync-recordings", {
+      body: {
+        sourceId: "source-1",
+        workspaceId: "workspace-1",
+        workspace_id: "workspace-1",
+        recordingIds: ["grain-1"],
+      },
+    });
+    expect(result).toEqual({
+      jobId: "job-1",
+      total: 1,
+      message: "Importing 1 Grain call(s)...",
+    });
+  });
+});

--- a/src/components/connectors/registry/adapters/grain.ts
+++ b/src/components/connectors/registry/adapters/grain.ts
@@ -1,0 +1,133 @@
+import { RiCloudLine } from "@remixicon/react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ConnectorAdapter } from "../types";
+
+interface GrainAvailableMeeting {
+  recording_id: string;
+  title: string;
+  recording_start_time: string | null;
+  duration: number | null;
+  calendar_invitees?: Array<{ name: string | null; email: string | null }>;
+  synced: boolean;
+  importable?: boolean;
+  share_url?: string | null;
+  source_url?: string | null;
+}
+
+export const grainAdapter: ConnectorAdapter = {
+  metadata: {
+    sourceApp: "grain",
+    label: "Grain",
+    description: "AI meeting recordings and transcripts",
+    icon: RiCloudLine,
+    brandColor: "#E1572A",
+    authMethods: ["oauth", "api_key"],
+    order: 46,
+  },
+
+  async getOAuthAuthUrl() {
+    const { data, error } = await supabase.functions.invoke("grain-oauth-url");
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+    if (!data?.authUrl) {
+      throw new Error("grain-oauth-url returned no authUrl");
+    }
+    return {
+      authUrl: data.authUrl as string,
+      sourceId: data.sourceId as string | undefined,
+    };
+  },
+
+  async saveApiKeyCredentials({ apiKey }) {
+    const { data, error } = await supabase.functions.invoke(
+      "grain-connect-token",
+      {
+        body: { accessToken: apiKey.trim() },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+    if (!data?.sourceId) {
+      throw new Error("grain-connect-token returned no sourceId");
+    }
+    return { sourceId: data.sourceId as string };
+  },
+
+  async disconnect(sourceId) {
+    const { error } = await supabase
+      .from("import_sources")
+      .update({ is_active: false })
+      .eq("id", sourceId)
+      .eq("source_app", "grain");
+    if (error) throw new Error(error.message);
+  },
+
+  async searchAvailable({ sourceId, dateStart, dateEnd, limit, cursor }) {
+    const { data, error } = await supabase.functions.invoke(
+      "grain-fetch-recordings",
+      {
+        body: {
+          sourceId,
+          createdAfter: dateStart.toISOString(),
+          createdBefore: dateEnd.toISOString(),
+          cursor: cursor ?? null,
+          limit: limit ?? 10,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+
+    const response = data as {
+      meetings?: GrainAvailableMeeting[];
+      nextCursor?: string | null;
+    } | null;
+
+    return {
+      items: (response?.meetings ?? []).map((meeting) => ({
+        externalId: meeting.recording_id,
+        title: meeting.title,
+        startTime: meeting.recording_start_time,
+        durationSeconds: meeting.duration,
+        participants: meeting.calendar_invitees,
+        alreadyImported: meeting.synced || meeting.importable === false,
+        externalUrl: meeting.share_url ?? meeting.source_url,
+        metadata: { importable: meeting.importable ?? true },
+      })),
+      nextCursor: response?.nextCursor ?? null,
+    };
+  },
+
+  async importSelected({ sourceId, externalIds, workspaceId }) {
+    const { data, error } = await supabase.functions.invoke(
+      "grain-sync-recordings",
+      {
+        body: {
+          sourceId,
+          workspaceId,
+          workspace_id: workspaceId,
+          recordingIds: externalIds,
+        },
+      },
+    );
+    if (error) throw new Error(error.message);
+    if ((data as { error?: string } | null)?.error) {
+      throw new Error((data as { error: string }).error);
+    }
+    if (!(data as { jobId?: string } | null)?.jobId) {
+      throw new Error("grain-sync-recordings returned no jobId");
+    }
+
+    return {
+      jobId: (data as { jobId: string }).jobId,
+      total: externalIds.length,
+      message: `Importing ${externalIds.length} Grain call(s)...`,
+    };
+  },
+};

--- a/src/components/connectors/registry/connectorRegistry.ts
+++ b/src/components/connectors/registry/connectorRegistry.ts
@@ -18,6 +18,7 @@ import { fathomAdapter } from "./adapters/fathom";
 import { zoomAdapter } from "./adapters/zoom";
 import { firefliesAdapter } from "./adapters/fireflies";
 import { readAiAdapter } from "./adapters/read-ai";
+import { grainAdapter } from "./adapters/grain";
 import { plaudAdapter } from "./adapters/plaud";
 import { youtubeAdapter } from "./adapters/youtube";
 import { fileUploadAdapter } from "./adapters/file-upload";
@@ -32,6 +33,7 @@ const ALL_ADAPTERS: readonly ConnectorAdapter[] = [
   zoomAdapter,
   firefliesAdapter,
   readAiAdapter,
+  grainAdapter,
   plaudAdapter,
   youtubeAdapter,
   fileUploadAdapter,

--- a/src/components/connectors/registry/types.ts
+++ b/src/components/connectors/registry/types.ts
@@ -14,6 +14,7 @@ export type ConnectorSourceApp =
   | "zoom"
   | "fireflies"
   | "read-ai"
+  | "grain"
   | "plaud"
   | "youtube"
   | "file-upload";

--- a/src/components/panes/ImportSourcePane.tsx
+++ b/src/components/panes/ImportSourcePane.tsx
@@ -29,6 +29,7 @@ export type ImportSourceId =
   | 'zoom'
   | 'fireflies'
   | 'read-ai'
+  | 'grain'
   | 'plaud'
   | 'youtube'
   | 'file-upload'
@@ -58,6 +59,7 @@ const PRIMARY_SOURCES: SourceDef[] = [
   { id: 'zoom', label: 'Zoom', subtitle: 'Cloud recordings', icon: RiVideoLine },
   { id: 'fireflies', label: 'Fireflies', subtitle: 'Transcript API import', icon: RiCloudLine },
   { id: 'read-ai', label: 'Read.ai', subtitle: 'Meeting reports', icon: RiCloudLine },
+  { id: 'grain', label: 'Grain', subtitle: 'AI meeting recorder', icon: RiCloudLine },
   { id: 'plaud', label: 'Plaud', subtitle: 'AI voice recorder', icon: RiCloudLine },
   { id: 'youtube', label: 'YouTube', subtitle: 'Video imports', icon: RiYoutubeLine },
   { id: 'file-upload', label: 'File Upload', subtitle: 'Direct upload', icon: RiUploadCloud2Line },

--- a/src/config/source-registry.ts
+++ b/src/config/source-registry.ts
@@ -38,6 +38,7 @@ export type SourceId =
   | "zoom"
   | "fireflies"
   | "read-ai"
+  | "grain"
   | "plaud"
   | "youtube"
   | "file-upload"
@@ -118,6 +119,16 @@ export const SOURCE_REGISTRY: readonly SourceConfig[] = [
     adapter: "native",
     authMode: "oauth2",
     hasWebhook: false,
+    status: "beta",
+  },
+  {
+    id: "grain",
+    label: "Grain",
+    subtitle: "Import Grain recordings and transcripts",
+    icon: RiCloudLine,
+    adapter: "native",
+    authMode: "oauth2",
+    hasWebhook: true,
     status: "beta",
   },
   {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -166,6 +166,20 @@ export async function completeReadAiOAuth(code: string, state: string) {
 }
 
 /**
+ * Get Grain OAuth authorization URL.
+ */
+export async function getGrainAuthUrl() {
+  return callEdgeFunction('grain-oauth-url', undefined, { retry: false });
+}
+
+/**
+ * Complete Grain OAuth flow.
+ */
+export async function completeGrainOAuth(code: string, state: string) {
+  return callEdgeFunction('grain-oauth-callback', { code, state }, { retry: false });
+}
+
+/**
  * Refresh Zoom OAuth token
  */
 export async function refreshZoomOAuth() {

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -76,6 +76,17 @@ async function connectReadAi(sourceId?: string) {
   window.open(data.authUrl as string, "_blank", "noopener,noreferrer");
 }
 
+async function connectGrain(sourceId?: string) {
+  const { data, error } = await supabase.functions.invoke("grain-oauth-url", {
+    body: sourceId ? { sourceId } : undefined,
+  });
+  if (error || !data?.authUrl) {
+    toast.error("Failed to start Grain connection");
+    return;
+  }
+  window.open(data.authUrl as string, "_blank", "noopener,noreferrer");
+}
+
 const PLAUD_SERVER_OPTIONS = [
   { key: "global", label: "Global", apiBase: "https://api.plaud.ai" },
   { key: "eu", label: "EU", apiBase: "https://api-euc1.plaud.ai" },
@@ -156,6 +167,7 @@ export default function ImportPage() {
           fathom: "sync-meetings",
           zoom: "zoom-sync-meetings",
           "read-ai": "read-ai-sync-meetings",
+          grain: "grain-sync-recordings",
           plaud: "plaud-sync-recordings",
         };
         const fnName = syncFnMap[connectedSource];
@@ -172,6 +184,8 @@ export default function ImportPage() {
                 ? "Zoom"
                 : connectedSource === "read-ai"
                   ? "Read.ai"
+                  : connectedSource === "grain"
+                    ? "Grain"
                   : "Plaud";
           if (synced > 0) {
             toast.success(
@@ -538,6 +552,35 @@ export default function ImportPage() {
       );
     }
 
+    if (selectedSource === "grain") {
+      const grainRow = sources.find((s) => s.source_app === "grain") ?? null;
+      return (
+        <div className="flex flex-col h-full overflow-y-auto">
+          <PageHeader
+            title="Grain"
+            subtitle="Connect Grain, search completed recordings, and import selected transcripts"
+            icon={RiDownloadCloud2Line}
+          />
+          <div className="px-6 py-4 max-w-4xl space-y-4">
+            {!grainRow?.is_active && (
+              <Button variant="default" onClick={() => void connectGrain()}>
+                Connect Grain
+              </Button>
+            )}
+            <ConnectorImportWizard sourceApp="grain" />
+            {grainRow && (
+              <Button
+                variant="hollow"
+                onClick={() => setDisconnectTarget(grainRow)}
+              >
+                Disconnect
+              </Button>
+            )}
+          </div>
+        </div>
+      );
+    }
+
     if (selectedSource === "youtube") {
       return (
         <div className="flex flex-col h-full overflow-y-auto">
@@ -643,6 +686,8 @@ export default function ImportPage() {
       setSelectedSource("fireflies");
     } else if (choice === "read-ai") {
       void connectReadAi();
+    } else if (choice === "grain") {
+      void connectGrain();
     } else if (choice === "plaud") {
       void connectPlaud();
     } else if (choice === "youtube") {
@@ -736,6 +781,7 @@ export default function ImportPage() {
 function getSourceName(sourceApp: string): string {
   if (sourceApp === "fireflies") return "Fireflies";
   if (sourceApp === "read-ai") return "Read.ai";
+  if (sourceApp === "grain") return "Grain";
   if (sourceApp === "plaud") return "Plaud";
   if (sourceApp === "youtube") return "YouTube";
   if (sourceApp === "file-upload") return "File Upload";

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -3,7 +3,13 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { RiLoader4Line, RiCheckLine, RiCloseLine } from "@remixicon/react";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
-import { completeFathomOAuth, completePlaudOAuth, completeReadAiOAuth, completeZoomOAuth } from "@/lib/api-client";
+import {
+  completeFathomOAuth,
+  completeGrainOAuth,
+  completePlaudOAuth,
+  completeReadAiOAuth,
+  completeZoomOAuth,
+} from "@/lib/api-client";
 import { supabase } from "@/integrations/supabase/client";
 import { getSafeUser } from "@/lib/auth-utils";
 
@@ -17,6 +23,7 @@ type CallbackState = "loading" | "success" | "error";
  *   /oauth/callback/zoom - Zoom OAuth callback
  *   /oauth/callback/plaud - Plaud OAuth callback
  *   /oauth/callback/read-ai - Read.ai OAuth callback
+ *   /oauth/callback/grain - Grain OAuth callback
  * Process:
  * 1. Extract code and state from URL params
  * 2. Determine provider from path
@@ -58,13 +65,16 @@ export default function OAuthCallback() {
         const isZoomCallback = location.pathname.includes("/zoom");
         const isPlaudCallback = location.pathname.includes("/plaud");
         const isReadAiCallback = location.pathname.includes("/read-ai");
+        const isGrainCallback = location.pathname.includes("/grain");
         const provider = isZoomCallback
           ? "Zoom"
           : isPlaudCallback
             ? "Plaud"
             : isReadAiCallback
               ? "Read.ai"
-              : "Fathom";
+              : isGrainCallback
+                ? "Grain"
+                : "Fathom";
 
         setMessage(`Completing ${provider} connection...`);
         logger.info(`Processing ${provider} OAuth callback`);
@@ -77,6 +87,8 @@ export default function OAuthCallback() {
           response = await completePlaudOAuth(code, stateParam);
         } else if (isReadAiCallback) {
           response = await completeReadAiOAuth(code, stateParam);
+        } else if (isGrainCallback) {
+          response = await completeGrainOAuth(code, stateParam);
         } else {
           response = await completeFathomOAuth(code, stateParam);
         }
@@ -101,7 +113,9 @@ export default function OAuthCallback() {
             ? "plaud"
             : isReadAiCallback
               ? "read-ai"
-              : "fathom";
+              : isGrainCallback
+                ? "grain"
+                : "fathom";
         const extraParams = [
           connectedSourceId ? `sourceId=${connectedSourceId}` : "",
           connectedEmail ? `email=${encodeURIComponent(connectedEmail)}` : "",

--- a/src/services/import-sources.service.ts
+++ b/src/services/import-sources.service.ts
@@ -331,6 +331,7 @@ export async function disconnectImportSource(sourceId: string): Promise<void> {
  * - youtube   → youtube-import            with { singleCallId }
  * - fireflies → fireflies-sync-meetings   with { singleCallId }
  * - read-ai   → read-ai-sync-meetings     with { singleCallId }
+ * - grain     → grain-sync-recordings     with { singleCallId }
  * - plaud     → plaud-sync-recordings     with { singleCallId }
  * - file-upload → error (user must re-upload)
  */
@@ -344,6 +345,7 @@ export async function retryFailedImport(
     youtube: "youtube-import",
     fireflies: "fireflies-sync-meetings",
     "read-ai": "read-ai-sync-meetings",
+    grain: "grain-sync-recordings",
     plaud: "plaud-sync-recordings",
   };
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -63,6 +63,23 @@ verify_jwt = false
 [functions.read-ai-sync-meetings]
 verify_jwt = false
 
+[functions.grain-oauth-url]
+verify_jwt = false
+
+[functions.grain-oauth-callback]
+verify_jwt = false
+
+[functions.grain-oauth-refresh]
+verify_jwt = false
+
+[functions.grain-connect-token]
+verify_jwt = false
+
+[functions.grain-fetch-recordings]
+verify_jwt = false
+
+[functions.grain-sync-recordings]
+verify_jwt = false
 
 [functions.youtube-import]
 verify_jwt = false

--- a/supabase/functions/_shared/__tests__/grain-connector.test.ts
+++ b/supabase/functions/_shared/__tests__/grain-connector.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { listRecordings } from "../grain-client";
+import {
+  grainRecordingToCanonical,
+  type GrainRecording,
+} from "../grain-connector";
+
+describe("grain connector", () => {
+  const recording: GrainRecording = {
+    id: "pppp6666-qq77-rr88-ss99-tttt00000000",
+    title: "All Hands",
+    source: "zoom",
+    url: "https://grain.com/share/recording/pppp6666-qq77-rr88-ss99-tttt00000000",
+    media_type: "video",
+    tags: ["all-hands"],
+    start_datetime: "2025-01-01T09:30:00Z",
+    end_datetime: "2025-01-01T10:00:00Z",
+    duration_ms: 1_800_000,
+    thumbnail_url: "https://media.grain.com/public_thumbnails/recordings/pppp6666",
+    participants: [
+      { id: "p1", name: "Leia Example", email: "leia@example.com", confirmed_attendee: true },
+      { id: "p2", name: "Han Example", email: "han@example.com", confirmed_attendee: false },
+    ],
+    teams: [{ id: "team-1", name: "Sales" }],
+    meeting_type: { id: "type-1", name: "Team Coordination", scope: "internal" },
+    ai_summary: "We reviewed launch progress.",
+    ai_action_items: [{ text: "Send launch recap" }],
+    transcript: [
+      { start: 8_000, end: 9_000, speaker: "Leia Example", participant_id: "p1", text: "Let's begin." },
+      { start: 11_482, end: 13_000, speaker: "Han Example", participant_id: "p2", text: "The rollout is ready." },
+    ],
+  };
+
+  it("normalizes Grain API recordings into canonical recordings", () => {
+    const canonical = grainRecordingToCanonical(recording);
+
+    expect(canonical).toMatchObject({
+      externalId: "pppp6666-qq77-rr88-ss99-tttt00000000",
+      sourceApp: "grain",
+      title: "All Hands",
+      recordingStartTime: "2025-01-01T09:30:00.000Z",
+      recordingEndTime: "2025-01-01T10:00:00.000Z",
+      durationSeconds: 1800,
+      sourceUrl: "https://grain.com/share/recording/pppp6666-qq77-rr88-ss99-tttt00000000",
+      participantEmails: ["leia@example.com", "han@example.com"],
+    });
+    expect(canonical.fullTranscript).toBe(
+      "[0:08] Leia Example: Let's begin.\n\n[0:11] Han Example: The rollout is ready.",
+    );
+    expect(canonical.summary).toContain("We reviewed launch progress.");
+    expect(canonical.summary).toContain("- Send launch recap");
+    expect(canonical.sourceMetadata).toMatchObject({
+      grain_recording_id: "pppp6666-qq77-rr88-ss99-tttt00000000",
+      grain_source: "zoom",
+      grain_media_type: "video",
+      grain_tags: ["all-hands"],
+      grain_ai_action_items: ["Send launch recap"],
+    });
+  });
+
+  it("throws for recordings without transcript text", () => {
+    expect(() =>
+      grainRecordingToCanonical({
+        id: "empty",
+        start_datetime: "2025-01-01T09:30:00Z",
+        transcript: [],
+      }),
+    ).toThrow(/no transcript text/);
+  });
+});
+
+describe("grain client", () => {
+  it("uses Grain v2 headers, filters, include body, and cursor pagination", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ cursor: "next-cursor", recordings: [] }), {
+          status: 200,
+        }),
+    ) as unknown as typeof fetch;
+
+    await listRecordings({
+      token: "secret-token",
+      cursor: "last-cursor",
+      startDateTimeGte: "2025-01-01T00:00:00Z",
+      startDateTimeLte: "2025-02-01T00:00:00Z",
+      titleSearch: "hands",
+      include: { participants: true, ai_summary: true },
+      fetchImpl,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).toBe("https://api.grain.com/_/public-api/v2/recordings");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer secret-token",
+        "Content-Type": "application/json",
+        "Public-Api-Version": "2025-10-31",
+      },
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      cursor: "last-cursor",
+      include: { participants: true, ai_summary: true },
+      filter: {
+        title_search: "hands",
+        start_datetime_gte: "2025-01-01T00:00:00Z",
+        start_datetime_lte: "2025-02-01T00:00:00Z",
+      },
+    });
+  });
+});

--- a/supabase/functions/_shared/__tests__/grain-source.test.ts
+++ b/supabase/functions/_shared/__tests__/grain-source.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveGrainSource } from "../grain-source";
+
+function createSourceQuery(result: unknown) {
+  const query = {
+    from: vi.fn(() => query),
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    maybeSingle: vi.fn(async () => result),
+  };
+  return query;
+}
+
+describe("resolveGrainSource", () => {
+  it("scopes caller-provided source ids to the user's Grain sources", async () => {
+    const query = createSourceQuery({ data: { id: "source-1" }, error: null });
+
+    await expect(resolveGrainSource(query, "user-1", "source-1")).resolves.toEqual({ id: "source-1" });
+
+    expect(query.from).toHaveBeenCalledWith("import_sources");
+    expect(query.select).toHaveBeenCalledWith("id");
+    expect(query.eq).toHaveBeenCalledWith("user_id", "user-1");
+    expect(query.eq).toHaveBeenCalledWith("source_app", "grain");
+    expect(query.eq).toHaveBeenCalledWith("id", "source-1");
+  });
+
+  it("selects the latest active Grain source when no source id is provided", async () => {
+    const query = createSourceQuery({ data: { id: "source-2" }, error: null });
+
+    await expect(resolveGrainSource(query, "user-1", null)).resolves.toEqual({ id: "source-2" });
+
+    expect(query.eq).toHaveBeenCalledWith("is_active", true);
+    expect(query.order).toHaveBeenCalledWith("updated_at", { ascending: false });
+    expect(query.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("surfaces lookup errors instead of treating them as disconnected", async () => {
+    const query = createSourceQuery({ data: null, error: new Error("database unavailable") });
+
+    await expect(resolveGrainSource(query, "user-1", "source-1")).rejects.toThrow("database unavailable");
+  });
+});

--- a/supabase/functions/_shared/grain-client.ts
+++ b/supabase/functions/_shared/grain-client.ts
@@ -1,0 +1,276 @@
+export const GRAIN_API_BASE = "https://api.grain.com";
+export const GRAIN_PUBLIC_API_VERSION = "2025-10-31";
+export const GRAIN_AUTHORIZE_URL = "https://grain.com/_/public-api/oauth2/authorize";
+export const GRAIN_TOKEN_URL = "https://api.grain.com/_/public-api/oauth2/token";
+
+export interface GrainTokenResponse {
+  token_type?: string | null;
+  access_token: string;
+  refresh_token?: string | null;
+  expires_in?: number | null;
+}
+
+export interface GrainListRecordingsParams {
+  token: string;
+  cursor?: string | null;
+  startDateTimeGte?: string | null;
+  startDateTimeLte?: string | null;
+  titleSearch?: string | null;
+  include?: GrainRecordingInclude;
+  fetchImpl?: typeof fetch;
+  apiBase?: string;
+}
+
+export interface GrainRecordingInclude {
+  highlights?: boolean;
+  participants?: boolean;
+  ai_action_items?: boolean;
+  ai_summary?: boolean;
+  private_notes?: boolean;
+  calendar_event?: boolean;
+  hubspot?: boolean;
+}
+
+export interface GrainListRecordingsResponse<T> {
+  cursor?: string | null;
+  recordings?: T[];
+}
+
+export interface GrainClientOptions {
+  accessToken?: string;
+  apiBase?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class GrainClient {
+  private readonly accessToken: string;
+  private readonly apiBase: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: GrainClientOptions = {}) {
+    this.accessToken = options.accessToken ?? "";
+    this.apiBase = normalizeBaseUrl(options.apiBase ?? Deno.env.get("GRAIN_API_BASE") ?? GRAIN_API_BASE);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  static authorizationUrl(): string {
+    return Deno.env.get("GRAIN_OAUTH_AUTHORIZE_URL") ?? GRAIN_AUTHORIZE_URL;
+  }
+
+  static tokenUrl(): string {
+    return Deno.env.get("GRAIN_OAUTH_TOKEN_URL") ?? GRAIN_TOKEN_URL;
+  }
+
+  static buildAuthorizationUrl(params: {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    codeChallenge?: string | null;
+  }): string {
+    const url = new URL(GrainClient.authorizationUrl());
+    url.searchParams.set("client_id", params.clientId);
+    url.searchParams.set("redirect_uri", params.redirectUri);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("state", params.state);
+    if (params.codeChallenge) {
+      url.searchParams.set("code_challenge", params.codeChallenge);
+      url.searchParams.set("code_challenge_method", "S256");
+    }
+    return url.toString();
+  }
+
+  static async exchangeCodeForTokens(params: {
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    redirectUri: string;
+    codeVerifier?: string | null;
+    fetchImpl?: typeof fetch;
+  }): Promise<GrainTokenResponse> {
+    const body: Record<string, string> = {
+      grant_type: "authorization_code",
+      code: params.code,
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+      redirect_uri: params.redirectUri,
+    };
+    if (params.codeVerifier) body.code_verifier = params.codeVerifier;
+
+    const response = await (params.fetchImpl ?? fetch)(GrainClient.tokenUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    return await parseJsonResponse<GrainTokenResponse>(response, "Grain token exchange failed");
+  }
+
+  static async refreshTokens(params: {
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    fetchImpl?: typeof fetch;
+  }): Promise<GrainTokenResponse> {
+    const response = await (params.fetchImpl ?? fetch)(GrainClient.tokenUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: params.refreshToken,
+        client_id: params.clientId,
+        client_secret: params.clientSecret,
+      }),
+    });
+    return await parseJsonResponse<GrainTokenResponse>(response, "Grain token refresh failed");
+  }
+
+  async listRecordings<T = unknown>(params: Omit<GrainListRecordingsParams, "token" | "fetchImpl" | "apiBase"> = {}) {
+    return await listRecordings<T>({
+      ...params,
+      token: this.accessToken,
+      fetchImpl: this.fetchImpl,
+      apiBase: this.apiBase,
+    });
+  }
+
+  async getRecording<T = unknown>(id: string, include: GrainRecordingInclude = {}) {
+    return await getRecording<T>(this.accessToken, id, include, this.fetchImpl, this.apiBase);
+  }
+
+  async getRecordingTranscript(id: string) {
+    return await getRecordingTranscript(this.accessToken, id, this.fetchImpl, this.apiBase);
+  }
+
+  async testToken() {
+    return await this.listRecordings({ include: { participants: false } });
+  }
+}
+
+export async function listRecordings<T = unknown>(
+  params: GrainListRecordingsParams,
+): Promise<GrainListRecordingsResponse<T>> {
+  const token = cleanToken(params.token);
+  const body: Record<string, unknown> = {
+    include: params.include ?? { participants: true, ai_summary: true, ai_action_items: true, calendar_event: true },
+  };
+  const filter: Record<string, unknown> = {};
+  if (params.cursor) body.cursor = params.cursor;
+  if (params.titleSearch?.trim()) filter.title_search = params.titleSearch.trim();
+  if (params.startDateTimeGte) filter.start_datetime_gte = params.startDateTimeGte;
+  if (params.startDateTimeLte) filter.start_datetime_lte = params.startDateTimeLte;
+  if (Object.keys(filter).length > 0) body.filter = filter;
+
+  const response = await (params.fetchImpl ?? fetch)(`${normalizeBaseUrl(params.apiBase ?? GRAIN_API_BASE)}/_/public-api/v2/recordings`, {
+    method: "POST",
+    headers: grainHeaders(token),
+    body: JSON.stringify(body),
+  });
+  return await parseJsonResponse<GrainListRecordingsResponse<T>>(response, "Grain list recordings failed");
+}
+
+export async function getRecording<T = unknown>(
+  token: string,
+  id: string,
+  include: GrainRecordingInclude = {},
+  fetchImpl: typeof fetch = fetch,
+  apiBase = GRAIN_API_BASE,
+): Promise<T> {
+  if (!id.trim()) throw new Error("Grain recording id is required");
+  const response = await fetchImpl(`${normalizeBaseUrl(apiBase)}/_/public-api/v2/recordings/${encodeURIComponent(id)}`, {
+    method: "POST",
+    headers: grainHeaders(cleanToken(token)),
+    body: JSON.stringify({ include }),
+  });
+  return await parseJsonResponse<T>(response, "Grain get recording failed");
+}
+
+export async function getRecordingTranscript(
+  token: string,
+  id: string,
+  fetchImpl: typeof fetch = fetch,
+  apiBase = GRAIN_API_BASE,
+): Promise<unknown[]> {
+  if (!id.trim()) throw new Error("Grain recording id is required");
+  const response = await fetchImpl(`${normalizeBaseUrl(apiBase)}/_/public-api/v2/recordings/${encodeURIComponent(id)}/transcript`, {
+    headers: grainHeaders(cleanToken(token)),
+  });
+  return await parseJsonResponse<unknown[]>(response, "Grain get transcript failed");
+}
+
+export async function parseJsonResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const text = await response.text();
+  let payload: unknown = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  if (!response.ok) {
+    const message = extractErrorMessage(payload) ?? `${fallbackMessage} with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+export async function createPkcePair(): Promise<{ verifier: string; challenge: string }> {
+  const verifier = base64Url(crypto.getRandomValues(new Uint8Array(32)));
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64Url(new Uint8Array(digest)) };
+}
+
+export function parseGrainOAuthState(value: string | null | undefined): { state: string; codeVerifier: string } | null {
+  if (!value?.startsWith("grain:")) return null;
+  const [, state, codeVerifier] = value.split(":");
+  if (!state || !codeVerifier) return null;
+  return { state, codeVerifier };
+}
+
+export function serializeGrainOAuthState(state: string, codeVerifier: string): string {
+  return `grain:${state}:${codeVerifier}`;
+}
+
+function grainHeaders(token: string): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    Authorization: `Bearer ${token}`,
+    "Public-Api-Version": Deno.env.get("GRAIN_PUBLIC_API_VERSION") ?? GRAIN_PUBLIC_API_VERSION,
+  };
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function cleanToken(token: string): string {
+  const cleaned = token.trim().replace(/^Bearer\s+/i, "");
+  if (!cleaned) throw new Error("Grain access token is required");
+  return cleaned;
+}
+
+function extractErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.error === "string") return record.error;
+  if (typeof record.message === "string") return record.message;
+  if (record.error && typeof record.error === "object") {
+    const nested = record.error as Record<string, unknown>;
+    if (typeof nested.message === "string") return nested.message;
+  }
+  return null;
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}

--- a/supabase/functions/_shared/grain-connector.ts
+++ b/supabase/functions/_shared/grain-connector.ts
@@ -1,0 +1,170 @@
+import {
+  formatCanonicalTranscript,
+  normalizeEmailList,
+  type CanonicalRecording,
+  type CanonicalTranscriptTurn,
+} from "./canonical-recording.ts";
+
+export interface GrainParticipant {
+  id?: string | null;
+  name?: string | null;
+  scope?: string | null;
+  email?: string | null;
+  confirmed_attendee?: boolean | null;
+}
+
+export interface GrainTeam {
+  id?: string | null;
+  name?: string | null;
+}
+
+export interface GrainMeetingType {
+  id?: string | null;
+  name?: string | null;
+  scope?: string | null;
+}
+
+export interface GrainTranscriptSegment {
+  participant_id?: string | null;
+  speaker?: string | null;
+  start?: number | null;
+  end?: number | null;
+  text?: string | null;
+}
+
+export interface GrainRecording {
+  id: string;
+  title?: string | null;
+  source?: string | null;
+  url?: string | null;
+  media_type?: string | null;
+  tags?: string[] | null;
+  start_datetime?: string | null;
+  end_datetime?: string | null;
+  duration_ms?: number | null;
+  thumbnail_url?: string | null;
+  participants?: GrainParticipant[] | null;
+  teams?: GrainTeam[] | null;
+  meeting_type?: GrainMeetingType | null;
+  ai_summary?: unknown;
+  ai_action_items?: unknown;
+  private_notes?: unknown;
+  calendar_event?: unknown;
+  transcript?: GrainTranscriptSegment[] | null;
+}
+
+export function grainRecordingToCanonical(recording: GrainRecording): CanonicalRecording {
+  const turns = grainTranscriptToTurns(recording);
+  const fullTranscript = formatCanonicalTranscript(turns);
+  if (!fullTranscript.trim()) {
+    throw new Error(`Grain recording ${recording.id} has no transcript text`);
+  }
+
+  const recordingStartTime = coerceGrainStartTime(recording);
+  const participantEmails = normalizeEmailList((recording.participants ?? []).map((participant) => participant.email ?? ""));
+
+  return {
+    externalId: recording.id,
+    sourceApp: "grain",
+    title: recording.title?.trim() || `Grain recording ${recording.id}`,
+    fullTranscript,
+    summary: grainSummaryMarkdown(recording),
+    recordingStartTime,
+    recordingEndTime: coerceIso(recording.end_datetime),
+    durationSeconds: grainDurationSeconds(recording),
+    sourceUrl: recording.url ?? null,
+    shareUrl: recording.url ?? null,
+    participantEmails,
+    calendarInvitees: recording.participants ?? [],
+    sourceMetadata: {
+      grain_recording_id: recording.id,
+      grain_source: recording.source ?? null,
+      grain_media_type: recording.media_type ?? null,
+      grain_tags: recording.tags ?? [],
+      grain_teams: recording.teams ?? [],
+      grain_meeting_type: recording.meeting_type ?? null,
+      grain_thumbnail_url: recording.thumbnail_url ?? null,
+      grain_ai_action_items: normalizeUnknownList(recording.ai_action_items),
+    },
+    rawPayload: recording,
+  };
+}
+
+export function grainTranscriptToTurns(recording: GrainRecording): CanonicalTranscriptTurn[] {
+  return (recording.transcript ?? []).map((segment) => ({
+    speakerName: segment.speaker?.trim() || null,
+    text: segment.text ?? "",
+    startSeconds: millisToSeconds(segment.start),
+    endSeconds: millisToSeconds(segment.end),
+  })).filter((turn) => turn.text.trim().length > 0);
+}
+
+export function coerceGrainStartTime(recording: GrainRecording): string {
+  const start = coerceIso(recording.start_datetime);
+  if (!start) throw new Error(`Grain recording ${recording.id} is missing a valid start_datetime`);
+  return start;
+}
+
+export function grainDurationSeconds(recording: GrainRecording): number | null {
+  if (recording.duration_ms != null && Number.isFinite(recording.duration_ms) && recording.duration_ms >= 0) {
+    return Math.round(recording.duration_ms / 1000);
+  }
+  const start = recording.start_datetime ? Date.parse(recording.start_datetime) : NaN;
+  const end = recording.end_datetime ? Date.parse(recording.end_datetime) : NaN;
+  if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+    return Math.round((end - start) / 1000);
+  }
+  return null;
+}
+
+export function grainSummaryMarkdown(recording: GrainRecording): string | null {
+  const sections = [
+    stringifyUnknown(recording.ai_summary),
+    stringifyList("Action items", normalizeUnknownList(recording.ai_action_items)),
+    stringifyUnknown(recording.private_notes),
+  ].filter((section): section is string => Boolean(section?.trim()));
+  return sections.length > 0 ? sections.join("\n\n") : null;
+}
+
+function coerceIso(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? new Date(time).toISOString() : null;
+}
+
+function millisToSeconds(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return Math.max(0, value / 1000);
+}
+
+function normalizeUnknownList(value: unknown): string[] {
+  if (!value) return [];
+  if (typeof value === "string") return value.trim() ? [value.trim()] : [];
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    if (typeof item === "string") return item.trim();
+    if (item && typeof item === "object") {
+      const record = item as Record<string, unknown>;
+      return [record.text, record.description, record.title, record.summary]
+        .find((candidate) => typeof candidate === "string" && candidate.trim()) as string | undefined ?? "";
+    }
+    return "";
+  }).map((item) => item.trim()).filter(Boolean);
+}
+
+function stringifyUnknown(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value.trim() || null;
+  if (Array.isArray(value)) return stringifyList("Summary", normalizeUnknownList(value));
+  if (typeof value === "object") {
+    const direct = ["text", "summary", "overview"]
+      .map((key) => (value as Record<string, unknown>)[key])
+      .find((candidate) => typeof candidate === "string" && candidate.trim());
+    if (typeof direct === "string") return direct.trim();
+  }
+  return null;
+}
+
+function stringifyList(label: string, items: string[]): string | null {
+  return items.length > 0 ? `${label}:\n${items.map((item) => `- ${item}`).join("\n")}` : null;
+}

--- a/supabase/functions/_shared/grain-source.ts
+++ b/supabase/functions/_shared/grain-source.ts
@@ -1,0 +1,26 @@
+export interface GrainSourceRecord {
+  id: string;
+  account_email?: string | null;
+  oauth_token_expires?: number | null;
+}
+
+export async function resolveGrainSource<T extends GrainSourceRecord = GrainSourceRecord>(
+  supabase: any,
+  userId: string,
+  sourceId: string | null,
+  columns = "id",
+): Promise<T | null> {
+  let query = supabase
+    .from("import_sources")
+    .select(columns)
+    .eq("user_id", userId)
+    .eq("source_app", "grain");
+
+  query = sourceId
+    ? query.eq("id", sourceId)
+    : query.eq("is_active", true).order("updated_at", { ascending: false }).limit(1);
+
+  const { data, error } = await query.maybeSingle();
+  if (error) throw error;
+  return data as T | null;
+}

--- a/supabase/functions/grain-connect-token/__tests__/grain-connect-token.test.ts
+++ b/supabase/functions/grain-connect-token/__tests__/grain-connect-token.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("grain-connect-token wiring", () => {
+  it("validates pasted tokens against a user-owned Grain source before storing credentials", () => {
+    expect(source).toMatch(/resolveGrainSource\(supabase,\s*userId,\s*sourceId\)/);
+    expect(source.indexOf("resolveSourceId")).toBeLessThan(source.indexOf("storeAccessToken"));
+  });
+
+  it("returns not found for caller-provided non-Grain source ids", () => {
+    expect(source).toMatch(/sourceId && !existing/);
+    expect(source).toMatch(/Grain source not found\./);
+  });
+});

--- a/supabase/functions/grain-connect-token/index.ts
+++ b/supabase/functions/grain-connect-token/index.ts
@@ -1,0 +1,98 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { GrainClient } from '../_shared/grain-client.ts';
+import { resolveGrainSource } from '../_shared/grain-source.ts';
+
+interface GrainConnectTokenRequest {
+  sourceId?: string | null;
+  accessToken?: string;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as GrainConnectTokenRequest;
+    const accessToken = body.accessToken?.trim().replace(/^Bearer\s+/i, '') ?? '';
+    if (!accessToken) return json({ error: 'Grain bearer token is required.' }, 400, corsHeaders);
+
+    const sourceId = await resolveSourceId(supabase, userId, body.sourceId ?? null, corsHeaders);
+    if (sourceId instanceof Response) return sourceId;
+    await new GrainClient({ accessToken }).testToken();
+
+    await storeAccessToken(supabase, sourceId, userId, accessToken);
+    const { error } = await supabase
+      .from('import_sources')
+      .update({
+        account_email: null,
+        connection_metadata: {
+          auth_type: 'api_token',
+          note: 'Grain Personal Access Tokens and Workspace Access Tokens are accepted as bearer tokens.',
+        },
+        error_message: null,
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sourceId)
+      .eq('user_id', userId);
+    if (error) throw error;
+
+    return json({ success: true, sourceId }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Grain connect-token error:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function resolveSourceId(
+  supabase: any,
+  userId: string,
+  sourceId: string | null,
+  corsHeaders: Record<string, string>,
+): Promise<string | Response> {
+  const existing = await resolveGrainSource(supabase, userId, sourceId);
+  if (sourceId && !existing) return json({ success: false, error: 'Grain source not found.' }, 404, corsHeaders);
+  if (existing?.id) return existing.id;
+  const { data, error } = await supabase.from('import_sources').insert({ user_id: userId, source_app: 'grain', is_active: false }).select('id').single();
+  if (error || !data?.id) throw new Error(error?.message ?? 'Failed to create Grain import source');
+  return data.id;
+}
+
+async function storeAccessToken(supabase: any, sourceId: string, userId: string, accessToken: string) {
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  const expiresAt = null;
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: accessToken,
+      p_refresh_token: null,
+      p_token_expires: expiresAt,
+      p_encryption_key: encryptionKey,
+      p_is_active: true,
+    });
+    if (error) throw error;
+    return;
+  }
+
+  const { error } = await supabase.from('import_sources').update({
+    oauth_access_token: accessToken,
+    oauth_refresh_token: null,
+    oauth_token_expires: expiresAt,
+    is_active: true,
+    updated_at: new Date().toISOString(),
+  }).eq('id', sourceId).eq('user_id', userId);
+  if (error) throw error;
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/grain-fetch-recordings/index.ts
+++ b/supabase/functions/grain-fetch-recordings/index.ts
@@ -1,0 +1,136 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
+import { listRecordings, GrainClient } from '../_shared/grain-client.ts';
+import { coerceGrainStartTime, grainDurationSeconds, type GrainRecording } from '../_shared/grain-connector.ts';
+import { resolveGrainSource } from '../_shared/grain-source.ts';
+
+interface GrainFetchRecordingsRequest {
+  sourceId?: string | null;
+  createdAfter?: string | null;
+  createdBefore?: string | null;
+  dateStart?: string | null;
+  dateEnd?: string | null;
+  cursor?: string | null;
+  limit?: number;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as GrainFetchRecordingsRequest;
+    const source = await resolveSource(supabase, userId, body.sourceId ?? null);
+    if (!source) return json({ error: 'Grain is not connected. Connect Grain first.' }, 400, corsHeaders);
+
+    const accessToken = await resolveAccessToken(supabase, source, userId);
+    const start = body.createdAfter ?? body.dateStart ?? null;
+    const end = body.createdBefore ?? body.dateEnd ?? null;
+    const response = await listRecordings<GrainRecording>({
+      token: accessToken,
+      cursor: body.cursor ?? null,
+      startDateTimeGte: start,
+      startDateTimeLte: end,
+      fetchImpl: fetch,
+    });
+    const recordings = response.recordings ?? [];
+    const ids = recordings.map((recording) => recording.id).filter(Boolean);
+    const syncedIds = await fetchSyncedIds(supabase, userId, ids);
+
+    return json({
+      meetings: recordings.map((recording) => mapRecording(recording, syncedIds)),
+      nextCursor: response.cursor ?? null,
+      sourceId: source.id,
+      accountEmail: source.account_email ?? null,
+    }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Error fetching Grain meetings:', error);
+    return json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+interface SourceRecord {
+  id: string;
+  account_email: string | null;
+  oauth_token_expires: number | null;
+}
+
+async function resolveSource(supabase: any, userId: string, sourceId: string | null): Promise<SourceRecord | null> {
+  return await resolveGrainSource<SourceRecord>(supabase, userId, sourceId, 'id, account_email, oauth_token_expires');
+}
+
+async function resolveAccessToken(supabase: any, source: SourceRecord, userId: string): Promise<string> {
+  const tokens = await getDecryptedOAuthTokens(supabase, source.id, userId);
+  if (!tokens.access_token) throw new Error('Grain access token is missing. Reconnect Grain.');
+  if (tokens.token_expires && tokens.token_expires < Date.now() + 30_000) {
+    if (!tokens.refresh_token) throw new Error('Grain token expired. Reconnect Grain with OAuth.');
+    return await refreshGrainTokens(supabase, source.id, userId, tokens.refresh_token);
+  }
+  return tokens.access_token;
+}
+
+async function refreshGrainTokens(supabase: any, sourceId: string, userId: string, refreshToken: string): Promise<string> {
+  const clientId = Deno.env.get('GRAIN_OAUTH_CLIENT_ID');
+  const clientSecret = Deno.env.get('GRAIN_OAUTH_CLIENT_SECRET');
+  if (!clientId || !clientSecret) throw new Error('Grain OAuth is not configured.');
+  const refreshed = await GrainClient.refreshTokens({ clientId, clientSecret, refreshToken });
+  const expiresAt = refreshed.expires_in ? Date.now() + refreshed.expires_in * 1000 : null;
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: refreshed.access_token,
+      p_refresh_token: refreshed.refresh_token ?? refreshToken,
+      p_token_expires: expiresAt,
+      p_encryption_key: encryptionKey,
+      p_is_active: true,
+    });
+    if (error) throw error;
+  } else {
+    const { error } = await supabase.from('import_sources').update({ oauth_access_token: refreshed.access_token, oauth_refresh_token: refreshed.refresh_token ?? refreshToken, oauth_token_expires: expiresAt, updated_at: new Date().toISOString() }).eq('id', sourceId).eq('user_id', userId);
+    if (error) throw error;
+  }
+  return refreshed.access_token;
+}
+
+async function fetchSyncedIds(supabase: any, userId: string, ids: string[]): Promise<Set<string>> {
+  if (ids.length === 0) return new Set();
+  const { data, error } = await supabase.from('recordings').select('source_call_id').eq('owner_user_id', userId).eq('source_app', 'grain').in('source_call_id', ids);
+  if (error) throw error;
+  return new Set((data ?? []).map((row: { source_call_id?: string | null }) => row.source_call_id).filter(Boolean));
+}
+
+function mapRecording(recording: GrainRecording, syncedIds: Set<string>) {
+  let start: string | null = null;
+  try {
+    start = coerceGrainStartTime(recording);
+  } catch {
+    start = null;
+  }
+  return {
+    recording_id: recording.id,
+    title: recording.title?.trim() || `Grain recording ${recording.id}`,
+    created_at: start,
+    recording_start_time: start,
+    recording_end_time: recording.end_datetime ? new Date(recording.end_datetime).toISOString() : null,
+    duration: grainDurationSeconds(recording),
+    synced: syncedIds.has(recording.id),
+    importable: Boolean(recording.end_datetime),
+    calendar_invitees: (recording.participants ?? []).map((participant) => ({ name: participant.name ?? null, email: participant.email ?? null })),
+    source_url: recording.url ?? null,
+    share_url: recording.url ?? null,
+  };
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/grain-oauth-callback/__tests__/grain-oauth-callback.test.ts
+++ b/supabase/functions/grain-oauth-callback/__tests__/grain-oauth-callback.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("grain-oauth-callback wiring", () => {
+  it("validates the pending source is owned by the user and is a Grain source before storing tokens", () => {
+    expect(source).toMatch(/resolveGrainSource\(supabase,\s*userId,\s*sourceId\)/);
+    expect(source.indexOf("resolveGrainSource")).toBeLessThan(source.indexOf("storeTokens"));
+  });
+
+  it("checks state clearing and source activation failures", () => {
+    expect(source).toMatch(/settingsClearError/);
+    expect(source).toMatch(/sourceUpdateError/);
+    expect(source).toMatch(/Grain connected, but activating the source failed/);
+  });
+
+  it("starts initial Grain sync after successful connection", () => {
+    expect(source).toMatch(/supabase\.functions\.invoke\('grain-sync-recordings'/);
+    expect(source).toMatch(/body:\s*\{\s*sourceId\s*\}/);
+  });
+});

--- a/supabase/functions/grain-oauth-callback/index.ts
+++ b/supabase/functions/grain-oauth-callback/index.ts
@@ -1,0 +1,158 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { GrainClient, parseGrainOAuthState } from '../_shared/grain-client.ts';
+import { resolveGrainSource } from '../_shared/grain-source.ts';
+
+interface GrainOAuthCallbackRequest {
+  code?: string;
+  state?: string;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const { code, state } = await req.json() as GrainOAuthCallbackRequest;
+    if (!code || !state) return json({ error: 'Missing code or state' }, 400, corsHeaders);
+
+    const { data: settings, error: settingsError } = await supabase
+      .from('user_settings')
+      .select('oauth_state, pending_import_source_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (settingsError) throw settingsError;
+
+    const grainState = parseGrainOAuthState(settings?.oauth_state);
+    if (!grainState || grainState.state !== state) {
+      return json({ error: 'Invalid state parameter' }, 400, corsHeaders);
+    }
+    const sourceId = settings.pending_import_source_id;
+    if (!sourceId) return json({ error: 'No pending import source found. Please connect Grain again.' }, 400, corsHeaders);
+    const source = await resolveGrainSource(supabase, userId, sourceId);
+    if (!source) return json({ error: 'Pending Grain source was not found. Please connect Grain again.' }, 400, corsHeaders);
+
+    const clientId = Deno.env.get('GRAIN_OAUTH_CLIENT_ID');
+    const clientSecret = Deno.env.get('GRAIN_OAUTH_CLIENT_SECRET');
+    const redirectUri = Deno.env.get('GRAIN_OAUTH_REDIRECT_URI')
+      || `${Deno.env.get('SITE_URL') || 'https://app.callvaultai.com'}/oauth/callback/grain`;
+    if (!clientId || !clientSecret) {
+      return json({ error: 'Grain OAuth is not configured. Set GRAIN_OAUTH_CLIENT_ID and GRAIN_OAUTH_CLIENT_SECRET.' }, 500, corsHeaders);
+    }
+
+    const tokens = await GrainClient.exchangeCodeForTokens({
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      codeVerifier: grainState.codeVerifier,
+    });
+    const expiresAt = tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null;
+    await storeTokens(supabase, sourceId, userId, tokens.access_token, tokens.refresh_token ?? null, expiresAt, true);
+
+    const { error: settingsClearError } = await supabase
+      .from('user_settings')
+      .update({ oauth_state: null, pending_import_source_id: null })
+      .eq('user_id', userId);
+    if (settingsClearError) throw settingsClearError;
+
+    try {
+      await new GrainClient({ accessToken: tokens.access_token }).testToken();
+    } catch (error) {
+      console.warn('Grain token test failed after OAuth callback:', error);
+    }
+
+    const { error: sourceUpdateError } = await supabase
+      .from('import_sources')
+      .update({
+        account_email: null,
+        connection_metadata: { auth_type: 'oauth' },
+        error_message: null,
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sourceId)
+      .eq('user_id', userId);
+    if (sourceUpdateError) {
+      console.error('Failed to activate Grain source after OAuth:', { userId, sourceId, error: sourceUpdateError });
+      throw new Error('Grain connected, but activating the source failed. Try reconnecting.');
+    }
+
+    const authHeaderForward = req.headers.get('Authorization') || '';
+    const syncTask = supabase.functions.invoke('grain-sync-recordings', {
+      body: { sourceId },
+      headers: { Authorization: authHeaderForward, 'Content-Type': 'application/json' },
+    }).then((result: { error?: unknown }) => {
+      if (result.error) console.error('[grain-oauth-callback] initial sync invoke error:', result.error);
+    }).catch((error: unknown) => console.error('[grain-oauth-callback] initial sync invoke threw:', error));
+
+    // @ts-expect-error EdgeRuntime is available in Supabase Edge Functions.
+    EdgeRuntime.waitUntil(syncTask);
+
+    return json({
+      success: true,
+      message: 'Successfully connected to Grain. Your meetings are syncing in the background.',
+      sourceId,
+      accountEmail: null,
+      backfillTriggered: true,
+    }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Grain OAuth callback error:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function storeTokens(
+  supabase: any,
+  sourceId: string,
+  userId: string,
+  accessToken: string,
+  refreshToken: string | null,
+  tokenExpires: number | null,
+  isActive: boolean,
+) {
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: accessToken,
+      p_refresh_token: refreshToken,
+      p_token_expires: tokenExpires,
+      p_encryption_key: encryptionKey,
+      p_is_active: isActive,
+    });
+    if (error) throw error;
+    return;
+  }
+
+  const { error } = await supabase
+    .from('import_sources')
+    .update({
+      oauth_access_token: accessToken,
+      oauth_refresh_token: refreshToken,
+      oauth_token_expires: tokenExpires,
+      is_active: isActive,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', sourceId)
+    .eq('user_id', userId);
+  if (error) throw error;
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/grain-oauth-refresh/index.ts
+++ b/supabase/functions/grain-oauth-refresh/index.ts
@@ -1,0 +1,87 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
+import { GrainClient } from '../_shared/grain-client.ts';
+
+interface GrainRefreshRequest {
+  sourceId?: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+    const body = await req.json().catch(() => ({})) as GrainRefreshRequest;
+
+    const source = await resolveSource(supabase, userId, body.sourceId ?? null);
+    if (!source) return json({ error: 'Grain is not connected.' }, 400, corsHeaders);
+
+    const tokens = await getDecryptedOAuthTokens(supabase as any, source.id, userId);
+    if (!tokens.refresh_token) {
+      await markSourceError(supabase, source.id, userId, 'Grain refresh token is missing. Reconnect Grain.');
+      return json({ error: 'Grain refresh token is missing. Reconnect Grain.' }, 400, corsHeaders);
+    }
+
+    const clientId = Deno.env.get('GRAIN_OAUTH_CLIENT_ID');
+    const clientSecret = Deno.env.get('GRAIN_OAUTH_CLIENT_SECRET');
+    if (!clientId || !clientSecret) {
+      return json({ error: 'Grain OAuth is not configured.' }, 500, corsHeaders);
+    }
+
+    const refreshed = await GrainClient.refreshTokens({ clientId, clientSecret, refreshToken: tokens.refresh_token });
+    const expiresAt = refreshed.expires_in ? Date.now() + refreshed.expires_in * 1000 : null;
+    await storeTokens(supabase, source.id, userId, refreshed.access_token, refreshed.refresh_token ?? tokens.refresh_token, expiresAt);
+    await markSourceError(supabase, source.id, userId, null);
+
+    return json({ success: true, sourceId: source.id, accessTokenExpires: expiresAt }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Grain token refresh error:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function resolveSource(supabase: any, userId: string, sourceId: string | null) {
+  let query = supabase.from('import_sources').select('id').eq('user_id', userId).eq('source_app', 'grain');
+  query = sourceId ? query.eq('id', sourceId) : query.eq('is_active', true).order('updated_at', { ascending: false }).limit(1);
+  const { data } = await query.maybeSingle();
+  return data as { id: string } | null;
+}
+
+async function storeTokens(supabase: any, sourceId: string, userId: string, accessToken: string, refreshToken: string, tokenExpires: number | null) {
+  const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+  if (encryptionKey) {
+    const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+      p_source_id: sourceId,
+      p_user_id: userId,
+      p_access_token: accessToken,
+      p_refresh_token: refreshToken,
+      p_token_expires: tokenExpires,
+      p_encryption_key: encryptionKey,
+      p_is_active: true,
+    });
+    if (error) throw error;
+  } else {
+    const { error } = await supabase
+      .from('import_sources')
+      .update({ oauth_access_token: accessToken, oauth_refresh_token: refreshToken, oauth_token_expires: tokenExpires, is_active: true, updated_at: new Date().toISOString() })
+      .eq('id', sourceId)
+      .eq('user_id', userId);
+    if (error) throw error;
+  }
+}
+
+async function markSourceError(supabase: any, sourceId: string, userId: string, errorMessage: string | null) {
+  await supabase.from('import_sources').update({ error_message: errorMessage, updated_at: new Date().toISOString() }).eq('id', sourceId).eq('user_id', userId);
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}

--- a/supabase/functions/grain-oauth-url/__tests__/grain-oauth-url.test.ts
+++ b/supabase/functions/grain-oauth-url/__tests__/grain-oauth-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("grain-oauth-url wiring", () => {
+  it("validates caller-provided source ids before persisting OAuth state", () => {
+    expect(source).toMatch(/resolveGrainSource\(supabase,\s*userId,\s*requestedSourceId\)/);
+    expect(source.indexOf("resolveGrainSource")).toBeLessThan(source.indexOf("pending_import_source_id"));
+  });
+
+  it("returns a startup error when OAuth state persistence fails", () => {
+    expect(source).toMatch(/settingsError/);
+    expect(source).toMatch(/Failed to start Grain OAuth\. Try again\./);
+  });
+});

--- a/supabase/functions/grain-oauth-url/index.ts
+++ b/supabase/functions/grain-oauth-url/index.ts
@@ -1,0 +1,86 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { createPkcePair, GrainClient, serializeGrainOAuthState } from '../_shared/grain-client.ts';
+import { resolveGrainSource } from '../_shared/grain-source.ts';
+
+interface GrainOAuthUrlRequest {
+  sourceId?: string | null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as GrainOAuthUrlRequest;
+    const clientId = Deno.env.get('GRAIN_OAUTH_CLIENT_ID');
+    const redirectUri = Deno.env.get('GRAIN_OAUTH_REDIRECT_URI')
+      || `${Deno.env.get('SITE_URL') || 'https://app.callvaultai.com'}/oauth/callback/grain`;
+
+    if (!clientId) {
+      return json({ success: false, error: 'Grain OAuth is not configured. Set GRAIN_OAUTH_CLIENT_ID.' }, 500, corsHeaders);
+    }
+
+    const requestedSourceId = body.sourceId ?? null;
+    let sourceId = requestedSourceId;
+    if (requestedSourceId) {
+      const source = await resolveGrainSource(supabase, userId, requestedSourceId);
+      if (!source) return json({ success: false, error: 'Grain source not found.' }, 404, corsHeaders);
+    } else {
+      const { data, error } = await supabase
+        .from('import_sources')
+        .insert({
+          user_id: userId,
+          source_app: 'grain',
+          is_active: false,
+          connection_metadata: { auth_type: 'oauth' },
+        })
+        .select('id')
+        .single();
+      if (error || !data?.id) throw new Error(error?.message ?? 'Failed to initialize Grain source');
+      sourceId = data.id;
+    }
+
+    const state = crypto.randomUUID();
+    const pkce = await createPkcePair();
+    const { error: settingsError } = await supabase
+      .from('user_settings')
+      .upsert({
+        user_id: userId,
+        oauth_state: serializeGrainOAuthState(state, pkce.verifier),
+        pending_import_source_id: sourceId,
+      }, { onConflict: 'user_id' });
+    if (settingsError) {
+      console.error('Failed to persist Grain OAuth state:', { userId, sourceId, error: settingsError });
+      return json({ success: false, error: 'Failed to start Grain OAuth. Try again.' }, 500, corsHeaders);
+    }
+
+    const authUrl = GrainClient.buildAuthorizationUrl({
+      clientId,
+      redirectUri,
+      state,
+      codeChallenge: pkce.challenge,
+    });
+    return json({ success: true, authUrl, sourceId }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Error generating Grain OAuth URL:', error);
+    return json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/grain-sync-recordings/__tests__/grain-sync-recordings.test.ts
+++ b/supabase/functions/grain-sync-recordings/__tests__/grain-sync-recordings.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../index.ts"), "utf8");
+
+describe("grain-sync-recordings wiring", () => {
+  it("resolves sources through the shared Grain ownership/type guard", () => {
+    expect(source).toMatch(/resolveGrainSource\(supabase,\s*userId,\s*sourceId\)/);
+  });
+
+  it("validates workspace membership before creating the sync job", () => {
+    expect(source.indexOf("validateWorkspace")).toBeLessThan(source.indexOf(".from('sync_jobs')"));
+    expect(source).toMatch(/workspace_memberships/);
+  });
+
+  it("runs selected recordings through the canonical connector pipeline and returns completion details", () => {
+    expect(source).toMatch(/getRecording<GrainRecording>/);
+    expect(source).toMatch(/getRecordingTranscript/);
+    expect(source).toMatch(/runCanonicalConnectorPipeline/);
+    expect(source).toMatch(/waitForCompletion/);
+    expect(source).toMatch(/finalStatus/);
+  });
+});

--- a/supabase/functions/grain-sync-recordings/index.ts
+++ b/supabase/functions/grain-sync-recordings/index.ts
@@ -1,0 +1,215 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authenticateRequest } from '../_shared/auth.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
+import { getDecryptedOAuthTokens } from '../_shared/oauth-encrypt.ts';
+import { getRecording, getRecordingTranscript, listRecordings, GrainClient } from '../_shared/grain-client.ts';
+import { grainRecordingToCanonical, type GrainRecording, type GrainTranscriptSegment } from '../_shared/grain-connector.ts';
+import { runCanonicalConnectorPipeline } from '../_shared/recording-connectors.ts';
+import { resolveGrainSource } from '../_shared/grain-source.ts';
+
+interface GrainSyncRequest {
+  sourceId?: string | null;
+  meetingIds?: string[];
+  recordingIds?: string[];
+  singleCallId?: string;
+  createdAfter?: string | null;
+  createdBefore?: string | null;
+  workspace_id?: string | null;
+  workspaceId?: string | null;
+  waitForCompletion?: boolean;
+}
+
+const MAX_BATCH_SIZE = 50;
+const GRAIN_DETAIL_INCLUDE = { participants: true, ai_summary: true, ai_action_items: true, calendar_event: true };
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('Origin');
+  const corsHeaders = getCorsHeaders(origin);
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+
+  try {
+    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const authResult = await authenticateRequest(req, supabase as any, corsHeaders);
+    if (authResult instanceof Response) return authResult;
+    const userId = authResult.userId;
+
+    const body = await req.json().catch(() => ({})) as GrainSyncRequest;
+    const source = await resolveSource(supabase, userId, body.sourceId ?? null);
+    if (!source) return json({ error: 'Grain is not connected. Connect Grain first.' }, 400, corsHeaders);
+
+    const accessToken = await resolveAccessToken(supabase, source.id, userId);
+    const explicitIds = body.singleCallId
+      ? [body.singleCallId]
+      : (body.meetingIds ?? body.recordingIds ?? []).map(String).filter(Boolean);
+    const recordingIds = explicitIds.length > 0
+      ? explicitIds
+      : await fetchRecentRecordingIds(accessToken, body);
+
+    if (recordingIds.length === 0) {
+      return json({ error: 'recordingIds must be provided or a date-window must return recordings.' }, 400, corsHeaders);
+    }
+    if (recordingIds.length > MAX_BATCH_SIZE) {
+      return json({ error: `Too many Grain recordings: max ${MAX_BATCH_SIZE} per request.` }, 400, corsHeaders);
+    }
+
+    const workspaceId = body.workspace_id ?? body.workspaceId ?? null;
+    const validatedWorkspaceId = workspaceId ? await validateWorkspace(supabase, userId, workspaceId, corsHeaders) : null;
+    if (validatedWorkspaceId instanceof Response) return validatedWorkspaceId;
+
+    const { data: syncJob, error: jobError } = await supabase
+      .from('sync_jobs')
+      .insert({
+        user_id: userId,
+        recording_ids: recordingIds,
+        status: 'processing',
+        progress_current: 0,
+        progress_total: recordingIds.length,
+        type: 'grain',
+      })
+      .select()
+      .single();
+    if (jobError) throw jobError;
+    const jobId = syncJob.id;
+
+    const processSyncJob = async () => {
+      const synced: string[] = [];
+      const failed: string[] = [];
+      let skippedCount = 0;
+
+      try {
+        for (const recordingId of recordingIds) {
+          try {
+            const recording = await getRecording<GrainRecording>(accessToken, recordingId, GRAIN_DETAIL_INCLUDE);
+            if (!recording.end_datetime) {
+              skippedCount++;
+            } else {
+              const transcript = await getRecordingTranscript(accessToken, recordingId) as GrainTranscriptSegment[];
+              const canonical = grainRecordingToCanonical({ ...recording, transcript });
+              const result = await runCanonicalConnectorPipeline(supabase, userId, canonical, {
+                importSource: 'grain-sync-recordings',
+                workspaceId: validatedWorkspaceId,
+                includeRawPayload: true,
+              });
+
+              if (result.success) {
+                synced.push(recordingId);
+              } else if (result.skipped) {
+                skippedCount++;
+              } else {
+                failed.push(recordingId);
+                console.error(`Grain sync failed for ${recordingId}:`, result.error);
+              }
+            }
+          } catch (error) {
+            failed.push(recordingId);
+            console.error(`Grain sync failed for ${recordingId}:`, error);
+          }
+
+          await supabase.from('sync_jobs').update({
+            progress_current: synced.length + failed.length + skippedCount,
+            synced_ids: synced,
+            failed_ids: failed,
+            skipped_count: skippedCount,
+          }).eq('id', jobId);
+        }
+
+        const finalStatus = failed.length === 0 ? 'completed' : synced.length === 0 && skippedCount === 0 ? 'failed' : 'completed_with_errors';
+        await supabase.from('sync_jobs').update({
+          status: finalStatus,
+          completed_at: new Date().toISOString(),
+          skipped_count: skippedCount,
+        }).eq('id', jobId);
+        await supabase.from('import_sources').update({
+          last_sync_at: new Date().toISOString(),
+          error_message: failed.length ? `${failed.length} Grain recording${failed.length === 1 ? '' : 's'} failed to sync` : null,
+          updated_at: new Date().toISOString(),
+        }).eq('id', source.id).eq('user_id', userId);
+
+        return { finalStatus, synced, failed, skippedCount };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Grain sync job crashed';
+        await supabase.from('sync_jobs').update({
+          status: 'failed',
+          error: message,
+          completed_at: new Date().toISOString(),
+          synced_ids: synced,
+          failed_ids: failed,
+          skipped_count: skippedCount,
+        }).eq('id', jobId);
+        await supabase.from('import_sources').update({
+          error_message: message,
+          updated_at: new Date().toISOString(),
+        }).eq('id', source.id).eq('user_id', userId);
+        return { finalStatus: 'failed', synced, failed, skippedCount, error: message };
+      }
+    };
+
+    if (body.waitForCompletion) {
+      const result = await processSyncJob();
+      return json({ success: true, jobId, result }, 200, corsHeaders);
+    }
+
+    // @ts-expect-error EdgeRuntime is available in Supabase Edge Functions.
+    EdgeRuntime.waitUntil(processSyncJob());
+
+    return json({ success: true, jobId, message: `Grain sync job started for ${recordingIds.length} recordings` }, 200, corsHeaders);
+  } catch (error) {
+    console.error('Error syncing Grain meetings:', error);
+    return json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+  }
+});
+
+async function resolveSource(supabase: any, userId: string, sourceId: string | null): Promise<{ id: string } | null> {
+  return await resolveGrainSource(supabase, userId, sourceId);
+}
+
+async function resolveAccessToken(supabase: any, sourceId: string, userId: string): Promise<string> {
+  const tokens = await getDecryptedOAuthTokens(supabase, sourceId, userId);
+  if (!tokens.access_token) throw new Error('Grain access token is missing. Reconnect Grain.');
+  if (tokens.token_expires && tokens.token_expires < Date.now() + 30_000) {
+    if (!tokens.refresh_token) throw new Error('Grain token expired. Reconnect Grain with OAuth.');
+    const clientId = Deno.env.get('GRAIN_OAUTH_CLIENT_ID');
+    const clientSecret = Deno.env.get('GRAIN_OAUTH_CLIENT_SECRET');
+    if (!clientId || !clientSecret) throw new Error('Grain OAuth is not configured.');
+    const refreshed = await GrainClient.refreshTokens({ clientId, clientSecret, refreshToken: tokens.refresh_token });
+    const expiresAt = refreshed.expires_in ? Date.now() + refreshed.expires_in * 1000 : null;
+    const encryptionKey = Deno.env.get('OAUTH_ENCRYPTION_KEY');
+    if (encryptionKey) {
+      const { error } = await supabase.rpc('store_encrypted_oauth_tokens', {
+        p_source_id: sourceId,
+        p_user_id: userId,
+        p_access_token: refreshed.access_token,
+        p_refresh_token: refreshed.refresh_token ?? tokens.refresh_token,
+        p_token_expires: expiresAt,
+        p_encryption_key: encryptionKey,
+        p_is_active: true,
+      });
+      if (error) throw error;
+    } else {
+      const { error } = await supabase.from('import_sources').update({ oauth_access_token: refreshed.access_token, oauth_refresh_token: refreshed.refresh_token ?? tokens.refresh_token, oauth_token_expires: expiresAt, updated_at: new Date().toISOString() }).eq('id', sourceId).eq('user_id', userId);
+      if (error) throw error;
+    }
+    return refreshed.access_token;
+  }
+  return tokens.access_token;
+}
+
+async function fetchRecentRecordingIds(accessToken: string, body: GrainSyncRequest): Promise<string[]> {
+  const response = await listRecordings<GrainRecording>({
+    token: accessToken,
+    startDateTimeGte: body.createdAfter ?? null,
+    startDateTimeLte: body.createdBefore ?? null,
+  });
+  return (response.recordings ?? []).filter((recording) => Boolean(recording.end_datetime)).map((recording) => recording.id);
+}
+
+async function validateWorkspace(supabase: any, userId: string, workspaceId: string, corsHeaders: Record<string, string>): Promise<string | Response> {
+  const { data, error } = await supabase.from('workspace_memberships').select('id').eq('workspace_id', workspaceId).eq('user_id', userId).maybeSingle();
+  if (error) return json({ error: 'Failed to verify workspace membership. Try again.' }, 500, corsHeaders);
+  if (!data) return json({ error: 'You are not a member of the requested workspace.' }, 403, corsHeaders);
+  return workspaceId;
+}
+
+function json(payload: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+}


### PR DESCRIPTION
## Summary

Adds a Grain connector using the same connector-template path as the Read.ai implementation this branch stacks on:

- Grain OAuth + token fallback edge functions
- Grain v2 client for listing recordings, fetching recording details, and fetching transcript JSON
- canonical recording normalization into the shared connector pipeline
- frontend connector adapter, import source registry entries, import page pane, and OAuth callback route
- focused tests for adapter wiring, source ownership guards, OAuth wiring, client request shape, and canonical mapping

## Research Notes

Checked Grain's current public developer docs before implementation:

- Auth supports bearer tokens from OAuth, Personal Access Tokens, or Workspace Access Tokens.
- API calls require `Public-Api-Version: 2025-10-31`.
- Listing recordings uses `POST /_/public-api/v2/recordings`.
- Fetching a transcript uses `GET /_/public-api/v2/recordings/:recording_id/transcript`.
- OAuth authorize uses `https://grain.com/_/public-api/oauth2/authorize`; token exchange uses `POST /_/public-api/oauth2/token`.

Source: https://developers.grain.com/

## Validation

- `npm test -- --run supabase/functions/_shared/__tests__/grain-connector.test.ts src/components/connectors/registry/adapters/__tests__/grain.test.ts supabase/functions/grain-sync-recordings/__tests__/grain-sync-recordings.test.ts supabase/functions/grain-oauth-url/__tests__/grain-oauth-url.test.ts supabase/functions/grain-oauth-callback/__tests__/grain-oauth-callback.test.ts supabase/functions/grain-connect-token/__tests__/grain-connect-token.test.ts supabase/functions/_shared/__tests__/grain-source.test.ts`
- `npm run type-check`
- `npm run lint` exits 0; repo still reports existing warnings only.

## Notes

This is intentionally stacked on the Read.ai connector branch so reviewers can compare Grain against the same template directly.
