### PR TITLE
feat: pixel cat easter egg with walking animation and joke bubble

### DIFF
--- a/.oneignore
+++ b/.oneignore
@@ -1,0 +1,134 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Env files - NEVER commit sensitive credentials
+.env
+.env.bak
+.env.local
+.env.*.local
+.env.development.local
+.env.production.local
+.env.test.local
+*.bak
+
+# Coverage and caches
+coverage/
+.eslintcache
+
+# Playwright MCP
+.playwright-mcp/
+
+# Database exports (too large for git)
+database-export-*.json
+migration-export-*.json
+.vercel
+PROJECT_INDEX.md
+PROJECT_INDEX.json
+test-results/
+
+# Auto Claude data directory
+.auto-claude/
+
+# Debug/diagnostic exports (security)
+recent_deliveries*.json
+success_delivery.json
+RCA.md
+# Only ignore SQL exports in root - NOT supabase/migrations/*.sql
+/*.sql
+
+# Tool directories (AI assistants)
+.serena/
+.worktrees/
+
+# Debug logs
+logs.txt
+webhook_logs.txt
+.venv/
+
+# Playwright auth state
+playwright/.auth/
+
+# Claude Code - local config and runtime artifacts (NOT skills/commands/agents)
+.claude/settings.json
+.claude/metadata-updater.sh
+.claude/skills/dev-browser/profiles/browser-data/
+.claude/skills/dev-browser/node_modules/
+.claude/worktrees/
+
+# Supabase CLI auto-managed local state
+supabase/.temp/
+
+# One-off debug/fix scripts (use scripts/ directory instead)
+/apply-fix*.ts
+/fix_*.ts
+/test-*.ts
+/refactor_*.py
+/check_*.sql
+
+# Archived/historical content (preserved in git history)
+ralph-archived/
+playwright-report/
+artifacts/
+project-decisions/
+
+# ── GSD baseline (auto-generated) ──
+.gsd
+.gsd-id
+Thumbs.db
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.code-workspace
+.env.*
+!.env.example
+node_modules/
+.next/
+dist/
+build/
+__pycache__/
+*.pyc
+venv/
+target/
+vendor/
+.cache/
+tmp/
+
+# Graphify outputs (regenerable, ~110MB combined — never commit)
+graphify-out/
+.planning/graphs/
+
+# CodeGraph local index (regenerable)
+.codegraph/
+
+# QA crawler output (regenerable)
+qa-report.json
+
+# Symlink to the sibling autopilot daemon repo (~/dev/autopilot) — navigation only, never committed
+/autopilot
+
+# Throwaway Interceptor verification screenshots (never commit)
+interceptor-screenshot-*.png

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import ForgotPassword from "@/pages/ForgotPassword";
 import ResetPassword from "@/pages/ResetPassword";
 import OAuthCallback from "@/pages/OAuthCallback";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { PixelCat } from "@/components/easter-eggs/PixelCat";
 import { CallDetailPage } from "@/pages/CallDetailPage";
 import { SharedCallView } from "@/pages/SharedCallView";
 import OrganizationJoin from "@/pages/OrganizationJoin";
@@ -316,6 +317,7 @@ function App() {
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <SonnerToaster position="bottom-right" richColors duration={6000} />
+                <PixelCat />
               </Router>
             </ThemeProvider>
           </AuthProvider>

--- a/src/components/easter-eggs/PixelCat.tsx
+++ b/src/components/easter-eggs/PixelCat.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import "./pixel-cat.css";
+import "@/components/easter-eggs/pixel-cat.css";
 import {
   CAT_HEIGHT,
   CAT_PIXEL_UNIT,
   CAT_WIDTH,
   FRAME_A_SHADOW,
   FRAME_B_SHADOW,
-} from "./pixelCatSprite";
+} from "@/components/easter-eggs/pixelCatSprite";
 
 const JOKES = [
   "Why do programmers prefer dark mode? Because light attracts bugs.",
@@ -29,9 +29,9 @@ export function PixelCat() {
   const [bubbleVisible, setBubbleVisible] = useState(false);
   const lastIndexRef = useRef(0);
 
-  useEffect(() => {
-    let hideTimeout: ReturnType<typeof setTimeout>;
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  useEffect(() => {
     const showJoke = () => {
       let next = Math.floor(Math.random() * JOKES.length);
       if (JOKES.length > 1) {
@@ -42,7 +42,11 @@ export function PixelCat() {
       lastIndexRef.current = next;
       setJoke(JOKES[next]);
       setBubbleVisible(true);
-      hideTimeout = setTimeout(() => setBubbleVisible(false), BUBBLE_VISIBLE_MS);
+      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = setTimeout(() => {
+        setBubbleVisible(false);
+        hideTimeoutRef.current = null;
+      }, BUBBLE_VISIBLE_MS);
     };
 
     const initialDelay = setTimeout(showJoke, FIRST_BUBBLE_DELAY_MS);
@@ -50,7 +54,7 @@ export function PixelCat() {
 
     return () => {
       clearTimeout(initialDelay);
-      clearTimeout(hideTimeout);
+      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
       clearInterval(interval);
     };
   }, []);

--- a/src/components/easter-eggs/PixelCat.tsx
+++ b/src/components/easter-eggs/PixelCat.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import "./pixel-cat.css";
+import {
+  CAT_HEIGHT,
+  CAT_PIXEL_UNIT,
+  CAT_WIDTH,
+  FRAME_A_SHADOW,
+  FRAME_B_SHADOW,
+} from "./pixelCatSprite";
+
+const JOKES = [
+  "Why do programmers prefer dark mode? Because light attracts bugs.",
+  "There are only 10 types of people: those who understand binary and those who don't.",
+  "A SQL query walks into a bar, walks up to two tables and asks: 'Can I join you?'",
+  "Why do Java developers wear glasses? Because they don't see sharp.",
+  "I'd tell you a UDP joke, but you might not get it.",
+  "!false — it's funny because it's true.",
+  "How many programmers does it take to change a light bulb? None, that's a hardware problem.",
+  "99 little bugs in the code, 99 little bugs. Take one down, patch it around — 127 little bugs in the code.",
+  "I have a joke about recursion, but to understand it you need to understand recursion first.",
+] as const;
+
+const BUBBLE_INTERVAL_MS = 9000;
+const BUBBLE_VISIBLE_MS = 4200;
+const FIRST_BUBBLE_DELAY_MS = 3000;
+
+export function PixelCat() {
+  const [joke, setJoke] = useState<string>(JOKES[0]);
+  const [bubbleVisible, setBubbleVisible] = useState(false);
+  const lastIndexRef = useRef(0);
+
+  useEffect(() => {
+    let hideTimeout: ReturnType<typeof setTimeout>;
+
+    const showJoke = () => {
+      let next = Math.floor(Math.random() * JOKES.length);
+      if (JOKES.length > 1) {
+        while (next === lastIndexRef.current) {
+          next = Math.floor(Math.random() * JOKES.length);
+        }
+      }
+      lastIndexRef.current = next;
+      setJoke(JOKES[next]);
+      setBubbleVisible(true);
+      hideTimeout = setTimeout(() => setBubbleVisible(false), BUBBLE_VISIBLE_MS);
+    };
+
+    const initialDelay = setTimeout(showJoke, FIRST_BUBBLE_DELAY_MS);
+    const interval = setInterval(showJoke, BUBBLE_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initialDelay);
+      clearTimeout(hideTimeout);
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div className="cv-cat-stage" aria-hidden="true">
+      <style>{`
+        @keyframes cv-leg-cycle {
+          0% { box-shadow: ${FRAME_A_SHADOW}; }
+          49.9% { box-shadow: ${FRAME_A_SHADOW}; }
+          50% { box-shadow: ${FRAME_B_SHADOW}; }
+          99.9% { box-shadow: ${FRAME_B_SHADOW}; }
+          100% { box-shadow: ${FRAME_A_SHADOW}; }
+        }
+      `}</style>
+      <div className="cv-cat-mover">
+        <div className={`cv-speech-bubble${bubbleVisible ? " cv-bubble-visible" : ""}`}>
+          {joke}
+        </div>
+        <div className="cv-cat-flip">
+          <div className="cv-cat-sprite-bounds" style={{ width: CAT_WIDTH, height: CAT_HEIGHT }}>
+            <div
+              className="cv-cat-pixel"
+              style={{
+                width: CAT_PIXEL_UNIT,
+                height: CAT_PIXEL_UNIT,
+                boxShadow: FRAME_A_SHADOW,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/easter-eggs/pixel-cat.css
+++ b/src/components/easter-eggs/pixel-cat.css
@@ -1,0 +1,123 @@
+/* Self-contained styling for the walking pixel-cat easter egg.
+   Kept isolated from the design system on purpose — this is a decorative
+   extra, not a brand surface. */
+
+.cv-cat-stage {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  width: 190px;
+  height: 56px;
+  pointer-events: none;
+  z-index: 30;
+  overflow: visible;
+}
+
+.cv-cat-mover {
+  position: absolute;
+  left: 0;
+  bottom: 4px;
+  animation: cv-walk-position 9s ease-in-out infinite;
+}
+
+.cv-cat-flip {
+  position: relative;
+  transform-origin: 50% 100%;
+  animation: cv-walk-flip 9s ease-in-out infinite;
+}
+
+.cv-cat-sprite-bounds {
+  position: relative;
+}
+
+.cv-cat-pixel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: transparent;
+  animation: cv-leg-cycle 0.6s linear infinite;
+}
+
+.cv-speech-bubble {
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  margin-bottom: 6px;
+  min-width: 130px;
+  max-width: 200px;
+  background: #ffffff;
+  color: #1a1a1a;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  transform: translate(-50%, 6px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.cv-speech-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: #ffffff;
+}
+
+.cv-speech-bubble.cv-bubble-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@keyframes cv-walk-position {
+  0% {
+    transform: translateX(0) translateY(0);
+  }
+  12% {
+    transform: translateX(20px) translateY(-2px);
+  }
+  24% {
+    transform: translateX(45px) translateY(0);
+  }
+  36% {
+    transform: translateX(75px) translateY(-2px);
+  }
+  48% {
+    transform: translateX(108px) translateY(0);
+  }
+  50% {
+    transform: translateX(112px) translateY(0);
+  }
+  62% {
+    transform: translateX(90px) translateY(-2px);
+  }
+  74% {
+    transform: translateX(60px) translateY(0);
+  }
+  86% {
+    transform: translateX(30px) translateY(-2px);
+  }
+  100% {
+    transform: translateX(0) translateY(0);
+  }
+}
+
+@keyframes cv-walk-flip {
+  0%,
+  48% {
+    transform: scaleX(1);
+  }
+  50%,
+  98% {
+    transform: scaleX(-1);
+  }
+  100% {
+    transform: scaleX(1);
+  }
+}

--- a/src/components/easter-eggs/pixel-cat.css
+++ b/src/components/easter-eggs/pixel-cat.css
@@ -40,11 +40,11 @@
 
 .cv-speech-bubble {
   position: absolute;
-  left: 50%;
+  right: 0;
   bottom: 100%;
   margin-bottom: 6px;
   min-width: 130px;
-  max-width: 200px;
+  max-width: min(200px, calc(100vw - 24px));
   background: #ffffff;
   color: #1a1a1a;
   font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -56,7 +56,7 @@
   border: 1px solid rgba(0, 0, 0, 0.08);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
   opacity: 0;
-  transform: translate(-50%, 6px);
+  transform: translate(0, 6px);
   transition: opacity 0.35s ease, transform 0.35s ease;
 }
 
@@ -64,15 +64,14 @@
   content: "";
   position: absolute;
   top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 18px;
   border: 6px solid transparent;
   border-top-color: #ffffff;
 }
 
 .cv-speech-bubble.cv-bubble-visible {
   opacity: 1;
-  transform: translate(-50%, 0);
+  transform: translate(0, 0);
 }
 
 @keyframes cv-walk-position {

--- a/src/components/easter-eggs/pixelCatSprite.ts
+++ b/src/components/easter-eggs/pixelCatSprite.ts
@@ -1,0 +1,114 @@
+// Pixel-art data for the walking cat easter egg. No image assets, canvas, or SVG —
+// the sprite is a set of (column, row, color) offsets rendered with the CSS
+// box-shadow technique (see PixelCat.tsx).
+
+type Pixel = readonly [col: number, row: number, color: string];
+
+const UNIT = 4;
+const GRID_COLS = 16;
+const GRID_ROWS = 10;
+
+const COLORS = {
+  // Mid-tone slate so the sprite reads clearly on both the light card
+  // background and the near-black dark theme (bg-card: #FFFFFF / #212121).
+  body: "#8b899a",
+  eye: "#f5f5f0",
+  nose: "#ff9db3",
+} as const;
+
+const EARS: Pixel[] = [
+  [10, 0, COLORS.body],
+  [12, 0, COLORS.body],
+];
+
+const HEAD: Pixel[] = [
+  [9, 1, COLORS.body],
+  [10, 1, COLORS.body],
+  [11, 1, COLORS.body],
+  [12, 1, COLORS.body],
+  [13, 1, COLORS.body],
+  [14, 1, COLORS.body],
+  [9, 2, COLORS.body],
+  [10, 2, COLORS.body],
+  [11, 2, COLORS.body],
+  [13, 2, COLORS.body],
+  [14, 2, COLORS.body],
+  [9, 3, COLORS.body],
+  [10, 3, COLORS.body],
+  [11, 3, COLORS.body],
+  [12, 3, COLORS.body],
+  [13, 3, COLORS.body],
+  [14, 3, COLORS.body],
+];
+
+const FACE: Pixel[] = [
+  [12, 2, COLORS.eye],
+  [15, 2, COLORS.nose],
+];
+
+const BODY: Pixel[] = [
+  [3, 3, COLORS.body],
+  [4, 3, COLORS.body],
+  [5, 3, COLORS.body],
+  [6, 3, COLORS.body],
+  [7, 3, COLORS.body],
+  [8, 3, COLORS.body],
+  [3, 4, COLORS.body],
+  [4, 4, COLORS.body],
+  [5, 4, COLORS.body],
+  [6, 4, COLORS.body],
+  [7, 4, COLORS.body],
+  [8, 4, COLORS.body],
+  [3, 5, COLORS.body],
+  [4, 5, COLORS.body],
+  [5, 5, COLORS.body],
+  [6, 5, COLORS.body],
+  [7, 5, COLORS.body],
+  [8, 5, COLORS.body],
+  [4, 6, COLORS.body],
+  [5, 6, COLORS.body],
+  [6, 6, COLORS.body],
+  [7, 6, COLORS.body],
+];
+
+const TAIL: Pixel[] = [
+  [2, 5, COLORS.body],
+  [1, 4, COLORS.body],
+  [1, 3, COLORS.body],
+  [1, 2, COLORS.body],
+  [2, 1, COLORS.body],
+  [3, 1, COLORS.body],
+];
+
+// Two leg poses swapped via a CSS keyframe animation to create the walk cycle.
+const LEGS_A: Pixel[] = [
+  [4, 7, COLORS.body],
+  [4, 8, COLORS.body],
+  [4, 9, COLORS.body],
+  [7, 7, COLORS.body],
+  [7, 8, COLORS.body],
+  [7, 9, COLORS.body],
+];
+
+const LEGS_B: Pixel[] = [
+  [4, 7, COLORS.body],
+  [4, 8, COLORS.body],
+  [8, 7, COLORS.body],
+  [8, 8, COLORS.body],
+  [8, 9, COLORS.body],
+];
+
+const STATIC_PIXELS: Pixel[] = [...EARS, ...HEAD, ...FACE, ...BODY, ...TAIL];
+
+function toBoxShadow(pixels: Pixel[]): string {
+  return pixels
+    .map(([col, row, color]) => `${col * UNIT}px ${row * UNIT}px 0 ${color}`)
+    .join(", ");
+}
+
+export const CAT_PIXEL_UNIT = UNIT;
+export const CAT_WIDTH = GRID_COLS * UNIT;
+export const CAT_HEIGHT = GRID_ROWS * UNIT;
+
+export const FRAME_A_SHADOW = toBoxShadow([...STATIC_PIXELS, ...LEGS_A]);
+export const FRAME_B_SHADOW = toBoxShadow([...STATIC_PIXELS, ...LEGS_B]);


### PR DESCRIPTION
## Summary
- Adds a persistent, self-contained pixel-art cat in the bottom-right corner that walks back and forth continuously and periodically shows a speech bubble with a random hardcoded programming joke.
- Pure CSS (`@keyframes`) drives the walk/flip/bob motion; the cat itself is rendered with the classic `box-shadow` pixel-grid technique — no image assets, canvas, or SVG sprites.
- Fully isolated in `src/components/easter-eggs/` (sprite data, styles, component). Only existing file touched is `src/App.tsx`, which mounts `<PixelCat />` once at the root alongside the toaster.
- `pointer-events: none` on the whole stage (z-index 30, below dialogs/toasts) so it never blocks clicks on underlying UI — verified with a Playwright click-through test on a form input near it.
- Body color tuned to `#8b899a` after testing contrast against both the light card background and the app's near-black dark theme (`#171717`), since the easter egg should stay legible in both themes without needing to match brand tokens.

## Test plan
- [x] `tsc --noEmit` — no errors in new files
- [x] `eslint` — clean on new files and `App.tsx`
- [x] Ran the real Vite dev server, used Playwright + system Chrome to screenshot the login page across multiple timestamps — confirmed the cat visibly moves/walks, flips direction, and the bubble fades in with different random jokes
- [x] Verified an `<input>` near the cat's stage still receives clicks/typed input (no click-through blocking)
- [x] Verified sprite contrast on both light and simulated dark backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)